### PR TITLE
add LANA_TNY firmware

### DIFF
--- a/Sources/README.md
+++ b/Sources/README.md
@@ -1,0 +1,64 @@
+## Keyboard expansion firmware
+
+This firmware runs on the Fri3D camp 2024 communicator expansion board, which is powered by [LANA_TNY](https://phyx.be/LANA_TNY).
+
+The firmware outputs [HID report packets](https://files.microscan.com/helpfiles/ms4_help_file/ms-4_help-02-46.html) (8 bytes) on USB, I2C (address ```0x38```) and UART.
+
+The first byte indicates the modifier keys that have been pressed:
+
+| Bit | Modifier Key |
+|-|-|
+| 0 | LEFT CTRL |
+| 1 | LEFT SHIFT |
+| 2 | LEFT ALT |
+| 3 | LEFT GUI |
+| 4 | RIGHT CTRL |
+| 5 | RIGHT SHIFT |
+| 6 | RIGHT ALT |
+| 7 | RIGHT GUI |
+
+The second byte is reserved, the remaining 6 bytes can contain a [HID keycode](https://gist.github.com/MightyPork/6da26e382a7ad91b5496ee55fdc73db2).
+
+## Building
+
+First install the RISCV GCC compiler:
+
+```
+https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/tag/v12.2.0-3/
+```
+
+Make a build directory:
+```
+mkdir build
+```
+
+And call the makefile:
+```
+make build -C build -f ../config/makefile TOOLPREFIX=/path/to/gnu_riscv_xpack_toolchain_12.2.0_3_64b/bin/riscv-none-elf-
+```
+
+## Flashing
+
+The application is can be flashed using ```wchisp``` over USB, or OpenOCD using WCHLink:
+
+```
+wchisp flash build/application.hex
+```
+
+## Usage
+
+The keyboard presents itself as a HID input device.
+The ```Fn``` key can be used to trigger special functions:
+ * ```Fn+F1```: Put LANA LED to red
+ * ```Fn+F2```: Put LANA LED to orange
+ * ```Fn+F3```: Put LANA LED to yellow
+ * ```Fn+F4```: Put LANA LED to green
+ * ```Fn+F5```: Put LANA LED to blue
+ * ```Fn+F6```: Put LANA LED to purple
+ * ```Fn+Windows```: Put LANA LED off
+ * ```Fn+Backspace```: Delete
+ * ```Fn+Up```: Page Up
+ * ```Fn+Down```: Page Down
+ * ```Fn+Left```: Home
+ * ```Fn+Right```: End
+ * ```Fn+Spacebar```: Toggle keyboard backlight

--- a/Sources/config/dashboard.mk
+++ b/Sources/config/dashboard.mk
@@ -1,0 +1,196 @@
+################################################################################
+#                                 DASHBOARD.MK                                 #
+################################################################################
+# COPYRIGHT (c) 2020 Embeetle                                                  #
+# This software component is licensed by Embeetle under the MIT license. Con-  #
+# sult the license text at the bottom of this file.                            #
+#                                                                              #
+#------------------------------------------------------------------------------#
+#                                   SUMMARY                                    #
+#------------------------------------------------------------------------------#
+# This file is intended to be included in the makefile. It contains all        #
+# variables that depend on dashboard settings in Embeetle.                     #
+#                                                                              #
+# We suggest to include this file in your makefile like so:                    #
+#                                                                              #
+#     MAKEFILE := $(lastword $(MAKEFILE_LIST))                                 #
+#     MAKEFILE_DIR := $(dir $(MAKEFILE))                                       #
+#     include $(MAKEFILE_DIR)dashboard.mk                                      #
+#                                                                              #
+#------------------------------------------------------------------------------#
+#                                    EDITS                                     #
+#------------------------------------------------------------------------------#
+# This file was automatically generated, but feel free to edit. When you chan- #
+# ge something in the dashboard, Embeetle will ask your permission to modify   #
+# this file accordingly. You'll be shown a proposal for a 3-way-merge in a     #
+# diffing window. In other words, your manual edits won't be lost.             #
+#                                                                              #
+#------------------------------------------------------------------------------#
+#                               MORE INFORMATION                               #
+#------------------------------------------------------------------------------#
+# Consult the Embeetle website for more info about this file:                  #
+# https://embeetle.com/#embeetle-ide/manual/beetle-anatomy/dashboard           #
+#                                                                              #
+################################################################################
+
+# 1. VERSION
+# ==========
+# Define the makefile interface version this 'dashboard.mk' file must be com-
+# patible with.
+EMBEETLE_MAKEFILE_INTERFACE_VERSION = 7
+
+# 2. TOOLS
+# ========
+# When invoking the makefile, Embeetle passes absolute paths to the toolchain
+# (ARM, RISCV, ...) and the flash tool (OpenOCD, esptool, ...) on the command-
+# line.
+# Example:
+#
+#   > "TOOLPREFIX=C:/my_tools/gnu_arm_toolchain_9.2.1/bin/arm-none-eabi-"
+#   > "FLASHTOOL=C:/my_tools/openocd_0.10.0_dev01138_32b/bin/openocd.exe"
+#
+# If you ever invoke the makefile without these commandline-arguments,
+# you need a fallback mechanism. Therefore, we provide a default value
+# for these variables here. Read more about the reasons in ADDENDUM 2.
+TOOLPREFIX = riscv-none-elf-
+FLASHTOOL = openocd
+
+# 3. PROJECT LAYOUT
+# =================
+# The PROJECT LAYOUT section in the dashboard points to all important config
+# file locations (eg. linkerscript, openocd config files, ...). If you change
+# any of those locations in the dashboard, Embeetle changes the variables be-
+# low accordingly.
+#
+# NOTES:
+#     - These paths are all relative to the build directory.
+#     - Locations of 'dashboard.mk' and 'filetree.mk' are not
+#       defined here. That's because they're always located in
+#       the same folder with the makefile.
+SOURCE_DIR = ../
+BIN_FILE = application.bin
+ELF_FILE = application.elf
+LINKERSCRIPT = ../config/linkerscript.ld
+OPENOCD_CHIPFILE = ../config/openocd_chip.cfg
+OPENOCD_PROBEFILE = ../config/openocd_probe.cfg
+
+# 4. BINARIES
+# ===========
+# Define the binaries that must be built.
+BINARIES = \
+  $(ELF_FILE) \
+  $(ELF_FILE:.elf=.bin) \
+  $(ELF_FILE:.elf=.hex)
+
+# Define the rules to build these binaries from the .elf file.
+%.bin: %.elf
+	$(info )
+	$(info )
+	$(info Preparing: $@)
+	$(OBJCOPY) -O binary $< $@
+
+%.hex: %.elf
+	$(info )
+	$(info )
+	$(info Preparing: $@)
+	$(OBJCOPY) -O ihex $< $@
+
+# 5. COMPILATION FLAGS
+# ====================
+# CPU specific flags for C++, C and assembly compilation and linking.
+TARGET_COMMONFLAGS = -march=rv32imac \
+                     -mabi=ilp32 \
+                     -msmall-data-limit=8 \
+                     -msave-restore \
+                     -fsigned-char \
+                     -fno-common \
+                     -Wunused \
+                     -Wuninitialized \
+
+# CPU specific C compilation flags
+TARGET_CFLAGS = -std=gnu99 \
+
+# CPU specific C++ compilation flags
+TARGET_CXXFLAGS = -std=gnu99 \
+
+# CPU specific assembler flags
+TARGET_SFLAGS = -x assembler-with-cpp \
+
+# CPU specific linker flags
+TARGET_LDFLAGS = --specs=nano.specs \
+                 --specs=nosys.specs \
+                 -nostartfiles \
+                 -T $(LINKERSCRIPT) \
+                 -L $(dir $(LINKERSCRIPT)) \
+
+# Libraries from the toolchain
+TOOLCHAIN_LDLIBS = -lm \
+
+# 6. FLASH RULES
+# ==============
+# The WCH microcontrollers need a modified OpenOCD (distributed by WCH). This
+# OpenOCD tool needs to load a few libraries that are in the executable-folder.
+# On Windows that happens automatically. On Linux, one needs to set the
+# LD_LIBRARY_PATH environment variable.
+
+# First, define the 'flash' target:
+.PHONY: flash
+
+# Set the LD_LIBRARY_PATH environment variable to point to the executable-
+# folder:
+flash: export LD_LIBRARY_PATH=$(dir $(FLASHTOOL))
+
+# Finally, launch OpenOCD:
+flash: $(BINARIES) print_flash
+	"$(FLASHTOOL)" -f $(OPENOCD_PROBEFILE) \
+               -f $(OPENOCD_CHIPFILE) \
+               -c "program {$(ELF_FILE)} verify reset; shutdown;"
+
+# Let's figure out what the flags mean:
+#
+#   -f: Specify a config file for OpenOCD to use. We pass this flag
+#       twice: once for the config file that defines the probe and
+#       once to define the chip (microcontroller).
+#
+#   -c: Run the specified commands. The ones we pass are:
+#         1) program {file} verify reset;
+#            Upload the firmware to the flash memory and verify
+#            if it was successful.
+#         2) shutdown;
+#            Quit OpenOCD.
+
+
+# ADDENDUM 1. MIT LICENSE
+# =======================
+# Copyright (c) 2020 Embeetle
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is furn-
+# ished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# ADDENDUM 2. WHY THE FALLBACK MECHANISM FOR TOOLS?
+# =================================================
+# You might wonder: why bother with a default value? Embeetle could simply
+# insert the actual paths (as selected in the dashboard) here, like:
+#
+# TOOLPREFIX = C:/my_tools/gnu_arm_toolchain_9.2.1/bin/arm-none-eabi-
+# FLASHTOOL  = C:/my_tools/openocd_0.10.0_dev01138_32b/bin/openocd.exe
+#
+# However, that would make this dashboard.mk file location dependent: the
+# location of the tool would be hardcoded. That's a problem if you access
+# this project from two computers where the same tool is stored in different
+# locations.

--- a/Sources/config/filetree.mk
+++ b/Sources/config/filetree.mk
@@ -1,0 +1,125 @@
+################################################################################
+#                              MAKEFILE INCLUDES                               #
+################################################################################
+# COPYRIGHT (c) 2023 Embeetle                                                  #
+# This software component is licensed by Embeetle under the MIT license. Con-  #
+# sult the license text at the bottom of this file.                            #
+#                                                                              #
+#------------------------------------------------------------------------------#
+#                                   SUMMARY                                    #
+#------------------------------------------------------------------------------#
+# This file should be included in the makefile. It lists all source files (c,  #
+# c++, asm..) that take part in the compilation.                               #
+#                                                                              #
+# Take a look at the Embeetle filetree. All files with a green checkmark are   #
+# the ones ending up here in this file. Embeetle attempts to list automatical- #
+# ly the right set of files, starting from 'main.c'. However, you can manually #
+# overrule the beetle's decisions by clicking the file's checkmark (turning it #
+# red). Save the project (Ctrl+S) and observe the result in this file.         #
+#                                                                              #
+# We suggest to include this file in your makefile like so:                    #
+#                                                                              #
+#     MAKEFILE := $(lastword $(MAKEFILE_LIST))                                 #
+#     MAKEFILE_DIR := $(dir $(MAKEFILE))                                       #
+#     include $(MAKEFILE_DIR)filetree.mk                                       #
+#                                                                              #
+#------------------------------------------------------------------------------#
+#                                    EDITS                                     #
+#------------------------------------------------------------------------------#
+# This file was automatically generated. Do not edit! It is overwritten regu-  #
+# larly by Embeetle. Although Embeetle IDE practices the "treat config as      #
+# code" principle, this file is an exception.                                  #
+#                                                                              #
+# If you want to force a certain source file to be in- or excluded from the    #
+# build, just click the corresponding checkbox in the Embeetle Filetree and    #
+# save the project. This file should adapt itself accordingly.                 #
+#                                                                              #
+#------------------------------------------------------------------------------#
+#                               MORE INFORMATION                               #
+#------------------------------------------------------------------------------#
+# Consult the following pages on our website for more info about this file:    #
+# https://embeetle.com/#embeetle-ide/manual/beetle-anatomy/file-tree           #
+# https://embeetle.com/#embeetle-ide/manual/build/source-file-selection        #
+#                                                                              #
+# Read this comic if you want to have a good laugh:                            #
+# https://embeetle.com/#comics/src_files_selection                             #
+#                                                                              #
+################################################################################
+
+# VERSION:
+EMBEETLE_MAKEFILE_INTERFACE_VERSION = 7
+
+# INCLUDED CFILES:
+C_OFILES = \
+project/source/Debug/debug.c.o \
+project/source/LanaKBD/User/Main.c.o \
+project/source/LanaKBD/User/USBLIB/CONFIG/hw_config.c.o \
+project/source/LanaKBD/User/USBLIB/CONFIG/usb_desc.c.o \
+project/source/LanaKBD/User/USBLIB/CONFIG/usb_endp.c.o \
+project/source/LanaKBD/User/USBLIB/CONFIG/usb_istr.c.o \
+project/source/LanaKBD/User/USBLIB/CONFIG/usb_prop.c.o \
+project/source/LanaKBD/User/USBLIB/CONFIG/usb_pwr.c.o \
+project/source/LanaKBD/User/USBLIB/USB-Driver/src/usb_core.c.o \
+project/source/LanaKBD/User/USBLIB/USB-Driver/src/usb_init.c.o \
+project/source/LanaKBD/User/USBLIB/USB-Driver/src/usb_int.c.o \
+project/source/LanaKBD/User/USBLIB/USB-Driver/src/usb_mem.c.o \
+project/source/LanaKBD/User/USBLIB/USB-Driver/src/usb_regs.c.o \
+project/source/LanaKBD/User/USBLIB/USB-Driver/src/usb_sil.c.o \
+project/source/LanaKBD/User/ch32v20x_it.c.o \
+project/source/LanaKBD/User/system_ch32v20x.c.o \
+project/source/LanaKBD/User/usbd_compostie_km.c.o \
+project/source/Peripheral/src/ch32v20x_exti.c.o \
+project/source/Peripheral/src/ch32v20x_gpio.c.o \
+project/source/Peripheral/src/ch32v20x_misc.c.o \
+project/source/Peripheral/src/ch32v20x_i2c.c.o \
+project/source/Peripheral/src/ch32v20x_rcc.c.o \
+project/source/Peripheral/src/ch32v20x_tim.c.o \
+project/source/Peripheral/src/ch32v20x_usart.c.o
+
+# INCLUDED CXXFILES:
+CXX_OFILES =
+
+# INCLUDED SFILES:
+S_OFILES = \
+project/source/Startup/startup_ch32v20x_D6.S.o
+
+# LIST ALL OFILES:
+OFILES = $(C_OFILES) $(CXX_OFILES) $(S_OFILES)
+
+# INCLUDED HDIRS:
+HDIR_FLAGS = \
+-I$(SOURCE_DIR)source/Core \
+-I$(SOURCE_DIR)source/Debug \
+-I$(SOURCE_DIR)source/LanaKBD \
+-I$(SOURCE_DIR)source/LanaKBD/User \
+-I$(SOURCE_DIR)source/LanaKBD/User/USBLIB \
+-I$(SOURCE_DIR)source/LanaKBD/User/USBLIB/CONFIG \
+-I$(SOURCE_DIR)source/LanaKBD/User/USBLIB/USB-Driver \
+-I$(SOURCE_DIR)source/LanaKBD/User/USBLIB/USB-Driver/inc \
+-I$(SOURCE_DIR)source/LanaKBD/User/USBLIB/USB-Driver/src \
+-I$(SOURCE_DIR)source/Peripheral/inc
+
+# INCLUDED ARCHIVES
+PROJECT_LDLIBS =
+
+# MIT LICENSE
+# ===========
+# COPYRIGHT (c) 2020 Embeetle
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is furn-
+# ished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.

--- a/Sources/config/linkerscript.ld
+++ b/Sources/config/linkerscript.ld
@@ -1,0 +1,174 @@
+/*
+********************************************************************************
+**                                                                            **
+**                    LINKERSCRIPT FOR 'ch32v203c8t6'                         **
+**                                                                            **
+********************************************************************************
+** Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+** Attention: This software (modified or not) and binary are used for
+** microcontrollers manufactured by Nanjing Qinheng Microelectronics.
+**
+*/
+
+ENTRY( _start )
+__stack_size = 2048;
+PROVIDE( _stack_size = __stack_size );
+
+MEMORY
+{
+    /*FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 64K
+    RAM (xrw) : ORIGIN = 0x20000000, LENGTH = 20K */
+  	FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 32K
+    RAM (xrw) : ORIGIN = 0x20000000, LENGTH = 10K
+}
+
+SECTIONS
+{
+    .init :
+    {
+        _sinit = .;
+        . = ALIGN(4);
+        KEEP(*(SORT_NONE(.init)))
+        . = ALIGN(4);
+        _einit = .;
+    } >FLASH AT>FLASH
+
+    .vector :
+    {
+        *(.vector);
+          . = ALIGN(64);
+    } >FLASH AT>FLASH
+
+    .text :
+    {
+        . = ALIGN(4);
+        *(.text)
+        *(.text.*)
+        *(.rodata)
+        *(.rodata*)
+        *(.gnu.linkonce.t.*)
+        . = ALIGN(4);
+    } >FLASH AT>FLASH
+
+    .fini :
+    {
+        KEEP(*(SORT_NONE(.fini)))
+        . = ALIGN(4);
+    } >FLASH AT>FLASH
+
+    PROVIDE( _etext = . );
+    PROVIDE( _eitcm = . );
+
+    .preinit_array :
+    {
+        PROVIDE_HIDDEN (__preinit_array_start = .);
+        KEEP (*(.preinit_array))
+        PROVIDE_HIDDEN (__preinit_array_end = .);
+    } >FLASH AT>FLASH
+
+    .init_array :
+    {
+        PROVIDE_HIDDEN (__init_array_start = .);
+        KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP (*(.init_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .ctors))
+        PROVIDE_HIDDEN (__init_array_end = .);
+    } >FLASH AT>FLASH
+
+    .fini_array :
+    {
+        PROVIDE_HIDDEN (__fini_array_start = .);
+        KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+        KEEP (*(.fini_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .dtors))
+        PROVIDE_HIDDEN (__fini_array_end = .);
+    } >FLASH AT>FLASH
+
+    .ctors :
+    {
+        /* gcc uses crtbegin.o to find the start of
+         * the constructors, so we make sure it is
+         * first.  Because this is a wildcard, it
+         * doesn't matter if the user does not
+         * actually link against crtbegin.o; the
+         * linker won't look for a file to match a
+         * wildcard.  The wildcard also means that it
+         * doesn't matter which directory crtbegin.o
+         * is in.
+         */
+        KEEP (*crtbegin.o(.ctors))
+        KEEP (*crtbegin?.o(.ctors))
+        /* We don't want to include the .ctor section from
+         * the crtend.o file until after the sorted ctors.
+         * The .ctor section from the crtend file contains the
+         * end of ctors marker and it must be last
+         */
+        KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o ) .ctors))
+        KEEP (*(SORT(.ctors.*)))
+        KEEP (*(.ctors))
+    } >FLASH AT>FLASH
+
+    .dtors :
+    {
+        KEEP (*crtbegin.o(.dtors))
+        KEEP (*crtbegin?.o(.dtors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o ) .dtors))
+        KEEP (*(SORT(.dtors.*)))
+        KEEP (*(.dtors))
+    } >FLASH AT>FLASH
+
+    .dalign :
+    {
+        . = ALIGN(4);
+        PROVIDE(_data_vma = .);
+    } >RAM AT>FLASH
+
+    .dlalign :
+    {
+        . = ALIGN(4);
+        PROVIDE(_data_lma = .);
+    } >FLASH AT>FLASH
+
+    .data :
+    {
+        *(.gnu.linkonce.r.*)
+        *(.data .data.*)
+        *(.gnu.linkonce.d.*)
+        . = ALIGN(8);
+        PROVIDE( __global_pointer$ = . + 0x800 );
+        *(.sdata .sdata.*)
+        *(.sdata2.*)
+        *(.gnu.linkonce.s.*)
+        . = ALIGN(8);
+        *(.srodata.cst16)
+        *(.srodata.cst8)
+        *(.srodata.cst4)
+        *(.srodata.cst2)
+        *(.srodata .srodata.*)
+        . = ALIGN(4);
+        PROVIDE( _edata = .);
+    } >RAM AT>FLASH
+
+    .bss :
+    {
+        . = ALIGN(4);
+        PROVIDE( _sbss = .);
+        *(.sbss*)
+        *(.gnu.linkonce.sb.*)
+        *(.bss*)
+        *(.gnu.linkonce.b.*)
+        *(COMMON*)
+        . = ALIGN(4);
+        PROVIDE( _ebss = .);
+    } >RAM AT>FLASH
+
+    PROVIDE( _end = _ebss);
+    PROVIDE( end = . );
+
+    .stack ORIGIN(RAM) + LENGTH(RAM) - __stack_size :
+    {
+        PROVIDE( _heap_end = . );
+        . = ALIGN(4);
+        PROVIDE(_susrstack = . );
+        . = . + __stack_size;
+        PROVIDE( _eusrstack = .);
+    } >RAM
+}

--- a/Sources/config/makefile
+++ b/Sources/config/makefile
@@ -1,0 +1,699 @@
+################################################################################
+#                                                                              #
+#                      MAKEFILE FOR EMBEETLE PROJECTS                          #
+#                                                                              #
+################################################################################
+# COPYRIGHT (c) 2021 Johan Cockx                                               #
+# This software component is licensed by Embeetle under the MIT license. Con-  #
+# sult the license text at the bottom of this file.                            #
+#                                                                              #
+# Acknowledgements: inspiration for this makefile came from many sources,      #
+# including:                                                                   #
+#                                                                              #
+# - Recursive Make Considered Harmful                                          #
+#   https://accu.org/journals/overload/14/71/miller_2004/                      #
+#                                                                              #
+# - https://make.mad-scientist.net/papers/rules-of-makefiles                   #
+#                                                                              #
+# - http://make.mad-scientist.net/papers/advanced-auto-dependency-generation/  #
+#                                                                              #
+#------------------------------------------------------------------------------#
+#                           HOW TO RUN THIS MAKEFILE                           #
+#------------------------------------------------------------------------------#
+# This makefile is invoked by Embeetle IDE, when you click one of the makefile #
+# targets in the top-toolbar, eg. 'clean', 'build', 'flash'.                   #
+#                                                                              #
+# You can invoke this makefile also manually in a console ('cmd' on Windows,   #
+# 'sh' on Linux). First navigate to the toplevel project folder:               #
+#   $ cd C:/beetle_projects/my_project                                         #
+#                                                                              #
+# Then invoke the makefile with following arguments:                           #
+#   $ make build                                                               #
+#       -C build                                                               #
+#       -f ../config/makefile                                                  #
+#       "TOOLPREFIX=C:/my_tools/gnu_arm_toolchain_9.2.1/bin/arm-none-eabi-"    #
+#       "FLASHTOOL=C:/my_tools/openocd_0.10.0_dev01138_32b/bin/openocd.exe"    #
+#                                                                              #
+# The arguments TOOLPREFIX and FLASHTOOL are absolute paths to the compiler    #
+# toolchain (ARM, RISCV, ...) and the flash tool (OpenOCD, avrdude, ...) res-  #
+# pectively. You should provide them if they're not available on your PATH en- #
+# vironment variable.                                                          #
+#                                                                              #
+# In some situations, you'll also have to provide a FLASH_PORT argument, like: #
+#    $ make flash                                                              #
+#       -C build                                                               #
+#       -f ../config/makefile                                                  #
+#       "TOOLPREFIX=C:/my_tools/gnu_avr_toolchain_7.3.0_32b/bin/avr-"          #
+#       FLASH_PORT=COM5                                                        #
+#                                                                              #
+# If you're unsure how to invoke this makefile manually, just run it once in   #
+# Embeetle IDE and observe the command that Embeetle invokes. Copy-paste the   #
+# command into your console.                                                   #
+#                                                                              #
+#------------------------------------------------------------------------------#
+#                                    NOTES                                     #
+#------------------------------------------------------------------------------#
+# - Embeetle IDE always provides the absolute paths to the tools when running  #
+#   this makefile. That way, you don't need to modify your PATH environment    #
+#   variable to use Embeetle. On Windows, it also helps to avoid registry      #
+#   problems, as explained in ADDENDUM 2 at the bottom.                        #
+#                                                                              #
+# - In the folder where this makefile is stored (usually the 'config' folder   #
+#   of your project), there should be a 'dashboard.mk' and 'filetree.mk' file  #
+#   as well. These two files are generated by Embeetle and get included into   #
+#   this makefile.                                                             #
+#                                                                              #
+#------------------------------------------------------------------------------#
+#                               MORE INFORMATION                               #
+#------------------------------------------------------------------------------#
+# Consult the Embeetle website for more info about this makefile:              #
+# https://embeetle.com/#embeetle-ide/manual/build/embeetle-makefiles/main-makefile #
+#                                                                              #
+################################################################################
+
+
+# DEFAULT TARGET
+# ==============
+# If no target is specified on the command line,  make builds the first target
+# of the makefile. By convention,  this is usually called 'default'.
+default: build
+
+# HOST OS SPECIFIC COMMANDS
+# =========================
+# In addition to build and flash tools, this makefile makes use of commands to
+# create and delete directories and files in the build directory. Depending on
+# the situation, it needs to use Unix-style commands (rm, mkdir, touch) or
+# Windows-style commands (del, mkdir, type).
+#
+# The magic below attempts to guess the commands to be used.  It has been tested
+# in different configurations both on Windows and on Linux.  If it doesn't work
+# for you, feel free to fix it and/or send us the details of your environment,
+# so that we can improve it.
+#
+# The commands to be used depend on the host OS (the OS in which you are running
+# Embeetle).  On Windows, they also depend on how 'make' was compiled (for
+# native Windows or for MSYS or WSL) and on the command shell from which 'make'
+# is started ('cmd' or a ported linux-style shell).  On Linux and other variants
+# of Unix, 'make' always uses the Bourne shell 'sh'.  On Windows, it is usually
+# 'cmd', the native Microsoft command shell.  However, Unix shells and commands
+# have also been ported to Windows in environments like MSYS or WSL; when 'make'
+# is executed from one of these, it will again use the Bourne shell.
+#
+# This makefile has been tested with GNU make on different flavors of Linux, as
+# well as on Windows from the 'cmd' shell, 'powershell' and an MSYS shell, both
+# with 'make' compiled natively and with make compiled for MSYS, and with or
+# without sh.exe on PATH. All tested combinations work.
+ifeq ($(SHELL),sh.exe)
+  SHELLSTYLE=cmd
+  RM = $(if $(1),del /f /q $(subst /,\,$(1)))
+  define REMOVE_ALL =
+  for /d %%p in (*) do rmdir /s /q "%%p"
+  for %%p in (*) do del /q "%%p"
+  endef
+  MKDIR = dir $(subst /,\,$(1)) >nul 2>nul || mkdir $(subst /,\,$(1)) >nul 2>nul || mkdir $(subst /,\,$(1))
+  TOUCH = type NUL >>
+else
+  SHELLSTYLE=sh
+  SYSBIN = $(dir $(wildcard /bin/rm))
+  RM = $(SYSBIN)rm -f $(1)
+  REMOVE_ALL = $(SYSBIN)rm -rf * .[!.]* ..?*
+  MKDIR = $(SYSBIN)mkdir -p $(1)
+  TOUCH = $(SYSBIN)touch
+endif
+
+# DASHBOARD.MK
+# ============
+# Embeetle generates a file dashboard.mk in the same directory as the makefile
+# itself.  It defines the variables that depend on the user's choices in the
+# dashboard. It must be included for the Embeetle dashboard mechanism to work.
+# If you don't include it, it is your responsibility to define these values.
+#
+# The following variables defined in 'dashboard.mk' are used in this makefile:
+#
+#     - SOURCE_DIR         : The location of the directory containing the source
+#                            files; see "shadow building" below. This can be an
+#                            absolute or a relative(*) path and must end in '/'.
+#                            Any spaces in the path must be preceded by a triple
+#                            backslash '\\\ '.
+#
+#     - ELF_FILE           : Relative(*) path to .elf file.
+#
+#     - TOOLPREFIX         : A fallback value like 'arm-none-eabi-' in case this
+#                            makefile is invoked without giving an absolute path
+#                            to TOOLPREFIX in the commandline.
+#
+#     - TARGET_COMMONFLAGS : Flags for C++, C and assembly compilation and
+#                            linking
+#
+#     - TARGET_CFLAGS      : C compilation flags.
+#
+#     - TARGET_CXXFLAGS    : C++ compilation flags.
+#
+#     - TARGET_SFLAGS      : Assembler flags.
+#
+#     - TARGET_LDFLAGS     : Linker flags.
+#
+#     - TOOLCHAIN_LDLIBS   : Libraries from the toolchain that should be pro-
+#                            vided to the linker. For example '-lgcc'
+#
+# (*) Note: all relative paths are relative with respect to the build folder.
+#
+# In addition, dashboard.mk defines rules to create .bin and .hex files from the
+# .elf file, and a 'flash' target to flash the .elf, .bin or .hex file to the
+# microcontroller. Creation of .bin and .hex files and the flashing procedure
+# are very target-specific, so these rules cannot be added to this generic
+# makefile.  Flashing is usually achieved through a combination of GDB and
+# OpenOCD. Some MCUs require more specific tools like 'avrdude', 'esptool', ...
+
+include $(dir $(firstword $(MAKEFILE_LIST)))dashboard.mk
+
+# Make sure that 'dashboard.mk' defines the right version variable. This make-
+# file is version 7, so 'dashboard.mk' must be compatible.
+ifneq ($(EMBEETLE_MAKEFILE_INTERFACE_VERSION),7)
+  $(error 'dashboard.mk' is not compatible with this makefile)
+endif
+
+
+# COMPILATION RULES
+# =================
+# To allow source files in external library folders to be built locally in the
+# project, compilation rules are defined in a function called compilation-rules.
+# This function is evaluated once for the project itself and once for each
+# external library folder containing source files.  It fixes the build subfolder
+# to be used for each source tree.
+#
+# The compilation-rules function takes two arguments.  The first argument is the
+# path of the folder in which object files should be stored, relative to the
+# build folder.  The second argument is the path of the folder containing the
+# corresponding source files. Both paths must end in '/' or be empty, and spaces
+# must be quoted by preceding them with a triple backslash.
+
+define compilation-rules
+$(1)%.c.o: $(2)%.c
+	$$(c-rule)
+
+$(1)%.cpp.o: $(2)%.cpp
+	$$(cxx-rule)
+
+$(1)%.cxx.o: $(2)%.cxx
+	$$(cxx-rule)
+
+$(1)%.c++.o: $(2)%.c++
+	$$(cxx-rule)
+
+$(1)%.cc.o: $(2)%.cc
+	$$(cxx-rule)
+
+$(1)%.C.o: $(2)%.C
+	$$(cxx-rule)
+
+$(1)%.s.o: $(2)%.s
+	$$(asm-rule)
+
+$(1)%.asm.o: $(2)%.asm
+	$$(asm-rule)
+
+$(1)%.S.o: $(2)%.S
+	$$(asm-rule)
+
+endef
+
+define c-rule
+$(info )
+$(info )
+$(info Compile: $<)
+$(CC) $(CFLAGS) '$<' -o $@ -c
+endef
+
+define cxx-rule
+$(info )
+$(info )
+$(info Compile: $<)
+$(CXX) $(CXXFLAGS) '$<' -o $@ -c
+endef
+
+define asm-rule
+$(info )
+$(info )
+$(info Compile: $<)
+$(CC) $(SFLAGS) '$<' -o $@ -c
+endef
+
+# Compile source files from the project itself into object files in the
+# subdirectory 'project' of the build folder.
+$(eval $(call compilation-rules,project/,$(SOURCE_DIR)))
+
+# Cancel implicit rules
+.SUFFIXES:
+
+
+# FILETREE.MK
+# ===========
+# Embeetle generates a file filetree.mk in the same directory as the makefile
+# itself.  It defines the variables that depend on the user's choices in
+# Embeetle's filetree. It must be included for the Embeetle filetree mechanism
+# to work. If you don't include it, it is your responsibility to define these
+# values. For more info, check this webpage:
+# https://embeetle.com/#embeetle-ide/manual/build/source-file-selection
+#
+# 'filetree.mk' defines the following variables:
+#
+#     - OFILES   : List of object files to be linked into the project.
+#                  Each of these object files will be compiled from a
+#                  corresponding source file (C, C++ or assembly) in the project
+#                  folder or in an external folder.
+#
+#     - CXX_OFILES: The subset of OFILES that is compiled from C++ files.
+#                   A project with at least one C++ file needs a different
+#                   rule for linking (see further).
+#
+#     - C_OFILES:   The subset of OFILES that is compiled from C files. Not
+#                   used.
+#
+#     - S_OFILES:   The subset of OFILES that is compiled from assembly files.
+#                   Not used.
+#
+#     - HDIR_FLAGS: List of include directory options for the preprocessor.
+#                   These options are used to located header files includes by
+#                   the project's source files.
+#
+#     - PROJECT_LDLIBS: List of linker flags and archive files to be linked
+#                   into the project's executable
+#
+# In addition,  filetree.mk instantiates compilation rules for source files
+# from any external library folders used by the project.  For example,  for an
+# external library /etc/libs/foo,  it may contain this line:
+#      $(eval $(call compilation-rules,ext.foo/,/etc/libs/foo/))
+
+include $(dir $(firstword $(MAKEFILE_LIST)))filetree.mk
+
+# Make sure that 'filetree.mk' defines the right version variable. This makefile
+# is version 7, so 'filetree.mk' must be compatible.
+ifneq ($(EMBEETLE_MAKEFILE_INTERFACE_VERSION),7)
+  $(error 'filetree.mk' is not compatible with this makefile)
+endif
+
+# SHADOW BUILDING
+# ===============
+# This makefile supports 'shadow building', i.e. building the project in another
+# directory than the projects top directory. Shadow building has several
+# advantages:
+#
+#  - build artifacts are cleanly separated from source files
+#
+#  - the 'clean' target can simply delete all files in the build directory
+#
+#  - it is possible to simultanuously build different configurations from the
+#    same set of source files
+#
+# Potential disadvantages of shadow building are:
+#
+#  - shadow building needs a way to find the source files, as they are not
+#    located in the build directory
+#
+#  - when starting 'make' from the command line, the makefile to be used must
+#    be explicitly specified
+#
+# For shadow building, SOURCE_DIR should contain the path of the directory
+# containing the project's source files. It can be relative to the build folder
+# or absolute, and should end with '/'. Any spaces in the path must be preceded
+# by a triple backslash. If SOURCE_DIR is not defined, shadow building is not
+# possible. If you want to build in the source directory,  you will also have
+# to remove the test for shadow building below.
+#
+# In Embeetle, source files are located in the project's top directory, and
+# SOURCE_DIR is defined accordingly in dashboard.mk.  When building outside
+# Embeetle, you can override SOURCE_DIR on the command line using:
+#    $ make SOURCE_DIR=/path/to/project ...
+#
+
+# Check that we are using shadow building. If you want to allow building in the
+# source directory, comment or remove the check below.
+ifeq ($(abspath $(SOURCE_DIR)),$(abspath .))
+  $(info Please use shadow building:)
+  $(info create a new directory and build there using)
+  $(info $   $(MAKE) SOURCE_DIR=$(abspath .) -f $(abspath $(firstword $(MAKEFILE_LIST))))
+  $(error Attempt to build in the source directory)
+else
+  # Protect against shadow building in non-build directories, to avoid deleting
+  # source files during `make clean`. Shadow building is only allowed in an
+  # empty directory and in a directory containing a .build file.  In an empty
+  # directory, a .build file is automatically created.  If you don't want this
+  # protection, comment or remove the check below.
+  ifeq ($(wildcard * .[^.]* ..?*),)
+    $(shell $(TOUCH) .build)
+  endif
+  ifeq ($(wildcard .build),)
+    $(info Build directory not empty and .build file not found)
+    $(info Build directory is $(abspath .))
+    $(info Create an empty .build file if you really want to build here)
+    $(error Attempt to build in a non-empty non-build directory)
+  endif
+
+  # If the source directory has subdirectories, create the same subdirectories
+  # in the build directory, so that the object file for a source file in a
+  # subdirectory can be created in the corresponding subdirectory of the build
+  # directory.
+  #
+  # The list of subdirectories to create is automatically derived from the list
+  # of object files OFILES (normally defined in filetree.mk - see further).
+  SUBDIRS = $(sort $(dir $(OFILES)))
+  .PHONY: subdirs
+  subdirs: $(SUBDIRS)
+  $(OFILES): | subdirs
+  %/: ; $(call MKDIR, $@)
+endif
+
+
+# AUTOMATIC DEPENDENCY TRACKING
+# =============================
+# Dependency (.d) files are generated by the preprocessor with the -MMD flag.
+# These files give make the necessary information to decide which files to
+# recompile when a header files changes.
+#
+# -MF makes sure that the dependency file is generated next to the object file.
+#
+# -MP adds a target with no dependencies for each header file, so that make
+#     will not complain when you remove a header file that is still mentioned in
+#     a dependency file.
+#
+# -MQ sets the name of the target file in the dependency file,  to make sure
+#     that it matches the object file.
+
+DEPFLAGS = -MMD -MF $(@:.o=.d) -MP -MQ $@
+include $(wildcard $(OFILES:.o=.d))
+
+
+# COMPILERS
+# =========
+# Define the compilers to be used for compilation. We'll use cross compilers
+# for the target microcontroller. These typically have the same command names as
+# a native gcc compiler, with a prefix (e.g. arm-none-eabi- for ARM
+# cross-compilers).
+#
+# Note: A cross compiler is a compiler that runs on one machine (e.g. a Windows
+#       desktop) to compile code for another type of machine (e.g. your
+#       microcontroller).
+#
+# The TOOLPREFIX variable can be given a value on the command line. If not, the
+# default value given in 'dashboard.mk' is used. In Embeetle, we use an absolute
+# path for TOOLPREFIX. See ADDENDUM 2 at the bottom of this file for why we do
+# that.
+#
+# We use the C and C++ compilers(*), as well as the 'objcopy' and 'size'
+# commands. The C compiler is also used for assembly code. For linking,  we use
+# the C++ compiler if there are any C++ files in the project,  and the C compiler
+# otherwise. The C++ compiler will link in the C++ standard libraries. CXX_OFILES
+# is defined in filetree.mk.
+#
+# (*) Strictly speaking,  'gcc' and 'g++' are not compilers but "driver
+#     programs",  programs that call the compiler and other tools as appropriate
+#     for the arguments you give them.
+
+CC      = "$(TOOLPREFIX)gcc"
+CXX     = "$(TOOLPREFIX)g++"
+LD      = $(if $(CXX_OFILES),$(CXX),$(CC))
+OBJCOPY = "$(TOOLPREFIX)objcopy"
+OBJSIZE = "$(TOOLPREFIX)size"
+GDB     = "$(TOOLPREFIX)gdb"
+
+
+# COMPILATION FLAGS
+# =================
+# COMMONFLAGS
+# -----------
+# Common flags for C/C++ and assembly compilations and linking.
+#
+#     $(TARGET_COMMONFLAGS) CPU specific compilation flags, defined in
+#                           dashboard.mk
+#
+#     -Og                   The optimization level of choice for the standard
+#                           edit-compile-debug cycle, offering a reasonable
+#                           level of optimization while maintaining fast
+#                           compilation and a good debugging experience.  It is
+#                           a better choice than -O0 for producing debuggable
+#                           code because some compiler passes that collect debug
+#                           information are disabled at -O0.
+#
+#     -g3                   Maximize debug information.
+#
+#     -MMD                  Tell preprocessor to generate dependency (.d) files
+#                           that will help make to determine what files to re-
+#                           compile after a change in a header file.
+#
+#     -fmessage-length=0    Try to format error messages so that they fit on li-
+#                           nes of about n characters. If n=0, they'll be prin-
+#                           ted on a single line.
+#
+#     -ffunction-sections   Generate a separate ELF section for each function in
+#                           the source file. The unused section elimination fea-
+#                           ture of the linker can then remove unused functions
+#                           at link time.
+#
+#     -fdata-sections       Enable the generation of one ELF section for each
+#                           variable in the source file.
+#
+#     -Wno-comment          Do not warn when /* appears in the middle of a /* */
+#                           comment.
+#
+#     -Wno-unused-function  Do not warn for a static function that is declared
+#                           but not defined, or a non\-inline static function
+#                           that is unused.
+#
+# ABOUT WARNINGS:
+#     The flags -Wall and -Wextra make sure that most potential problems are
+#     reported as warnings. We did not add these flags by default because they
+#     trigger a lot of warnings in third party code in many sample projects, and
+#     we don't have the resources to fix all of them. However, we do recommend
+#     to add these flags for your own projects.
+#
+#     The flag -Werror turns all these warnings into errors. To avoid acciden-
+#     tally missing an important warning, add this flag and edit your source
+#     code until no warnings are reported. For even more warnings, see
+#     https://kristerw.blogspot.com/2017/09/useful-gcc-warning-options-not-enabled.html
+COMMONFLAGS = \
+  $(TARGET_COMMONFLAGS) \
+  -Og \
+  -g3 \
+  -fmessage-length=0 \
+  -ffunction-sections \
+  -fdata-sections \
+  -Wno-comment \
+  -Wno-unused-function \
+
+# CFLAGS
+# ------
+# C compilation flags.
+#
+#     -Werror-implicit-function-declaration    Give a warning (or error) when-
+#                                              ever a function is used before
+#                                              being declared.
+#
+# Note: The variable TARGET_CFLAGS gets defined in 'dashboard.mk'.
+CFLAGS = $(COMMONFLAGS) $(DEPFLAGS) $(TARGET_CFLAGS) $(HDIR_FLAGS) \
+  -Werror-implicit-function-declaration \
+
+# CXXFLAGS
+# --------
+# C++ compilation flags.
+# Note: The variable TARGET_CXXFLAGS gets defined in 'dashboard.mk'.
+CXXFLAGS = $(COMMONFLAGS) $(DEPFLAGS) $(TARGET_CXXFLAGS) $(HDIR_FLAGS)
+
+# SFLAGS
+# ------
+# Assembly specific compilation flags.
+# Note: The variable TARGET_SFLAGS gets defined in 'dashboard.mk'.
+SFLAGS = $(COMMONFLAGS) $(DEPFLAGS) $(TARGET_SFLAGS) $(HDIR_FLAGS)
+
+# LDFLAGS
+# --------
+# Linker flags.
+# Note: The variable TARGET_LDFLAGS gets defined in 'dashboard.mk'.
+#
+#     -Wl,-Map=output.map    Pass "-Map output.map" flag to linker,
+#                            request output.map generation.
+#
+#     -Wl,--gc-sections      Pass "--gc-sections" flag to linker,
+#                            garbage collect unused sections.
+LDFLAGS = \
+  -Wl,-Map=output.map \
+  -Wl,--gc-sections \
+  $(COMMONFLAGS) \
+  $(TARGET_LDFLAGS) \
+
+# DEPENDENCIES FOR THE FINAL .ELF FILE
+# ====================================
+# If you included Embeetle's 'filetree.mk' file in this makefile, then the
+# object file list OFILES has been defined. Otherwise, you have to define it
+# yourself.
+#
+# The dependency on 'filetree.mk' below makes sure that the elf file is relinked
+# when the source file lists have changed, even if no source files changed. Feel
+# free to remove it if you do not want that behavior.
+#
+$(ELF_FILE): $(dir $(firstword $(MAKEFILE_LIST)))filetree.mk $(OFILES)
+
+# RULES TO BUILD THE ELF FILES AND EXTRACT INFORMATION FROM IT
+# ============================================================
+# The rules to build the .bin and .hex files from the .elf, can be
+# dependent on the target microcontroller. Therefore, we've moved them
+# to the 'dashboard.mk' file.
+
+%.elf:
+	$(info )
+	$(info )
+	$(info )
+	$(info Link program into $@)
+	$(LD) $(LDFLAGS) -o $@ $(filter %.o %.a %.so,$^) $(PROJECT_LDLIBS) $(TOOLCHAIN_LDLIBS)
+
+.PHONY: show_size
+show_size: $(ELF_FILE:.elf=.size)
+
+%.size: %.elf
+	$(info )
+	$(info )
+	$(info Preparing: $@)
+	$(OBJSIZE) $<
+
+# BUILD
+# =====
+# The eventual goal of the build target is to create all the binaries: .bin,
+# .elf and .hex. Potentially also the EEPROM file .eep. To create all these
+# files, we just need to add them as dependencies/prerequisites to the phony
+# build target.  Note: The variable BINARIES gets defined in 'dashboard.mk'.
+.PHONY: build
+build: print_build $(BINARIES) show_size
+
+# CLEAN
+# =====
+# Remove files generated during the build process. For a shadow build, all files
+# can be safely removed.  For a build in (a parent directory of) the source
+# directory, remove files selectively to avoid removing source files.
+
+.PHONY: clean
+clean: print_clean
+ifeq ($(filter $(realpath .)/,$(realpath $(SOURCE_DIR))/),)
+	$(REMOVE_ALL)
+else
+	$(call RM,$(wildcard $(patsubst %,%*.o %*.d,$(SUBDIRS)) *.elf *.size *.bin))
+endif
+
+# ASCII ART
+# =========
+# We provide some nice ascii-art, to be printed for each target.
+
+LPAREN :=(
+RPAREN :=)
+
+.PHONY: print_clean
+print_clean:
+	$(info)
+	$(info)
+	$(info # ----------------------------------------------------------)
+	$(info #        __         **************)
+	$(info #      __\ \___     * make clean *)
+	$(info #      \ _ _ _ \    **************)
+	$(info #       \_`_`_`_\ )
+	$(info # )
+	$(info #  Operating system:    $(OS))
+	$(info #  Shell:               $(SHELL))
+	$(info #  Shell style:         $(SHELLSTYLE))
+	$(info #  Source folder:       $(abspath $(SOURCE_DIR)))
+	$(info #  Build folder:        $(abspath .))
+	$(info # ----------------------------------------------------------)
+
+.PHONY: print_build
+print_build:
+	$(info)
+	$(info # ----------------------------------------------------------------)
+	$(info #             $(RPAREN)\     **************)
+	$(info #   $(LPAREN) =_=_=_=<| |    * make build *)
+	$(info #             $(RPAREN)$(LPAREN)     **************)
+	$(info #             "" )
+	$(info # )
+	$(info #  Operating system:    $(OS))
+	$(info #  Shell:               $(SHELL))
+	$(info #  Shell style:         $(SHELLSTYLE))
+	$(info #  Source folder:       $(abspath $(SOURCE_DIR)))
+	$(info #  Build folder:        $(abspath .))
+	$(info #  Binary output:       $(BINARIES))
+	$(info # ----------------------------------------------------------------)
+
+.PHONY: print_flash
+print_flash:
+	$(info)
+	$(info)
+	$(info # ----------------------------------------------------------)
+	$(info #        __         **************)
+	$(info #       / /_        * make flash *)
+	$(info #      /_  /        **************)
+	$(info #        /` )
+	$(info #       ` )
+	$(info #  Operating system:    $(OS))
+	$(info #  Shell:               $(SHELL))
+	$(info #  Shell style:         $(SHELLSTYLE))
+	$(info #  Source folder:       $(abspath $(SOURCE_DIR)))
+	$(info #  Build folder:        $(abspath .))
+	$(info # ----------------------------------------------------------)
+
+.PHONY: print_flash_bootloader
+print_flash_bootloader:
+	$(info)
+	$(info)
+	$(info # ----------------------------------------------------------)
+	$(info #        /\         *************************)
+	$(info #       $(LPAREN)  $(RPAREN)        * make flash_bootloader *)
+	$(info #       $(LPAREN)  $(RPAREN)        *************************)
+	$(info #      /|/\|\ )
+	$(info #     /_||||_\ )
+	$(info #  Operating system:    $(OS))
+	$(info #  Shell:               $(SHELL))
+	$(info #  Shell style:         $(SHELLSTYLE))
+	$(info #  Source folder:       $(abspath $(SOURCE_DIR)))
+	$(info #  Build folder:        $(abspath .))
+	$(info # ----------------------------------------------------------)
+
+
+# ADDENDUM 1. MIT LICENSE
+# =======================
+# Copyright 2023 Johan Cockx
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is furn-
+# ished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# ADDENDUM 2. WHY WE USE ABSOLUTE PATHS FOR THE COMPILERS
+# =======================================================
+# Please note that we use absolute(!) paths to refer to the compilers. Normally,
+# it would be sufficient to add the absolute paths just once to the PATH
+# environment variable and call the compiler by its name from then forward.
+# Unfortunately, on Windows this causes the error 'CreateProcess: No such file
+# or directory'. Apparently this is because of a missing registry key, one that
+# gets written to the registry when you install the compiler through the
+# official installer. That registry key then points to the location of the
+# installation. We strongly dislike this approach, because:
+#
+#       - We don't like messing with your registry.
+#
+#       - The location of your compiler must be stored in two places: the
+#         registry and the PATH environment variable. If you move the compiler,
+#         you should change both of them. Most often, people forget to adapt the
+#         registry key and disaster strikes...
+#
+# Therefore, we see no other option than calling the compilers by their absolute
+# path. To do that practically, we glue the TOOLCHAIN variable to the compiler
+# name.

--- a/Sources/config/openocd_chip.cfg
+++ b/Sources/config/openocd_chip.cfg
@@ -1,0 +1,14 @@
+# OpenOCD config file for 'ch32v203c8t6'
+wlink_set_address 0x00000000
+set _CHIPNAME wch_riscv
+sdi newtap $_CHIPNAME cpu -irlen 5 -expected-id 0x00001
+
+set _TARGETNAME $_CHIPNAME.cpu
+
+target create $_TARGETNAME.0 wch_riscv -chain-position $_TARGETNAME
+$_TARGETNAME.0 configure  -work-area-phys 0x20000000 -work-area-size 10000 -work-area-backup 1
+set _FLASHNAME $_CHIPNAME.flash
+
+flash bank $_FLASHNAME wch_riscv 0x00000000 0 0 0 $_TARGETNAME.0
+
+echo "Ready for Remote Connections"

--- a/Sources/config/openocd_probe.cfg
+++ b/Sources/config/openocd_probe.cfg
@@ -1,0 +1,5 @@
+# OpenOCD config file for 'wch-linke-r0-1v3-riscv'
+# Must be applied before the chip config file!
+adapter driver wlinke
+adapter speed 6000
+transport select sdi

--- a/Sources/source/Core/core_riscv.c
+++ b/Sources/source/Core/core_riscv.c
@@ -1,0 +1,307 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : core_riscv.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/06/06
+ * Description        : RISC-V Core Peripheral Access Layer Source File
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#include <stdint.h>
+
+/* define compiler specific symbols */
+#if defined ( __CC_ARM   )
+  #define __ASM            __asm                                      /*!< asm keyword for ARM Compiler          */
+  #define __INLINE         __inline                                   /*!< inline keyword for ARM Compiler       */
+
+#elif defined ( __ICCARM__ )
+  #define __ASM           __asm                                       /*!< asm keyword for IAR Compiler          */
+  #define __INLINE        inline                                      /*!< inline keyword for IAR Compiler. Only avaiable in High optimization mode! */
+
+#elif defined   (  __GNUC__  )
+  #define __ASM            __asm                                      /*!< asm keyword for GNU Compiler          */
+  #define __INLINE         inline                                     /*!< inline keyword for GNU Compiler       */
+
+#elif defined   (  __TASKING__  )
+  #define __ASM            __asm                                      /*!< asm keyword for TASKING Compiler      */
+  #define __INLINE         inline                                     /*!< inline keyword for TASKING Compiler   */
+
+#endif
+
+
+
+/*********************************************************************
+ * @fn      __get_MSTATUS
+ *
+ * @brief   Return the Machine Status Register
+ *
+ * @return  mstatus value
+ */
+uint32_t __get_MSTATUS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ( "csrr %0," "mstatus" : "=r" (result) );
+  return (result);
+}
+
+/*********************************************************************
+ * @fn      __set_MSTATUS
+ *
+ * @brief   Set the Machine Status Register
+ *
+ * @param   value  - set mstatus value
+ *
+ * @return  none
+ */
+void __set_MSTATUS(uint32_t value)
+{
+  __ASM volatile ("csrw mstatus, %0" : : "r" (value) );
+}
+
+/*********************************************************************
+ * @fn      __get_MISA
+ *
+ * @brief   Return the Machine ISA Register
+ *
+ * @return  misa value
+ */
+uint32_t __get_MISA(void)
+{
+  uint32_t result;
+
+  __ASM volatile ( "csrr %0," "misa" : "=r" (result) );
+  return (result);
+}
+
+/*********************************************************************
+ * @fn      __set_MISA
+ *
+ * @brief   Set the Machine ISA Register
+ *
+ * @param   value  - set misa value
+ *
+ * @return  none
+ */
+void __set_MISA(uint32_t value)
+{
+  __ASM volatile ("csrw misa, %0" : : "r" (value) );
+}
+
+
+/*********************************************************************
+ * @fn      __get_MTVEC
+ *
+ * @brief   Return the Machine Trap-Vector Base-Address Register
+ *
+ * @return  mtvec value
+ */
+uint32_t __get_MTVEC(void)
+{
+  uint32_t result;
+
+  __ASM volatile ( "csrr %0," "mtvec" : "=r" (result) );
+  return (result);
+}
+
+/*********************************************************************
+ * @fn      __set_MTVEC
+ *
+ * @brief   Set the Machine Trap-Vector Base-Address Register
+ *
+ * @param   value  - set mtvec value
+ *
+ * @return  none
+ */
+void __set_MTVEC(uint32_t value)
+{
+  __ASM volatile ("csrw mtvec, %0" : : "r" (value) );
+}
+
+/*********************************************************************
+ * @fn      __get_MSCRATCH
+ *
+ * @brief   Return the Machine Seratch Register
+ *
+ * @return  mscratch value
+ */
+uint32_t __get_MSCRATCH(void)
+{
+  uint32_t result;
+
+  __ASM volatile ( "csrr %0," "mscratch" : "=r" (result) );
+  return (result);
+}
+
+/*********************************************************************
+ * @fn      __set_MSCRATCH
+ *
+ * @brief   Set the Machine Seratch Register
+ *
+ * @param   value  - set mscratch value
+ *
+ * @return  none
+ */
+void __set_MSCRATCH(uint32_t value)
+{
+  __ASM volatile ("csrw mscratch, %0" : : "r" (value) );
+}
+
+/*********************************************************************
+ * @fn      __get_MEPC
+ *
+ * @brief   Return the Machine Exception Program Register
+ *
+ * @return  mepc value
+ */
+uint32_t __get_MEPC(void)
+{
+  uint32_t result;
+
+  __ASM volatile ( "csrr %0," "mepc" : "=r" (result) );
+  return (result);
+}
+
+/*********************************************************************
+ * @fn      __set_MEPC
+ *
+ * @brief   Set the Machine Exception Program Register
+ *
+ * @return  mepc value
+ */
+void __set_MEPC(uint32_t value)
+{
+  __ASM volatile ("csrw mepc, %0" : : "r" (value) );
+}
+
+/*********************************************************************
+ * @fn      __get_MCAUSE
+ *
+ * @brief   Return the Machine Cause Register
+ *
+ * @return  mcause value
+ */
+uint32_t __get_MCAUSE(void)
+{
+  uint32_t result;
+
+  __ASM volatile ( "csrr %0," "mcause" : "=r" (result) );
+  return (result);
+}
+
+/*********************************************************************
+ * @fn      __set_MEPC
+ *
+ * @brief   Set the Machine Cause Register
+ *
+ * @return  mcause value
+ */
+void __set_MCAUSE(uint32_t value)
+{
+  __ASM volatile ("csrw mcause, %0" : : "r" (value) );
+}
+
+/*********************************************************************
+ * @fn      __get_MTVAL
+ *
+ * @brief   Return the Machine Trap Value Register
+ *
+ * @return  mtval value
+ */
+uint32_t __get_MTVAL(void)
+{
+  uint32_t result;
+
+  __ASM volatile ( "csrr %0," "mtval" : "=r" (result) );
+  return (result);
+}
+
+/*********************************************************************
+ * @fn      __set_MTVAL
+ *
+ * @brief   Set the Machine Trap Value Register
+ *
+ * @return  mtval value
+ */
+void __set_MTVAL(uint32_t value)
+{
+  __ASM volatile ("csrw mtval, %0" : : "r" (value) );
+}
+
+/*********************************************************************
+ * @fn      __get_MVENDORID
+ *
+ * @brief   Return Vendor ID Register
+ *
+ * @return  mvendorid value
+ */
+uint32_t __get_MVENDORID(void)
+{
+  uint32_t result;
+
+  __ASM volatile ( "csrr %0," "mvendorid" : "=r" (result) );
+  return (result);
+}
+
+/*********************************************************************
+ * @fn      __get_MARCHID
+ *
+ * @brief   Return Machine Architecture ID Register
+ *
+ * @return  marchid value
+ */
+uint32_t __get_MARCHID(void)
+{
+  uint32_t result;
+
+  __ASM volatile ( "csrr %0," "marchid" : "=r" (result) );
+  return (result);
+}
+
+/*********************************************************************
+ * @fn      __get_MIMPID
+ *
+ * @brief   Return Machine Implementation ID Register
+ *
+ * @return  mimpid value
+ */
+uint32_t __get_MIMPID(void)
+{
+  uint32_t result;
+
+  __ASM volatile ( "csrr %0," "mimpid" : "=r" (result) );
+  return (result);
+}
+
+/*********************************************************************
+ * @fn      __get_MHARTID
+ *
+ * @brief   Return Hart ID Register
+ *
+ * @return  mhartid value
+ */
+uint32_t __get_MHARTID(void)
+{
+  uint32_t result;
+
+  __ASM volatile ( "csrr %0," "mhartid" : "=r" (result) );
+  return (result);
+}
+
+/*********************************************************************
+ * @fn      __get_SP
+ *
+ * @brief   Return SP Register
+ *
+ * @return  SP value
+ */
+uint32_t __get_SP(void)
+{
+  uint32_t result;
+
+  __ASM volatile ( "mv %0," "sp" : "=r"(result) : );
+  return (result);
+}
+

--- a/Sources/source/Core/core_riscv.h
+++ b/Sources/source/Core/core_riscv.h
@@ -1,0 +1,377 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : core_riscv.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/06/06
+ * Description        : RISC-V Core Peripheral Access Layer Header File for CH32V20x
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __CORE_RISCV_H__
+#define __CORE_RISCV_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* IO definitions */
+#ifdef __cplusplus
+  #define     __I     volatile                /*!< defines 'read only' permissions      */
+#else
+  #define     __I     volatile const          /*!< defines 'read only' permissions     */
+#endif
+#define     __O     volatile                  /*!< defines 'write only' permissions     */
+#define     __IO    volatile                  /*!< defines 'read / write' permissions   */
+
+/* Standard Peripheral Library old types (maintained for legacy purpose) */
+typedef __I uint64_t vuc64;  /* Read Only */
+typedef __I uint32_t vuc32;  /* Read Only */
+typedef __I uint16_t vuc16;  /* Read Only */
+typedef __I uint8_t vuc8;   /* Read Only */
+
+typedef const uint64_t uc64;  /* Read Only */
+typedef const uint32_t uc32;  /* Read Only */
+typedef const uint16_t uc16;  /* Read Only */
+typedef const uint8_t uc8;   /* Read Only */
+
+typedef __I int64_t vsc64;  /* Read Only */
+typedef __I int32_t vsc32;  /* Read Only */
+typedef __I int16_t vsc16;  /* Read Only */
+typedef __I int8_t vsc8;   /* Read Only */
+
+typedef const int64_t sc64;  /* Read Only */
+typedef const int32_t sc32;  /* Read Only */
+typedef const int16_t sc16;  /* Read Only */
+typedef const int8_t sc8;   /* Read Only */
+
+typedef __IO uint64_t  vu64;
+typedef __IO uint32_t  vu32;
+typedef __IO uint16_t vu16;
+typedef __IO uint8_t  vu8;
+
+typedef uint64_t  u64;
+typedef uint32_t  u32;
+typedef uint16_t u16;
+typedef uint8_t  u8;
+
+typedef __IO int64_t  vs64;
+typedef __IO int32_t  vs32;
+typedef __IO int16_t  vs16;
+typedef __IO int8_t   vs8;
+
+typedef int64_t  s64;
+typedef int32_t  s32;
+typedef int16_t s16;
+typedef int8_t  s8;
+
+typedef enum {NoREADY = 0, READY = !NoREADY} ErrorStatus;
+
+typedef enum {DISABLE = 0, ENABLE = !DISABLE} FunctionalState;
+
+typedef enum {RESET = 0, SET = !RESET} FlagStatus, ITStatus;
+
+#define   RV_STATIC_INLINE  static  inline
+
+/* memory mapped structure for Program Fast Interrupt Controller (PFIC) */
+typedef struct{
+  __I  uint32_t ISR[8];
+  __I  uint32_t IPR[8];
+  __IO uint32_t ITHRESDR;
+  __IO uint32_t RESERVED;
+  __IO uint32_t CFGR;
+  __I  uint32_t GISR;
+  __IO uint8_t VTFIDR[4];
+  uint8_t RESERVED0[12];
+  __IO uint32_t VTFADDR[4];
+  uint8_t RESERVED1[0x90];
+  __O  uint32_t IENR[8];
+  uint8_t RESERVED2[0x60];
+  __O  uint32_t IRER[8];
+  uint8_t RESERVED3[0x60];
+  __O  uint32_t IPSR[8];
+  uint8_t RESERVED4[0x60];
+  __O  uint32_t IPRR[8];
+  uint8_t RESERVED5[0x60];
+  __IO uint32_t IACTR[8];
+  uint8_t RESERVED6[0xE0];
+  __IO uint8_t IPRIOR[256];
+  uint8_t RESERVED7[0x810];
+  __IO uint32_t SCTLR;
+}PFIC_Type;
+
+/* memory mapped structure for SysTick */
+typedef struct
+{
+    __IO u32 CTLR;
+    __IO u32 SR;
+    __IO u64 CNT;
+    __IO u64 CMP;
+}SysTick_Type;
+
+
+#define PFIC            ((PFIC_Type *) 0xE000E000 )
+#define NVIC            PFIC
+#define NVIC_KEY1       ((uint32_t)0xFA050000)
+#define	NVIC_KEY2				((uint32_t)0xBCAF0000)
+#define	NVIC_KEY3				((uint32_t)0xBEEF0000)
+
+#define SysTick         ((SysTick_Type *) 0xE000F000)
+
+
+/*********************************************************************
+ * @fn      __enable_irq
+ *
+ * @brief   Enable Global Interrupt
+ *
+ * @return  none
+ */
+RV_STATIC_INLINE void __enable_irq()
+{
+  __asm volatile ("csrw 0x800, %0" : : "r" (0x6088) );
+}
+
+/*********************************************************************
+ * @fn      __disable_irq
+ *
+ * @brief   Disable Global Interrupt
+ *
+ * @return  none
+ */
+RV_STATIC_INLINE void __disable_irq()
+{
+  __asm volatile ("csrw 0x800, %0" : : "r" (0x6000) );
+}
+
+/*********************************************************************
+ * @fn      __NOP
+ *
+ * @brief   nop
+ *
+ * @return  none
+ */
+RV_STATIC_INLINE void __NOP()
+{
+  __asm volatile ("nop");
+}
+
+/*********************************************************************
+ * @fn       NVIC_EnableIRQ
+ *
+ * @brief   Disable Interrupt
+ *
+ * @param   IRQn - Interrupt Numbers
+ *
+ * @return  none
+ */
+RV_STATIC_INLINE void NVIC_EnableIRQ(IRQn_Type IRQn)
+{
+  NVIC->IENR[((uint32_t)(IRQn) >> 5)] = (1 << ((uint32_t)(IRQn) & 0x1F));
+}
+
+/*********************************************************************
+ * @fn       NVIC_DisableIRQ
+ *
+ * @brief   Disable Interrupt
+ *
+ * @param   IRQn - Interrupt Numbers
+ *
+ * @return  none
+ */
+RV_STATIC_INLINE void NVIC_DisableIRQ(IRQn_Type IRQn)
+{
+  NVIC->IRER[((uint32_t)(IRQn) >> 5)] = (1 << ((uint32_t)(IRQn) & 0x1F));
+}
+
+/*********************************************************************
+ * @fn       NVIC_GetStatusIRQ
+ *
+ * @brief   Get Interrupt Enable State
+ *
+ * @param   IRQn - Interrupt Numbers
+ *
+ * @return  1 - 1: Interrupt Pending Enable
+ *                0 - Interrupt Pending Disable
+ */
+RV_STATIC_INLINE uint32_t NVIC_GetStatusIRQ(IRQn_Type IRQn)
+{
+  return((uint32_t) ((NVIC->ISR[(uint32_t)(IRQn) >> 5] & (1 << ((uint32_t)(IRQn) & 0x1F)))?1:0));
+}
+
+/*********************************************************************
+ * @fn      NVIC_GetPendingIRQ
+ *
+ * @brief   Get Interrupt Pending State
+ *
+ * @param   IRQn - Interrupt Numbers
+ *
+ * @return  1 - 1: Interrupt Pending Enable
+ *                0 - Interrupt Pending Disable
+ */
+RV_STATIC_INLINE uint32_t NVIC_GetPendingIRQ(IRQn_Type IRQn)
+{
+  return((uint32_t) ((NVIC->IPR[(uint32_t)(IRQn) >> 5] & (1 << ((uint32_t)(IRQn) & 0x1F)))?1:0));
+}
+
+/*********************************************************************
+ * @fn      NVIC_SetPendingIRQ
+ *
+ * @brief   Set Interrupt Pending
+ *
+ * @param   IRQn - Interrupt Numbers
+ *
+ * @return  none
+ */
+RV_STATIC_INLINE void NVIC_SetPendingIRQ(IRQn_Type IRQn)
+{
+  NVIC->IPSR[((uint32_t)(IRQn) >> 5)] = (1 << ((uint32_t)(IRQn) & 0x1F));
+}
+
+/*********************************************************************
+ * @fn      NVIC_ClearPendingIRQ
+ *
+ * @brief   Clear Interrupt Pending
+ *
+ * @param   IRQn - Interrupt Numbers
+ *
+ * @return  none
+ */
+RV_STATIC_INLINE void NVIC_ClearPendingIRQ(IRQn_Type IRQn)
+{
+  NVIC->IPRR[((uint32_t)(IRQn) >> 5)] = (1 << ((uint32_t)(IRQn) & 0x1F));
+}
+
+/*********************************************************************
+ * @fn      NVIC_GetActive
+ *
+ * @brief   Get Interrupt Active State
+ *
+ * @param   IRQn - Interrupt Numbers
+ *
+ * @return  1 - Interrupt Active
+ *                0 - Interrupt No Active
+ */
+RV_STATIC_INLINE uint32_t NVIC_GetActive(IRQn_Type IRQn)
+{
+  return((uint32_t)((NVIC->IACTR[(uint32_t)(IRQn) >> 5] & (1 << ((uint32_t)(IRQn) & 0x1F)))?1:0));
+}
+
+/*********************************************************************
+ * @fn      NVIC_SetPriority
+ *
+ * @brief   Set Interrupt Priority
+ *
+ * @param   IRQn - Interrupt Numbers
+ *                  priority: bit7 - pre-emption priority
+ *                  bit6-bit4 - subpriority
+ *
+ * @return  none
+ */
+RV_STATIC_INLINE void NVIC_SetPriority(IRQn_Type IRQn, uint8_t priority)
+{
+  NVIC->IPRIOR[(uint32_t)(IRQn)] = priority;
+}
+
+/*********************************************************************
+ * @fn       __WFI
+ *
+ * @brief   Wait for Interrupt
+ *
+ * @return  none
+ */
+__attribute__( ( always_inline ) ) RV_STATIC_INLINE void __WFI(void)
+{
+  NVIC->SCTLR &= ~(1<<3);	// wfi
+  asm volatile ("wfi");
+}
+
+/*********************************************************************
+ * @fn       __WFE
+ *
+ * @brief   Wait for Events
+ *
+ * @return  none
+ */
+__attribute__( ( always_inline ) ) RV_STATIC_INLINE void __WFE(void)
+{
+  uint32_t t;
+
+  t = NVIC->SCTLR;
+  NVIC->SCTLR |= (1<<3)|(1<<5);		// (wfi->wfe)+(__sev)
+  NVIC->SCTLR = (NVIC->SCTLR & ~(1<<5)) | ( t & (1<<5));
+  asm volatile ("wfi");
+  asm volatile ("wfi");
+}
+
+/*********************************************************************
+ * @fn      SetVTFIRQ
+ *
+ * @brief   Set VTF Interrupt
+ *
+ * @param   addr - VTF interrupt service function base address.
+ *                  IRQn - Interrupt Numbers
+ *                  num - VTF Interrupt Numbers
+ *                  NewState -  DISABLE or ENABLE
+ *
+ * @return  none
+ */
+RV_STATIC_INLINE void SetVTFIRQ(uint32_t addr, IRQn_Type IRQn, uint8_t num, FunctionalState NewState){
+  if(num > 3)  return ;
+
+  if (NewState != DISABLE)
+  {
+      NVIC->VTFIDR[num] = IRQn;
+      NVIC->VTFADDR[num] = ((addr&0xFFFFFFFE)|0x1);
+  }
+  else{
+      NVIC->VTFIDR[num] = IRQn;
+      NVIC->VTFADDR[num] = ((addr&0xFFFFFFFE)&(~0x1));
+  }
+}
+
+/*********************************************************************
+ * @fn       NVIC_SystemReset
+ *
+ * @brief   Initiate a system reset request
+ *
+ * @return  none
+ */
+RV_STATIC_INLINE void NVIC_SystemReset(void)
+{
+  NVIC->CFGR = NVIC_KEY3|(1<<7);
+}
+
+
+
+/* Core_Exported_Functions */  
+extern uint32_t __get_MSTATUS(void);
+extern void __set_MSTATUS(uint32_t value);
+extern uint32_t __get_MISA(void);
+extern void __set_MISA(uint32_t value);
+extern uint32_t __get_MTVEC(void);
+extern void __set_MTVEC(uint32_t value);
+extern uint32_t __get_MSCRATCH(void);
+extern void __set_MSCRATCH(uint32_t value);
+extern uint32_t __get_MEPC(void);
+extern void __set_MEPC(uint32_t value);
+extern uint32_t __get_MCAUSE(void);
+extern void __set_MCAUSE(uint32_t value);
+extern uint32_t __get_MTVAL(void);
+extern void __set_MTVAL(uint32_t value);
+extern uint32_t __get_MVENDORID(void);
+extern uint32_t __get_MARCHID(void);
+extern uint32_t __get_MIMPID(void);
+extern uint32_t __get_MHARTID(void);
+extern uint32_t __get_SP(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+
+
+
+

--- a/Sources/source/Debug/debug.c
+++ b/Sources/source/Debug/debug.c
@@ -1,0 +1,191 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : debug.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/06/06
+ * Description        : This file contains all the functions prototypes for UART
+ *                      Printf , Delay functions.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#include "debug.h"
+
+static uint8_t  p_us = 0;
+static uint16_t p_ms = 0;
+/*********************************************************************
+ * @fn      Delay_Init
+ *
+ * @brief   Initializes Delay Funcation.
+ *
+ * @return  none
+ */
+void Delay_Init(void)
+{
+    p_us = SystemCoreClock / 8000000;
+    p_ms = (uint16_t)p_us * 1000;
+}
+
+/*********************************************************************
+ * @fn      Delay_Us
+ *
+ * @brief   Microsecond Delay Time.
+ *
+ * @param   n - Microsecond number.
+ *
+ * @return  None
+ */
+void Delay_Us(uint32_t n)
+{
+    uint32_t i;
+
+    SysTick->SR &= ~(1 << 0);
+    i = (uint32_t)n * p_us;
+
+    SysTick->CMP = i;
+    SysTick->CTLR |= (1 << 4);
+    SysTick->CTLR |= (1 << 5) | (1 << 0);
+
+    while((SysTick->SR & (1 << 0)) != (1 << 0));
+    SysTick->CTLR &= ~(1 << 0);
+}
+
+/*********************************************************************
+ * @fn      Delay_Ms
+ *
+ * @brief   Millisecond Delay Time.
+ *
+ * @param   n - Millisecond number.
+ *
+ * @return  None
+ */
+void Delay_Ms(uint32_t n)
+{
+    uint32_t i;
+
+    SysTick->SR &= ~(1 << 0);
+    i = (uint32_t)n * p_ms;
+
+    SysTick->CMP = i;
+    SysTick->CTLR |= (1 << 4);
+    SysTick->CTLR |= (1 << 5) | (1 << 0);
+
+    while((SysTick->SR & (1 << 0)) != (1 << 0));
+    SysTick->CTLR &= ~(1 << 0);
+}
+
+/*********************************************************************
+ * @fn      USART_Printf_Init
+ *
+ * @brief   Initializes the USARTx peripheral.
+ *
+ * @param   baudrate - USART communication baud rate.
+ *
+ * @return  None
+ */
+void USART_Printf_Init(uint32_t baudrate)
+{
+    GPIO_InitTypeDef  GPIO_InitStructure;
+    USART_InitTypeDef USART_InitStructure;
+
+#if(DEBUG == DEBUG_UART1)
+    RCC_APB2PeriphClockCmd(RCC_APB2Periph_USART1 | RCC_APB2Periph_GPIOA, ENABLE);
+
+    GPIO_InitStructure.GPIO_Pin = GPIO_Pin_9;
+    GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
+    GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF_PP;
+    GPIO_Init(GPIOA, &GPIO_InitStructure);
+
+#elif(DEBUG == DEBUG_UART2)
+    RCC_APB1PeriphClockCmd(RCC_APB1Periph_USART2, ENABLE);
+    RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOA, ENABLE);
+
+    GPIO_InitStructure.GPIO_Pin = GPIO_Pin_2;
+    GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
+    GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF_PP;
+    GPIO_Init(GPIOA, &GPIO_InitStructure);
+
+#elif(DEBUG == DEBUG_UART3)
+    RCC_APB1PeriphClockCmd(RCC_APB1Periph_USART3, ENABLE);
+    RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOB, ENABLE);
+
+    GPIO_InitStructure.GPIO_Pin = GPIO_Pin_10;
+    GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
+    GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF_PP;
+    GPIO_Init(GPIOB, &GPIO_InitStructure);
+
+#endif
+
+    USART_InitStructure.USART_BaudRate = baudrate;
+    USART_InitStructure.USART_WordLength = USART_WordLength_8b;
+    USART_InitStructure.USART_StopBits = USART_StopBits_1;
+    USART_InitStructure.USART_Parity = USART_Parity_No;
+    USART_InitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
+    USART_InitStructure.USART_Mode = USART_Mode_Tx;
+
+#if(DEBUG == DEBUG_UART1)
+    USART_Init(USART1, &USART_InitStructure);
+    USART_Cmd(USART1, ENABLE);
+
+#elif(DEBUG == DEBUG_UART2)
+    USART_Init(USART2, &USART_InitStructure);
+    USART_Cmd(USART2, ENABLE);
+
+#elif(DEBUG == DEBUG_UART3)
+    USART_Init(USART3, &USART_InitStructure);
+    USART_Cmd(USART3, ENABLE);
+
+#endif
+}
+
+/*********************************************************************
+ * @fn      _write
+ *
+ * @brief   Support Printf Function
+ *
+ * @param   *buf - UART send Data.
+ *          size - Data length
+ *
+ * @return  size: Data length
+ */
+__attribute__((used))
+int _write(int fd, char *buf, int size)
+{
+    int i;
+
+    for(i = 0; i < size; i++){
+#if(DEBUG == DEBUG_UART1)
+        while(USART_GetFlagStatus(USART1, USART_FLAG_TC) == RESET);
+        USART_SendData(USART1, *buf++);
+#elif(DEBUG == DEBUG_UART2)
+        while(USART_GetFlagStatus(USART2, USART_FLAG_TC) == RESET);
+        USART_SendData(USART2, *buf++);
+#elif(DEBUG == DEBUG_UART3)
+        while(USART_GetFlagStatus(USART3, USART_FLAG_TC) == RESET);
+        USART_SendData(USART3, *buf++);
+#endif
+    }
+
+    return size;
+}
+
+/*********************************************************************
+ * @fn      _sbrk
+ *
+ * @brief   Change the spatial position of data segment.
+ *
+ * @return  size: Data length
+ */
+void *_sbrk(ptrdiff_t incr)
+{
+    extern char _end[];
+    extern char _heap_end[];
+    static char *curbrk = _end;
+
+    if ((curbrk + incr < _end) || (curbrk + incr > _heap_end))
+    return NULL - 1;
+
+    curbrk += incr;
+    return curbrk - incr;
+}

--- a/Sources/source/Debug/debug.h
+++ b/Sources/source/Debug/debug.h
@@ -1,0 +1,48 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : debug.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/06/06
+ * Description        : This file contains all the functions prototypes for UART
+ *                      Printf , Delay functions.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __DEBUG_H
+#define __DEBUG_H
+
+#include "stdio.h"
+#include "ch32v20x.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* UART Printf Definition */
+#define DEBUG_UART1    1
+#define DEBUG_UART2    2
+#define DEBUG_UART3    3
+
+/* DEBUG UATR Definition */
+#ifndef DEBUG
+#define DEBUG   DEBUG_UART2
+#endif
+
+void Delay_Init(void);
+void Delay_Us(uint32_t n);
+void Delay_Ms(uint32_t n);
+void USART_Printf_Init(uint32_t baudrate);
+
+#if(DEBUG)
+  #define PRINT(format, ...)    printf(format, ##__VA_ARGS__)
+#else
+  #define PRINT(X...)
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Sources/source/LanaKBD/User/Main.c
+++ b/Sources/source/LanaKBD/User/Main.c
@@ -1,0 +1,75 @@
+/********************************** (C) COPYRIGHT *******************************
+* File Name          : main.c
+* Author             : Bert Outtier
+* Version            : V1.0.0
+* Date               : 2024/06/17
+* Description        : Main program body.
+*********************************************************************************
+* Copyright (c) 2024 Fri3D Camp
+*******************************************************************************/
+
+/*
+ * @Note
+ * Lana Keyboard:
+ * This codes runs on the Lana board mounted on the Fri3D Badge 2024 keyboard expansion.
+ * It presents as a USB HID device over USB and it also uses USART2 (TX only)
+ * to send the HID reports to the badge.
+ *
+ */
+
+#include "debug.h"
+#include "usb_lib.h"
+#include "usb_desc.h"
+#include "usb_pwr.h"
+#include "usb_prop.h"
+#include "usbd_composite_km.h"
+
+#define I2C_ADDRESS   0x38
+#define I2C_SPEED     400000
+
+/*********************************************************************
+ * @fn      main
+ *
+ * @brief   Main program.
+ *
+ * @return  none
+ */
+int main(void)
+{
+    NVIC_PriorityGroupConfig(NVIC_PriorityGroup_2);
+    Delay_Init();
+    USART_Badge_Init(115200);
+
+    /* initialize i2c */
+    IIC_Init(I2C_SPEED, I2C_ADDRESS);
+
+    /* makes sure that we can still flash using SWD */
+    Delay_Ms(500);
+
+    LED_Init_Neopixel();
+
+    /* Initialize GPIO for keyboard scan */
+    KB_Scan_Init();
+    KB_Sleep_Wakeup_Cfg();
+
+    /* Initialize timer for Keyboard and mouse scan timing */
+    TIM3_Init(1, SystemCoreClock / 10000 - 1);
+
+    /* initialize the USB HID endpoints */
+    Set_USBConfig();
+    USB_Init();
+    USB_Interrupts_Config();
+
+    while(1)
+    {
+        /* Handle keyboard scan data */
+        KB_Scan_Handle();
+    }
+}
+
+
+
+
+
+
+

--- a/Sources/source/LanaKBD/User/USBLIB/CONFIG/hw_config.c
+++ b/Sources/source/LanaKBD/User/USBLIB/CONFIG/hw_config.c
@@ -1,0 +1,174 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : hw_config.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/08/08
+ * Description        : USB configuration file.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/ 
+#include "usb_lib.h"
+#include "usb_prop.h"
+#include "usb_desc.h"
+#include "usb_istr.h"
+#include "hw_config.h"
+#include "usb_pwr.h"  
+#include "string.h"	
+#include "stdarg.h"		 
+#include "stdio.h"	
+#include "usbd_composite_km.h"
+
+void USBWakeUp_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+void USB_LP_CAN1_RX0_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+
+/*******************************************************************************
+ * @fn        USBWakeUp_IRQHandler
+ *
+ * @brief     This function handles USB wake up exception.
+ *
+ * @return    None
+ */
+void USBWakeUp_IRQHandler(void) 
+{
+	EXTI_ClearITPendingBit(EXTI_Line18);
+} 
+
+/*******************************************************************************
+ * @fn           USB_LP_CAN1_RX0_IRQHandler
+ *
+ * @brief        This function handles USB exception.
+ *
+ * @return None
+ */
+void USB_LP_CAN1_RX0_IRQHandler(void) 
+{
+	USB_Istr();
+} 
+
+/*******************************************************************************
+ * @fn        Set_USBConfig
+ *
+ * @brief     Set_USBConfig .
+ *
+ * @return    None
+ */
+void Set_USBConfig( )
+{
+	if( SystemCoreClock == 144000000 )
+    {
+        RCC_USBCLKConfig( RCC_USBCLKSource_PLLCLK_Div3 );
+    }
+    else if( SystemCoreClock == 96000000 ) 
+    {
+        RCC_USBCLKConfig( RCC_USBCLKSource_PLLCLK_Div2 );
+    }
+    else if( SystemCoreClock == 48000000 ) 
+    {
+        RCC_USBCLKConfig( RCC_USBCLKSource_PLLCLK_Div1 );
+    }
+	RCC_APB1PeriphClockCmd(RCC_APB1Periph_USB, ENABLE);	 		 
+}
+
+/*******************************************************************************
+ * @fn        Enter_LowPowerMode
+ *
+ * @brief     Enter low power mode.
+ *
+ * @return    None
+ */
+void Enter_LowPowerMode(void)
+{  
+	USBD_Sleep_Status |= 0x02;
+	if (USBD_Sleep_Status == 0x03)
+	{
+		MCU_Sleep_Wakeup_Operate();
+	}
+	bDeviceState = SUSPENDED;
+} 
+
+/*******************************************************************************
+ * @fn         Leave_LowPowerMode
+ *
+ * @brief      Leave low power mode.
+ *
+ * @return     None
+ */
+void Leave_LowPowerMode(void)
+{
+	DEVICE_INFO *pInfo=&Device_Info;
+	USBD_Sleep_Status &= ~0x02;
+	if (pInfo->Current_Configuration!=0)bDeviceState=CONFIGURED; 
+	else bDeviceState = ATTACHED; 
+} 
+
+/*******************************************************************************
+ * @fn         USB_Interrupts_Config
+ *
+ * @brief      Configrate USB interrupt.
+ *
+ * @return     None
+ */
+void USB_Interrupts_Config(void)
+{ 
+	NVIC_InitTypeDef NVIC_InitStructure;
+	EXTI_InitTypeDef EXTI_InitStructure;
+
+	EXTI_ClearITPendingBit(EXTI_Line18);
+	EXTI_InitStructure.EXTI_Line = EXTI_Line18; 
+	EXTI_InitStructure.EXTI_Mode = EXTI_Mode_Interrupt;
+	EXTI_InitStructure.EXTI_Trigger = EXTI_Trigger_Rising_Falling;	
+	EXTI_InitStructure.EXTI_LineCmd = ENABLE;
+	EXTI_Init(&EXTI_InitStructure); 	 
+
+	NVIC_InitStructure.NVIC_IRQChannel = USB_LP_CAN1_RX0_IRQn;	
+	NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 1;
+	NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
+	NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
+	NVIC_Init(&NVIC_InitStructure);
+	
+	NVIC_InitStructure.NVIC_IRQChannel = USBWakeUp_IRQn;  
+	NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 0;
+	NVIC_Init(&NVIC_InitStructure);   
+}	
+
+/*******************************************************************************
+ * @fn         USB_Port_Set
+ *
+ * @brief      Set USB IO port.
+ *
+ * @param      NewState: DISABLE or ENABLE.
+ *             Pin_In_IPU: Enables or Disables intenal pull-up resistance.
+ *
+ * @return     None
+ */
+void USB_Port_Set(FunctionalState NewState, FunctionalState Pin_In_IPU)
+{
+	RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOA, ENABLE);
+
+	if(NewState) {
+		_SetCNTR(_GetCNTR()&(~(1<<1)));
+		GPIOA->CFGHR&=0XFFF00FFF;
+		GPIOA->OUTDR&=~(3<<11);	//PA11/12=0
+		GPIOA->CFGHR|=0X00044000; //float
+	}
+	else
+	{	  
+		_SetCNTR(_GetCNTR()|(1<<1));  
+		GPIOA->CFGHR&=0XFFF00FFF;
+		GPIOA->OUTDR&=~(3<<11);	//PA11/12=0
+		GPIOA->CFGHR|=0X00033000;	// LOW
+	}
+	
+	if(Pin_In_IPU) (EXTEN->EXTEN_CTR) |= EXTEN_USBD_PU_EN; 
+	else (EXTEN->EXTEN_CTR) &= ~EXTEN_USBD_PU_EN;
+}  
+
+
+
+
+
+
+
+

--- a/Sources/source/LanaKBD/User/USBLIB/CONFIG/hw_config.h
+++ b/Sources/source/LanaKBD/User/USBLIB/CONFIG/hw_config.h
@@ -1,0 +1,38 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : hw_config.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/08/08
+ * Description        : Configuration file for USB.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/ 
+#ifndef __HW_CONFIG_H
+#define __HW_CONFIG_H
+
+#include "usb_type.h" 
+ 
+#ifdef	DEBUG
+#define printf_usb(X...) printf(X)
+#else
+#define printf_usb(X...)
+#endif 
+
+
+void Set_USBConfig(void);
+void Enter_LowPowerMode(void);
+void Leave_LowPowerMode(void);
+void USB_Interrupts_Config(void);
+void USB_Port_Set(FunctionalState NewState, FunctionalState Pin_In_IPU);
+
+#endif /* __HW_CONFIG_H */ 
+
+
+
+
+
+
+
+

--- a/Sources/source/LanaKBD/User/USBLIB/CONFIG/usb_conf.h
+++ b/Sources/source/LanaKBD/User/USBLIB/CONFIG/usb_conf.h
@@ -1,0 +1,75 @@
+/********************************** (C) COPYRIGHT *******************************
+* File Name          : usb_conf.h
+* Author             : WCH
+* Version            : V1.0.0
+* Date               : 2022/08/20
+* Description        : This file contains all the functions prototypes for the  
+*                      USB configration firmware library.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/ 
+#ifndef __USB_CONF_H
+#define __USB_CONF_H
+
+
+#define EP_NUM                          (3)
+
+/* Buffer Description Table */
+/* buffer table base address */
+/* buffer table base address */
+#define BTABLE_ADDRESS      (0x00)
+
+/* EP0  */
+/* rx/tx buffer base address */
+#define ENDP0_RXADDR        (0x40)
+#define ENDP0_TXADDR        (0x80)
+
+/* EP1  */
+/* tx buffer base address */
+#define ENDP1_TXADDR        (0xC0)
+#define ENDP2_TXADDR        (ENDP1_TXADDR + 0x10)
+
+/* ISTR events */
+/* IMR_MSK */
+/* mask defining which events has to be handled */
+/* by the device application software */
+#define IMR_MSK (CNTR_CTRM  | CNTR_WKUPM | CNTR_SUSPM | CNTR_ERRM  | CNTR_SOFM \
+                 | CNTR_ESOFM | CNTR_RESETM )
+
+/* #define CTR_CALLBACK */
+/* #define DOVR_CALLBACK */
+/* #define ERR_CALLBACK */
+/* #define WKUP_CALLBACK */
+/* #define SUSP_CALLBACK */
+/* #define RESET_CALLBAC K*/
+/* #define SOF_CALLBACK */
+/* #define ESOF_CALLBACK */
+
+
+/* CTR service routines */
+/* associated to defined endpoints */
+// #define  EP1_IN_Callback   NOP_Process
+// #define  EP2_IN_Callback   NOP_Process
+#define  EP3_IN_Callback   NOP_Process
+#define  EP4_IN_Callback   NOP_Process
+#define  EP5_IN_Callback   NOP_Process
+#define  EP6_IN_Callback   NOP_Process
+#define  EP7_IN_Callback   NOP_Process
+
+#define  EP1_OUT_Callback   NOP_Process
+#define  EP2_OUT_Callback   NOP_Process
+#define  EP3_OUT_Callback   NOP_Process
+#define  EP4_OUT_Callback   NOP_Process
+#define  EP5_OUT_Callback   NOP_Process
+#define  EP6_OUT_Callback   NOP_Process
+#define  EP7_OUT_Callback   NOP_Process
+
+#endif /* __USB_CONF_H */
+
+
+
+
+
+

--- a/Sources/source/LanaKBD/User/USBLIB/CONFIG/usb_desc.c
+++ b/Sources/source/LanaKBD/User/USBLIB/CONFIG/usb_desc.c
@@ -1,0 +1,137 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : usb_desc.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2019/10/15
+ * Description        : USB Descriptors.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/ 
+#include "usb_lib.h"
+#include "usb_desc.h"
+
+/* USB Device Descriptors */
+const uint8_t  USBD_DeviceDescriptor[] = { 
+    USBD_SIZE_DEVICE_DESC,           // bLength
+    0x01,                           // bDescriptorType
+    0x10, 0x01,                     // bcdUSB
+    0x00,                           // bDeviceClass
+    0x00,                           // bDeviceSubClass
+    0x00,                           // bDeviceProtocol
+    DEF_USBD_UEP0_SIZE,             // bMaxPacketSize0
+    0x86, 0x1A,                     // idVendor
+    0x00, 0xFE,                     // idProduct
+    0x00, 0x01,                     // bcdDevice
+    0x01,                           // iManufacturer
+    0x02,                           // iProduct
+    0x00,                           // iSerialNumber
+    0x01,                           // bNumConfigurations
+};
+
+/* USB Configration Descriptors */
+const uint8_t  USBD_ConfigDescriptor[] = { 
+    /* Configuration Descriptor */
+    0x09,                           // bLength
+    0x02,                           // bDescriptorType
+    USBD_SIZE_CONFIG_DESC & 0xFF, USBD_SIZE_CONFIG_DESC >> 8, // wTotalLength
+    0x01,                           // bNumInterfaces
+    0x01,                           // bConfigurationValue
+    0x00,                           // iConfiguration
+    0xA0,                           // bmAttributes: Bus Powered; Remote Wakeup
+    0x32,                           // MaxPower: 100mA
+
+    /* Interface Descriptor (Keyboard) */
+    0x09,                           // bLength
+    0x04,                           // bDescriptorType
+    0x00,                           // bInterfaceNumber
+    0x00,                           // bAlternateSetting
+    0x01,                           // bNumEndpoints
+    0x03,                           // bInterfaceClass
+    0x01,                           // bInterfaceSubClass
+    0x01,                           // bInterfaceProtocol: Keyboard
+    0x00,                           // iInterface
+
+    /* HID Descriptor (Keyboard) */
+    0x09,                           // bLength
+    0x21,                           // bDescriptorType
+    0x11, 0x01,                     // bcdHID
+    0x00,                           // bCountryCode
+    0x01,                           // bNumDescriptors
+    0x22,                           // bDescriptorType
+    USBD_SIZE_REPORT_DESC_KB & 0xFF, USBD_SIZE_REPORT_DESC_KB >> 8, // wDescriptorLength
+
+    /* Endpoint Descriptor (Keyboard) */
+    0x07,                           // bLength
+    0x05,                           // bDescriptorType
+    0x81,                           // bEndpointAddress: IN Endpoint 1
+    0x03,                           // bmAttributes
+    DEF_ENDP_SIZE_KB & 0xFF, DEF_ENDP_SIZE_KB >> 8, // wMaxPacketSize
+    0x0A,                           // bInterval: 10mS
+};
+
+/* USB String Descriptors */
+const uint8_t USBD_StringLangID[USBD_SIZE_STRING_LANGID] = {
+	USBD_SIZE_STRING_LANGID,
+	USB_STRING_DESCRIPTOR_TYPE,
+	0x09,
+	0x04 
+};
+
+/* USB Device String Vendor */
+const uint8_t USBD_StringVendor[USBD_SIZE_STRING_VENDOR] = {
+	USBD_SIZE_STRING_VENDOR,    
+	USB_STRING_DESCRIPTOR_TYPE,           
+	'F',0,'r',0,'i',0,'3',0,'D',0
+};
+
+/* USB Device String Product */
+const uint8_t USBD_StringProduct[USBD_SIZE_STRING_PRODUCT] = {
+	USBD_SIZE_STRING_PRODUCT,         
+	USB_STRING_DESCRIPTOR_TYPE,        
+    'L', 0, 'a', 0, 'n', 0, 'a', 0
+};
+
+/* USB Device String Serial */
+uint8_t USBD_StringSerial[USBD_SIZE_STRING_SERIAL] = {
+	USBD_SIZE_STRING_SERIAL,          
+	USB_STRING_DESCRIPTOR_TYPE,                   
+	'0', 0, '1', 0, '2', 0, '3', 0, '4', 0, '5', 0 , '6', 0, '7', 0, '8', 0, '9', 0
+};
+
+/* HID Report Descriptor */
+const uint8_t USBD_KeyRepDesc[USBD_SIZE_REPORT_DESC_KB] =
+{
+    0x05, 0x01,                     // Usage Page (Generic Desktop)
+    0x09, 0x06,                     // Usage (Keyboard)
+    0xA1, 0x01,                     // Collection (Application)
+    0x05, 0x07,                     // Usage Page (Key Codes)
+    0x19, 0xE0,                     // Usage Minimum (224)
+    0x29, 0xE7,                     // Usage Maximum (231)
+    0x15, 0x00,                     // Logical Minimum (0)
+    0x25, 0x01,                     // Logical Maximum (1)
+    0x75, 0x01,                     // Report Size (1)
+    0x95, 0x08,                     // Report Count (8)
+    0x81, 0x02,                     // Input (Data,Variable,Absolute)
+    0x95, 0x01,                     // Report Count (1)
+    0x75, 0x08,                     // Report Size (8)
+    0x81, 0x01,                     // Input (Constant)
+    0x95, 0x03,                     // Report Count (3)
+    0x75, 0x01,                     // Report Size (1)
+    0x05, 0x08,                     // Usage Page (LEDs)
+    0x19, 0x01,                     // Usage Minimum (1)
+    0x29, 0x03,                     // Usage Maximum (3)
+    0x91, 0x02,                     // Output (Data,Variable,Absolute)
+    0x95, 0x05,                     // Report Count (5)
+    0x75, 0x01,                     // Report Size (1)
+    0x91, 0x01,                     // Output (Constant,Array,Absolute)
+    0x95, 0x06,                     // Report Count (6)
+    0x75, 0x08,                     // Report Size (8)
+    0x26, 0xFF, 0x00,               // Logical Maximum (255)
+    0x05, 0x07,                     // Usage Page (Key Codes)
+    0x19, 0x00,                     // Usage Minimum (0)
+    0x29, 0x91,                     // Usage Maximum (145)
+    0x81, 0x00,                     // Input(Data,Array,Absolute)
+    0xC0                            // End Collection
+};

--- a/Sources/source/LanaKBD/User/USBLIB/CONFIG/usb_desc.h
+++ b/Sources/source/LanaKBD/User/USBLIB/CONFIG/usb_desc.h
@@ -1,0 +1,58 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : usb_desc.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/08/08
+ * Description        : This file contains all the functions prototypes for the  
+ *                      USB description firmware library.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/ 
+#ifndef __USB_DESC_H
+#define __USB_DESC_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+	 
+#include "ch32v20x.h"
+	 
+	 
+#define USB_DEVICE_DESCRIPTOR_TYPE              0x01
+#define USB_CONFIGURATION_DESCRIPTOR_TYPE       0x02
+#define USB_STRING_DESCRIPTOR_TYPE              0x03
+#define USB_INTERFACE_DESCRIPTOR_TYPE           0x04
+#define USB_ENDPOINT_DESCRIPTOR_TYPE            0x05
+
+#define DEF_USBD_UEP0_SIZE        64                                         
+#define DEF_ENDP_SIZE_KB            8
+
+       
+#define USBD_SIZE_DEVICE_DESC        18
+#define USBD_SIZE_CONFIG_DESC        34
+#define USBD_SIZE_REPORT_DESC_KB     62
+#define USBD_SIZE_STRING_LANGID      4
+#define USBD_SIZE_STRING_VENDOR      14
+#define USBD_SIZE_STRING_PRODUCT     18
+#define USBD_SIZE_STRING_SERIAL      22
+
+
+#define STANDARD_ENDPOINT_DESC_SIZE             0x09
+
+
+extern const uint8_t USBD_DeviceDescriptor[USBD_SIZE_DEVICE_DESC];
+extern const uint8_t USBD_ConfigDescriptor[USBD_SIZE_CONFIG_DESC];
+                    
+extern const uint8_t USBD_StringLangID [USBD_SIZE_STRING_LANGID];
+extern const uint8_t USBD_StringVendor [USBD_SIZE_STRING_VENDOR];
+extern const uint8_t USBD_StringProduct[USBD_SIZE_STRING_PRODUCT];
+extern uint8_t USBD_StringSerial [USBD_SIZE_STRING_SERIAL];
+extern const uint8_t USBD_KeyRepDesc[USBD_SIZE_REPORT_DESC_KB];
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __USB_DESC_H */

--- a/Sources/source/LanaKBD/User/USBLIB/CONFIG/usb_endp.c
+++ b/Sources/source/LanaKBD/User/USBLIB/CONFIG/usb_endp.c
@@ -1,0 +1,85 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : usb_endp.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/08/08
+ * Description        : Endpoint routines
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/ 
+#include "usb_lib.h"
+#include "usb_desc.h"
+#include "usb_mem.h"
+#include "hw_config.h"
+#include "usb_istr.h"
+#include "usb_pwr.h"
+
+uint8_t USBD_Endp1_Busy,USBD_Endp2_Busy;
+u16 USB_Rx_Cnt=0; 
+
+/*********************************************************************
+ * @fn      EP1_IN_Callback
+ *
+ * @brief  Endpoint 1 IN.
+ *
+ * @return  none
+ */
+void EP1_IN_Callback (void)
+{ 
+	USBD_Endp1_Busy = 0;
+}
+
+/*********************************************************************
+ * @fn      EP2_IN_Callback
+ *
+ * @brief  Endpoint 2 IN.
+ *
+ * @return  none
+ */
+void EP2_IN_Callback (void)
+{ 
+	USBD_Endp2_Busy = 0;
+}
+
+/*********************************************************************
+ * @fn      USBD_ENDPx_DataUp
+ *
+ * @brief  USBD ENDPx DataUp Function
+ * 
+ * @param   endp - endpoint num.
+ *          *pbuf - A pointer points to data.
+ *          len - data length to transmit.
+ * 
+ * @return  data up status.
+ */
+uint8_t USBD_ENDPx_DataUp( uint8_t endp, uint8_t *pbuf, uint16_t len )
+{
+	if( endp == ENDP1 )
+	{
+		if (USBD_Endp1_Busy)
+		{
+			return USB_ERROR;
+		}
+		USB_SIL_Write( EP1_IN, pbuf, len );
+		USBD_Endp1_Busy = 1;
+		SetEPTxStatus( ENDP1, EP_TX_VALID );
+		
+	}
+    else if( endp == ENDP2 )
+	{
+		if (USBD_Endp2_Busy)
+		{
+			return USB_ERROR;
+		}
+		USB_SIL_Write( EP2_IN, pbuf, len );
+		USBD_Endp2_Busy = 1;
+		SetEPTxStatus( ENDP2, EP_TX_VALID );
+	}
+	else
+	{
+		return USB_ERROR;
+	}
+	return USB_SUCCESS;
+}

--- a/Sources/source/LanaKBD/User/USBLIB/CONFIG/usb_istr.c
+++ b/Sources/source/LanaKBD/User/USBLIB/CONFIG/usb_istr.c
@@ -1,0 +1,196 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : usb_istr.c
+ * Author             : WCH
+ * Version            : V1.0.1
+ * Date               : 2022/12/28
+ * Description        : ISTR events interrupt service routines
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/ 
+#include "usb_lib.h"
+#include "usb_prop.h"
+#include "usb_pwr.h"
+#include "usb_istr.h"
+
+uint16_t Ep0RxBlks;
+
+/* Private variables */
+__IO uint16_t wIstr;  
+__IO uint8_t bIntPackSOF = 0;  
+__IO uint32_t esof_counter =0;
+__IO uint32_t wCNTR=0;
+
+/* function pointers to non-control endpoints service routines */
+void (*pEpInt_IN[7])(void) ={
+	EP1_IN_Callback,
+	EP2_IN_Callback,
+	EP3_IN_Callback,
+	EP4_IN_Callback,
+	EP5_IN_Callback,
+	EP6_IN_Callback,
+	EP7_IN_Callback,
+};
+
+void (*pEpInt_OUT[7])(void) ={
+	EP1_OUT_Callback,
+	EP2_OUT_Callback,
+	EP3_OUT_Callback,
+	EP4_OUT_Callback,
+	EP5_OUT_Callback,
+	EP6_OUT_Callback,
+	EP7_OUT_Callback,
+};
+
+/*******************************************************************************
+ * @fn        USB_Istr
+ *
+ * @brief     ISTR events interrupt service routine
+ *
+ * @return    None.
+ */
+void USB_Istr(void)
+{
+  uint32_t i=0;
+  __IO uint32_t EP[8];
+  if ((*_pEPRxCount(0) & 0xFC00 )!= Ep0RxBlks)
+  {
+    *_pEPRxCount(0) |= (Ep0RxBlks & 0xFC00);
+  }
+  wIstr = _GetISTR();
+#if (IMR_MSK & ISTR_SOF)
+  if (wIstr & ISTR_SOF & wInterrupt_Mask)
+  {
+    _SetISTR((uint16_t)CLR_SOF);
+    bIntPackSOF++;
+
+#ifdef SOF_CALLBACK
+    SOF_Callback();
+		
+#endif
+  }
+#endif
+ 
+  
+#if (IMR_MSK & ISTR_CTR)
+  if (wIstr & ISTR_CTR & wInterrupt_Mask)
+  {
+    CTR_LP();
+#ifdef CTR_CALLBACK
+    CTR_Callback();
+#endif
+  }
+#endif
+ 
+#if (IMR_MSK & ISTR_RESET)
+  if (wIstr & ISTR_RESET & wInterrupt_Mask)
+  {
+    _SetISTR((uint16_t)CLR_RESET);
+    Device_Property.Reset();
+    
+#ifdef RESET_CALLBACK
+    RESET_Callback();
+#endif
+  }
+#endif
+
+#if (IMR_MSK & ISTR_DOVR)
+  if (wIstr & ISTR_DOVR & wInterrupt_Mask)
+  {
+    _SetISTR((uint16_t)CLR_DOVR);
+#ifdef DOVR_CALLBACK
+    DOVR_Callback();
+#endif
+  }
+#endif
+
+#if (IMR_MSK & ISTR_ERR)
+  if (wIstr & ISTR_ERR & wInterrupt_Mask)
+  {
+    _SetISTR((uint16_t)CLR_ERR);
+#ifdef ERR_CALLBACK
+    ERR_Callback();
+#endif
+  }
+#endif
+
+#if (IMR_MSK & ISTR_WKUP)
+  if (wIstr & ISTR_WKUP & wInterrupt_Mask)
+  {
+    _SetISTR((uint16_t)CLR_WKUP);
+    Resume(RESUME_EXTERNAL);
+#ifdef WKUP_CALLBACK
+    WKUP_Callback();
+#endif
+  }
+#endif
+#if (IMR_MSK & ISTR_SUSP)
+  if (wIstr & ISTR_SUSP & wInterrupt_Mask)
+  {
+    if (fSuspendEnabled)
+    {
+      Suspend();
+    }
+    else
+    {
+      Resume(RESUME_LATER);
+    }
+    _SetISTR((uint16_t)CLR_SUSP);
+#ifdef SUSP_CALLBACK
+    SUSP_Callback();
+#endif
+  }
+#endif
+
+#if (IMR_MSK & ISTR_ESOF)
+  if (wIstr & ISTR_ESOF & wInterrupt_Mask)
+  {
+    _SetISTR((uint16_t)CLR_ESOF);
+    
+    if ((_GetFNR()&FNR_RXDP)!=0)
+    {
+      esof_counter ++;
+      
+      if ((esof_counter >3)&&((_GetCNTR()&CNTR_FSUSP)==0))
+      {           
+
+        wCNTR = _GetCNTR(); 
+      
+        for (i=0;i<8;i++) EP[i] = _GetENDPOINT(i);
+      
+        wCNTR|=CNTR_FRES;
+        _SetCNTR(wCNTR);
+ 
+        wCNTR&=~CNTR_FRES;
+        _SetCNTR(wCNTR);
+      
+        while((_GetISTR()&ISTR_RESET) == 0);
+  
+        _SetISTR((uint16_t)CLR_RESET);
+   
+        for (i=0;i<8;i++)
+        _SetENDPOINT(i, EP[i]);
+      
+        esof_counter = 0;
+      }
+    }
+    else
+    {
+        esof_counter = 0;
+    }
+    
+    Resume(RESUME_ESOF); 
+
+#ifdef ESOF_CALLBACK
+    ESOF_Callback();
+#endif
+  }
+#endif
+} /* USB_Istr */
+
+
+
+
+
+

--- a/Sources/source/LanaKBD/User/USBLIB/CONFIG/usb_istr.h
+++ b/Sources/source/LanaKBD/User/USBLIB/CONFIG/usb_istr.h
@@ -1,0 +1,77 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : usb_istr.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/08/08
+ * Description        : This file includes the peripherals header files in the 
+ *                      user application.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/ 
+#ifndef __USB_ISTR_H
+#define __USB_ISTR_H
+
+#include "usb_conf.h"
+
+
+void USB_Istr(void);
+void EP1_IN_Callback(void);
+void EP2_IN_Callback(void);
+void EP3_IN_Callback(void);
+void EP4_IN_Callback(void);
+void EP5_IN_Callback(void);
+void EP6_IN_Callback(void);
+void EP7_IN_Callback(void);
+
+void EP1_OUT_Callback(void);
+void EP2_OUT_Callback(void);
+void EP3_OUT_Callback(void);
+void EP4_OUT_Callback(void);
+void EP5_OUT_Callback(void);
+void EP6_OUT_Callback(void);
+void EP7_OUT_Callback(void);
+
+#ifdef CTR_CALLBACK
+void CTR_Callback(void);
+#endif
+
+#ifdef DOVR_CALLBACK
+void DOVR_Callback(void);
+#endif
+
+#ifdef ERR_CALLBACK
+void ERR_Callback(void);
+#endif
+
+#ifdef WKUP_CALLBACK
+void WKUP_Callback(void);
+#endif
+
+#ifdef SUSP_CALLBACK
+void SUSP_Callback(void);
+#endif
+
+#ifdef RESET_CALLBACK
+void RESET_Callback(void);
+#endif
+
+#ifdef SOF_CALLBACK
+void SOF_Callback(void);
+#endif
+
+#ifdef ESOF_CALLBACK
+void ESOF_Callback(void);
+#endif
+
+
+#endif /*__USB_ISTR_H*/
+
+
+
+
+
+
+
+

--- a/Sources/source/LanaKBD/User/USBLIB/CONFIG/usb_prop.c
+++ b/Sources/source/LanaKBD/User/USBLIB/CONFIG/usb_prop.c
@@ -1,0 +1,554 @@
+/********************************** (C) COPYRIGHT *******************************
+* File Name          : usb_prop.c
+* Author             : WCH
+* Version            : V1.0.0
+* Date               : 2022/08/20
+* Description        : USB Processing
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/ 
+#include "usb_lib.h"
+#include "usb_conf.h"
+#include "usb_prop.h"
+#include "usb_desc.h"
+#include "usb_pwr.h"
+#include "hw_config.h"
+#include "usbd_composite_km.h"
+
+
+uint8_t Request = 0;
+
+extern uint8_t USBD_Endp1_Busy,USBD_Endp2_Busy;
+volatile uint8_t HIDReportOut[8] = {0};
+volatile uint8_t USBD_Sleep_Status = 0x00;
+volatile uint8_t HID_Idle_Value[2] = {0};
+volatile uint8_t HID_Protocol_Value[2] = {0};
+
+DEVICE Device_Table =
+{
+	EP_NUM,
+	1
+};
+
+DEVICE_PROP Device_Property =
+{
+	USBD_init,
+	USBD_Reset,
+	USBD_Status_In,
+	USBD_Status_Out,
+	USBD_Data_Setup,
+	USBD_NoData_Setup,
+	USBD_Get_Interface_Setting,
+	USBD_GetDeviceDescriptor,
+	USBD_GetConfigDescriptor,
+	USBD_GetStringDescriptor,
+	0,
+	DEF_USBD_UEP0_SIZE                                 
+};
+
+USER_STANDARD_REQUESTS User_Standard_Requests =
+{
+	USBD_GetConfiguration,
+	USBD_SetConfiguration,
+	USBD_GetInterface,
+	USBD_SetInterface,
+	USBD_GetStatus, 
+	USBD_ClearFeature,
+	USBD_SetEndPointFeature,
+	USBD_SetDeviceFeature,
+	USBD_SetDeviceAddress
+};
+
+ONE_DESCRIPTOR Device_Descriptor =
+{
+	(uint8_t*)USBD_DeviceDescriptor,
+	USBD_SIZE_DEVICE_DESC
+};
+
+ONE_DESCRIPTOR Config_Descriptor =
+{
+	(uint8_t*)USBD_ConfigDescriptor,
+	USBD_SIZE_CONFIG_DESC
+};
+
+ONE_DESCRIPTOR String_Descriptor[4] =
+{
+	{(uint8_t*)USBD_StringLangID, USBD_SIZE_STRING_LANGID},
+	{(uint8_t*)USBD_StringVendor, USBD_SIZE_STRING_VENDOR},
+	{(uint8_t*)USBD_StringProduct,USBD_SIZE_STRING_PRODUCT},
+	{(uint8_t*)USBD_StringSerial, USBD_SIZE_STRING_SERIAL}
+};
+
+ONE_DESCRIPTOR Report_Descriptor[2] =
+{
+	{(uint8_t*)USBD_KeyRepDesc, USBD_SIZE_REPORT_DESC_KB},
+};
+
+ONE_DESCRIPTOR Hid_Descriptor[2] =
+{
+	{(uint8_t*)&USBD_ConfigDescriptor[18], 0x09},
+	{(uint8_t*)&USBD_ConfigDescriptor[43], 0x09},
+};
+
+
+/*********************************************************************
+ * @fn      USBD_SetConfiguration.
+ *
+ * @brief     Update the device state to configured.
+ *
+ * @return    None.
+ */
+void USBD_SetConfiguration(void)
+{
+  DEVICE_INFO *pInfo = &Device_Info;
+
+  if (pInfo->Current_Configuration != 0)
+  {
+    bDeviceState = CONFIGURED;
+  }
+}
+
+/*******************************************************************************
+ * @fn         USBD_SetDeviceAddress.
+ *
+ * @brief      Update the device state to addressed.
+ *
+ * @return     None.
+ */
+void USBD_SetDeviceAddress (void)
+{
+  bDeviceState = ADDRESSED;
+}
+
+
+/*********************************************************************
+ * @fn      USBD_SetDeviceFeature.
+ *
+ * @brief   SetDeviceFeature Routine.
+ *
+ * @return  none
+ */
+void USBD_SetDeviceFeature (void)
+{
+  USBD_Sleep_Status |= 0x01;
+}
+
+
+
+/*********************************************************************
+ * @fn      USBD_ClearFeature.
+ *
+ * @brief   ClearFeature Routine.
+ *
+ * @return  none
+ */
+void USBD_ClearFeature(void)
+{
+  USBD_Sleep_Status &= ~0x01;
+}
+
+
+
+
+
+/*********************************************************************
+ * @fn      USBD_Status_In.
+ *
+ * @brief    USBD Status In Routine.
+ *
+ * @return   None.
+ */
+void USBD_Status_In(void)
+{
+
+}
+
+/*******************************************************************************
+ * @fn       USBD_Status_Out
+ *
+ * @brief    USBD Status OUT Routine.
+ *
+ * @return   None.
+ */
+void USBD_Status_Out(void)
+{
+    
+}
+
+/*******************************************************************************
+ * @fn       USB_init.
+ *
+ * @brief    init routine.
+ * 
+ * @return   None.
+ */
+void USBD_init(void)
+{
+  uint8_t	i;
+    
+  pInformation->Current_Configuration = 0;
+  PowerOn();
+  for (i=0;i<8;i++) _SetENDPOINT(i,_GetENDPOINT(i) & 0x7F7F & EPREG_MASK);//all clear
+  _SetISTR((uint16_t)0x00FF);//all clear
+  USB_SIL_Init();
+  bDeviceState = UNCONNECTED;
+  
+  USB_Port_Set(DISABLE, DISABLE);	
+  Delay_Ms(20);
+  USB_Port_Set(ENABLE, ENABLE);    
+}
+
+/*******************************************************************************
+ * @fn      USBD_Reset
+ *
+ * @brief   Virtual_Com_Port Mouse reset routine
+ *
+ * @return  None.
+ */
+void USBD_Reset(void)
+{
+  pInformation->Current_Configuration = 0;
+  pInformation->Current_Feature = USBD_ConfigDescriptor[7];
+  pInformation->Current_Interface = 0;
+
+  SetBTABLE(BTABLE_ADDRESS);
+
+  SetEPType(ENDP0, EP_CONTROL);
+  SetEPTxStatus(ENDP0, EP_TX_STALL);
+  SetEPRxAddr(ENDP0, ENDP0_RXADDR);
+  SetEPTxAddr(ENDP0, ENDP0_TXADDR);
+  Clear_Status_Out(ENDP0);
+  SetEPRxCount(ENDP0, Device_Property.MaxPacketSize);
+  SetEPRxValid(ENDP0);
+  _ClearDTOG_RX(ENDP0);
+  _ClearDTOG_TX(ENDP0);
+
+    SetEPType(ENDP1, EP_INTERRUPT);
+    SetEPTxAddr(ENDP1, ENDP1_TXADDR);
+    SetEPTxStatus(ENDP1, EP_TX_NAK);
+    _ClearDTOG_TX(ENDP1);
+    _ClearDTOG_RX(ENDP1);
+
+    SetEPType(ENDP2, EP_INTERRUPT);
+    SetEPTxAddr(ENDP2, ENDP2_TXADDR);
+    SetEPTxStatus(ENDP2, EP_TX_NAK);
+    _ClearDTOG_TX(ENDP2);
+    _ClearDTOG_RX(ENDP2);
+    
+    SetDeviceAddress(0);
+
+    bDeviceState = ATTACHED;
+}
+
+/*******************************************************************************
+ * @fn      USBD_GetDeviceDescriptor.
+ *
+ * @brief   Gets the device descriptor.
+ *
+ * @param   Length.
+ *
+ * @return  The address of the device descriptor.
+ */
+uint8_t *USBD_GetDeviceDescriptor(uint16_t Length)
+{
+  return Standard_GetDescriptorData(Length, &Device_Descriptor);
+}
+
+/*******************************************************************************
+ * @fn       USBD_GetConfigDescriptor.
+ *
+ * @brief    get the configuration descriptor.
+ *
+ * @param    Length.
+ *
+ * @return   The address of the configuration descriptor.
+ */
+uint8_t *USBD_GetConfigDescriptor(uint16_t Length)
+{
+  return Standard_GetDescriptorData(Length, &Config_Descriptor);
+}
+
+/*******************************************************************************
+ * @fn        USBD_GetStringDescriptor
+ *
+ * @brief     Gets the string descriptors according to the needed index
+ *
+ * @param     Length.
+ *
+ * @return    The address of the string descriptors.
+ */
+uint8_t *USBD_GetStringDescriptor(uint16_t Length)
+{
+  uint8_t wValue0 = pInformation->USBwValue0;
+	
+  if (wValue0 > 4)
+  {
+    return NULL;
+  }
+  else
+  {
+    return Standard_GetDescriptorData(Length, &String_Descriptor[wValue0]);
+  }
+}
+
+/*********************************************************************
+ * @fn      USBD_GetReportDescriptor
+ *
+ * @brief   Gets the report descriptors according to the needed index
+ *
+ * @param   Length.
+ *
+ * @return  The address of the device descriptor.
+ */
+uint8_t *USBD_GetReportDescriptor(uint16_t Length)
+{
+  uint8_t wIndex0 = pInformation->USBwIndexs.bw.bb0;
+  if (wIndex0 > 2)
+  {
+    return NULL;
+  }
+  else
+  {
+    return Standard_GetDescriptorData(Length, &Report_Descriptor[wIndex0]);
+  }
+}
+
+/*********************************************************************
+ * @fn      USBD_GetHidDescriptor
+ *
+ * @brief   Gets the report descriptors according to the needed index
+ *
+ * @param   Length.
+ *
+ * @return  The address of the device descriptor.
+ */
+uint8_t *USBD_GetHidDescriptor(uint16_t Length)
+{
+  uint8_t wIndex0 = pInformation->USBwIndexs.bw.bb0;
+  if (wIndex0 > 2)
+  {
+    return NULL;
+  }
+  else
+  {
+    return Standard_GetDescriptorData(Length, &Hid_Descriptor[wIndex0]);
+  }
+}
+
+/*********************************************************************
+ * @fn      USBD_Get_Interface_Setting.
+ *
+ * @brief  test the interface and the alternate setting according to the
+ *                  supported one.
+ *
+ * @param  Interface: interface number.
+ *                  AlternateSetting: Alternate Setting number.
+ *
+ * @return USB_UNSUPPORT or USB_SUCCESS.
+ */
+RESULT USBD_Get_Interface_Setting(uint8_t Interface, uint8_t AlternateSetting)
+{
+  if (AlternateSetting > 0)
+  {
+    return USB_UNSUPPORT;
+  }
+  else if (Interface > 1)
+  {
+    return USB_UNSUPPORT;
+  }
+	
+  return USB_SUCCESS;
+}
+
+/*******************************************************************************
+ * @fn       USBD_Data_Setup
+ *
+ * @brief    handle the data class specific requests
+ *
+ * @param    Request Nb.
+ *
+ * @return   USB_UNSUPPORT or USB_SUCCESS.
+ */
+RESULT USBD_Data_Setup(uint8_t RequestNo)
+{
+  uint8_t *(*CopyRoutine)(uint16_t);
+  uint32_t Request_No = pInformation->USBbRequest;
+  uint32_t wOffset;
+  CopyRoutine = NULL;
+  wOffset = 0;
+
+
+  if (Type_Recipient == (STANDARD_REQUEST | INTERFACE_RECIPIENT))
+  {
+    uint8_t wValue1 = pInformation->USBwValue1;
+
+    if (wValue1 == HID_REPORT_DESCRIPTOR)
+    {
+      CopyRoutine = USBD_GetReportDescriptor;
+    }
+    else if (wValue1 == HID_DESCRIPTOR)
+    {
+      CopyRoutine = USBD_GetHidDescriptor;
+    }
+    if (CopyRoutine)
+    {
+      pInformation->Ctrl_Info.Usb_wOffset = wOffset;
+      pInformation->Ctrl_Info.CopyData = CopyRoutine;
+      (*CopyRoutine)(0);
+    }
+    else
+    {
+      return USB_UNSUPPORT;
+    }
+
+  }
+  else if (Type_Recipient == (CLASS_REQUEST | INTERFACE_RECIPIENT) )
+  {
+    if (Request_No == HID_GET_REPORT)
+    {
+      /* HID Get Report */
+    }
+    else if (Request_No == HID_GET_IDLE)
+    {
+      pInformation->Ctrl_Info.Usb_wLength = 1;
+      pInformation->Ctrl_Info.CopyData = &HID_Get_Idle;
+    }
+    else if (Request_No == HID_GET_PROTOCOL)
+    {
+      pInformation->Ctrl_Info.Usb_wLength = 1;
+      pInformation->Ctrl_Info.CopyData = &HID_Get_Protocol;
+    }  
+    else if (Request_No == HID_SET_REPORT)
+    {
+      if (pInformation->USBwLengths.w > 1)
+      {
+        return USB_UNSUPPORT;
+      }
+      else
+      {
+        pInformation->Ctrl_Info.Usb_wLength = pInformation->USBwLengths.w;
+        pInformation->Ctrl_Info.CopyData = &HID_Set_Report;
+        pInformation->ControlState = OUT_DATA;
+      }
+    }
+    else
+    {
+      return USB_UNSUPPORT;
+    }    
+  }
+  return USB_SUCCESS;
+}
+
+/*******************************************************************************
+ * @fn      USBD_NoData_Setup.
+ *
+ * @brief   handle the no data class specific requests.
+ *
+ * @param   Request Nb.
+ *
+ * @return  USB_UNSUPPORT or USB_SUCCESS.
+ */
+RESULT USBD_NoData_Setup(uint8_t RequestNo)
+{      
+  uint32_t Request_No = pInformation->USBbRequest;
+  uint8_t wIndex0 = pInformation->USBwIndexs.bw.bb0;
+  if (Type_Recipient == (CLASS_REQUEST | INTERFACE_RECIPIENT))
+  {
+    if (Request_No == HID_SET_IDLE)
+    {
+      if (wIndex0 > 2)
+      {
+        return USB_UNSUPPORT;
+      }
+      else
+      {
+        HID_Idle_Value[wIndex0] = pInformation->USBwValues.bw.bb1;
+      }
+      
+    }
+    else if (Request_No == HID_SET_PROTOCOL)
+    {
+      if (wIndex0 > 2)
+      {
+        return USB_UNSUPPORT;
+      }
+      else
+      {
+        HID_Protocol_Value[wIndex0] = pInformation->USBwValues.bw.bb0;
+      }
+    }
+    else
+    {
+      return USB_UNSUPPORT;
+    }    
+  }             
+  return USB_SUCCESS;
+}
+
+
+/*********************************************************************
+ * @fn      HID_Set_Report.
+ *
+ * @brief   HID Set Report.
+ *
+ * @param   
+ *
+ * @return  HIDReportOut.
+ */
+uint8_t *HID_Set_Report(uint16_t Length)
+{
+  uint8_t wIndex0 = pInformation->USBwIndexs.bw.bb0;
+  if (wIndex0 > 1)
+  {
+    return NULL;
+  }
+  else
+  {
+    return (uint8_t *)&KB_LED_Cur_Status;
+  }
+}
+
+/*********************************************************************
+ * @fn      HID_Get_Idle.
+ *
+ * @brief   HID Save Report Data.
+ *
+ * @param   
+ *
+ * @return  HIDReportOut.
+ */
+uint8_t *HID_Get_Idle(uint16_t Length)
+{
+  uint8_t wIndex0 = pInformation->USBwIndexs.bw.bb0;
+  if (wIndex0 > 2)
+  {
+    return NULL;
+  }
+  else
+  {
+    return (uint8_t*)&HID_Idle_Value[wIndex0];
+  }
+}
+/*********************************************************************
+ * @fn      HID_Get_Protocol.
+ *
+ * @brief   HID Save Report Data.
+ *
+ * @param   
+ *
+ * @return  HIDReportOut.
+ */
+uint8_t *HID_Get_Protocol(uint16_t Length)
+{
+  uint8_t wIndex0 = pInformation->USBwIndexs.bw.bb0;
+  if (wIndex0 > 2)
+  {
+    return NULL;
+  }
+  else
+  {
+    return (uint8_t*)&HID_Protocol_Value[wIndex0];
+  }
+}

--- a/Sources/source/LanaKBD/User/USBLIB/CONFIG/usb_prop.h
+++ b/Sources/source/LanaKBD/User/USBLIB/CONFIG/usb_prop.h
@@ -1,0 +1,89 @@
+/********************************** (C) COPYRIGHT *******************************
+* File Name          : usb_prop.h
+* Author             : WCH
+* Version            : V1.0.0
+* Date               : 2022/08/20
+* Description        : USB processing.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __usb_prop_H
+#define __usb_prop_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#include "ch32v20x.h"
+
+#define USBD_GetConfiguration          NOP_Process
+//#define USBD_SetConfiguration          NOP_Process
+#define USBD_GetInterface              NOP_Process
+#define USBD_SetInterface              NOP_Process
+#define USBD_GetStatus                 NOP_Process
+// #define USBD_ClearFeature              NOP_Process
+#define USBD_SetEndPointFeature        NOP_Process
+// #define USBD_SetDeviceFeature          NOP_Process
+//#define USBD_SetDeviceAddress          NOP_Process
+
+#define SEND_ENCAPSULATED_COMMAND   0x00
+#define GET_ENCAPSULATED_RESPONSE   0x01
+#define SET_COMM_FEATURE            0x02
+#define GET_COMM_FEATURE            0x03
+#define CLEAR_COMM_FEATURE          0x04
+#define SET_LINE_CODING             0x20
+#define GET_LINE_CODING             0x21
+#define SET_CONTROL_LINE_STATE      0x22
+#define SEND_BREAK                  0x23
+
+
+/* Definition of HID */
+
+#define HID_GET_REPORT      0x01  
+#define HID_GET_IDLE        0x02 
+#define HID_GET_PROTOCOL    0x03  
+#define HID_SET_REPORT      0x09  
+#define HID_SET_IDLE        0x0A 
+#define HID_SET_PROTOCOL    0x0B 
+
+#define HID_DESCRIPTOR          0x21
+#define HID_REPORT_DESCRIPTOR   0x22
+
+#define HID_SET_REPORT_DEAL_OVER          0x00
+#define HID_SET_REPORT_WAIT_DEAL          0x01
+
+
+extern volatile uint8_t USBD_Sleep_Status;
+
+void USBD_init(void);
+void USBD_Reset(void);
+void USBD_SetConfiguration(void);
+void USBD_SetDeviceAddress (void);
+void USBD_SetDeviceFeature (void);
+void USBD_ClearFeature (void);
+void USBD_Status_In (void);
+void USBD_Status_Out (void);
+RESULT USBD_Data_Setup(uint8_t);
+RESULT USBD_NoData_Setup(uint8_t);
+RESULT USBD_Get_Interface_Setting(uint8_t Interface, uint8_t AlternateSetting);
+uint8_t *USBD_GetDeviceDescriptor(uint16_t );
+uint8_t *USBD_GetConfigDescriptor(uint16_t);
+uint8_t *USBD_GetStringDescriptor(uint16_t);
+uint8_t *USBD_GetReportDescriptor(uint16_t);
+uint8_t *HID_Set_Report(uint16_t);
+uint8_t *HID_Get_Idle(uint16_t);
+uint8_t *HID_Get_Protocol(uint16_t);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __usb_prop_H */
+
+
+
+
+
+
+

--- a/Sources/source/LanaKBD/User/USBLIB/CONFIG/usb_pwr.c
+++ b/Sources/source/LanaKBD/User/USBLIB/CONFIG/usb_pwr.c
@@ -1,0 +1,215 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : usb_pwr.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/08/08
+ * Description        : Connection/disconnection & power management
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/ 
+#include "usb_lib.h"
+#include "usb_conf.h"
+#include "usb_pwr.h"
+#include "hw_config.h"
+
+__IO uint32_t bDeviceState = UNCONNECTED; 
+__IO bool fSuspendEnabled = TRUE;  
+__IO uint32_t EP[8];
+
+struct
+{
+  __IO RESUME_STATE eState;
+  __IO uint8_t bESOFcnt;
+}
+ResumeS;
+
+__IO uint32_t remotewakeupon=0;
+
+/*******************************************************************************
+ * @fn      PowerOn
+ *
+ * @brief   Enable power on.
+ *
+ * @return  USB_SUCCESS.
+ */
+RESULT PowerOn(void)
+{
+  uint16_t wRegVal;
+
+  wRegVal = CNTR_FRES;
+  _SetCNTR(wRegVal);
+  wInterrupt_Mask = 0;
+  _SetCNTR(wInterrupt_Mask);
+  _SetISTR(0);
+  wInterrupt_Mask = CNTR_RESETM | CNTR_SUSPM | CNTR_WKUPM;
+  _SetCNTR(wInterrupt_Mask);
+  
+  return USB_SUCCESS;
+}
+
+/*******************************************************************************
+ * @fn      PowerOff
+ *
+ * @brief   handles switch-off conditions
+ *
+ * @return  USB_SUCCESS.
+ */
+RESULT PowerOff()
+{
+  _SetCNTR(CNTR_FRES); 
+  _SetISTR(0); 
+  _SetCNTR(CNTR_FRES + CNTR_PDWN);
+
+  return USB_SUCCESS;
+}
+
+/*******************************************************************************
+ * @fn        Suspend
+ *
+ * @brief     sets suspend mode operating conditions
+ *
+ * @return    USB_SUCCESS.
+ */
+void Suspend(void)
+{
+	uint32_t i =0;
+	uint16_t wCNTR; 
+
+	wCNTR = _GetCNTR();  
+  for (i=0;i<8;i++) EP[i] = _GetENDPOINT(i);
+	
+	wCNTR|=CNTR_RESETM;
+	_SetCNTR(wCNTR);
+	
+	wCNTR|=CNTR_FRES;
+	_SetCNTR(wCNTR);
+	
+	wCNTR&=~CNTR_FRES;
+	_SetCNTR(wCNTR);
+
+	while((_GetISTR()&ISTR_RESET) == 0);
+	
+	_SetISTR((uint16_t)CLR_RESET);
+	
+	for (i=0;i<8;i++)
+	_SetENDPOINT(i, EP[i]);
+	
+	wCNTR |= CNTR_FSUSP;
+	_SetCNTR(wCNTR);
+	
+	wCNTR = _GetCNTR();
+	wCNTR |= CNTR_LPMODE;
+	_SetCNTR(wCNTR);
+
+	Enter_LowPowerMode();
+}
+
+/*******************************************************************************
+ * @fn       Resume_Init
+ *
+ * @brief    Handles wake-up restoring normal operations
+ *
+ * @return   USB_SUCCESS.
+ */
+void Resume_Init(void)
+{
+  uint16_t wCNTR;
+  
+  wCNTR = _GetCNTR();
+  wCNTR &= (~CNTR_LPMODE);
+  _SetCNTR(wCNTR);      
+  Leave_LowPowerMode();
+  _SetCNTR(IMR_MSK);
+}
+
+/*******************************************************************************
+ * @fn       Resume
+ *
+ * @brief    This is the state machine handling resume operations and
+ *                 timing sequence. The control is based on the Resume structure
+ *                 variables and on the ESOF interrupt calling this subroutine
+ *                 without changing machine state.
+ *
+ * @param    a state machine value (RESUME_STATE)
+ *                  RESUME_ESOF doesn't change ResumeS.eState allowing
+ *                  decrementing of the ESOF counter in different states.
+ *
+ * @return  None.
+ */
+void Resume(RESUME_STATE eResumeSetVal)
+{
+  uint16_t wCNTR;
+
+  if (eResumeSetVal != RESUME_ESOF)
+	{
+   ResumeS.eState = eResumeSetVal;
+	}
+	
+  switch (ResumeS.eState)
+  {
+    case RESUME_EXTERNAL:
+      if (remotewakeupon ==0)
+      {
+        Resume_Init();
+        ResumeS.eState = RESUME_OFF;
+      }
+      else 
+      {
+        ResumeS.eState = RESUME_ON;
+      }
+      break;
+			
+    case RESUME_INTERNAL:
+      Resume_Init();
+      ResumeS.eState = RESUME_START;
+      remotewakeupon = 1;
+      break;
+		
+    case RESUME_LATER:
+      ResumeS.bESOFcnt = 2;
+      ResumeS.eState = RESUME_WAIT;
+      break;
+		
+    case RESUME_WAIT:
+      ResumeS.bESOFcnt--;
+      if (ResumeS.bESOFcnt == 0)
+        ResumeS.eState = RESUME_START;
+      break;
+			
+    case RESUME_START:
+      wCNTR = _GetCNTR();
+      wCNTR |= CNTR_RESUME;
+      _SetCNTR(wCNTR);
+      ResumeS.eState = RESUME_ON;
+      ResumeS.bESOFcnt = 10;
+      break;
+		
+    case RESUME_ON:    
+      ResumeS.bESOFcnt--;
+      if (ResumeS.bESOFcnt == 0)
+      {
+        wCNTR = _GetCNTR();
+        wCNTR &= (~CNTR_RESUME);
+        _SetCNTR(wCNTR);
+        ResumeS.eState = RESUME_OFF;
+        remotewakeupon = 0;
+      }
+      break;
+			
+    case RESUME_OFF:
+			
+    case RESUME_ESOF:
+			
+    default:
+      ResumeS.eState = RESUME_OFF;
+      break;
+  }
+}
+
+
+
+
+
+

--- a/Sources/source/LanaKBD/User/USBLIB/CONFIG/usb_pwr.h
+++ b/Sources/source/LanaKBD/User/USBLIB/CONFIG/usb_pwr.h
@@ -1,0 +1,62 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : usb_pwr.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/08/08
+ * Description        : Connection/disconnection & power management header 
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/ 
+#ifndef __USB_PWR_H
+#define __USB_PWR_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+	 
+#include "ch32v20x.h"
+typedef enum _RESUME_STATE
+{
+  RESUME_EXTERNAL,
+  RESUME_INTERNAL,
+  RESUME_LATER,
+  RESUME_WAIT,
+  RESUME_START,
+  RESUME_ON,
+  RESUME_OFF,
+  RESUME_ESOF
+} RESUME_STATE;
+
+typedef enum _DEVICE_STATE
+{
+  UNCONNECTED,
+  ATTACHED,
+  POWERED,
+  SUSPENDED,
+  ADDRESSED,
+  CONFIGURED
+} DEVICE_STATE;
+
+
+void Suspend(void);
+void Resume_Init(void);
+void Resume(RESUME_STATE eResumeSetVal);
+RESULT PowerOn(void);
+RESULT PowerOff(void);
+
+extern  __IO uint32_t bDeviceState; /* USB device status */
+extern __IO bool fSuspendEnabled;  /* true when suspend is possible */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /*__USB_PWR_H*/
+
+
+
+
+
+

--- a/Sources/source/LanaKBD/User/USBLIB/USB-Driver/inc/usb_core.h
+++ b/Sources/source/LanaKBD/User/USBLIB/USB-Driver/inc/usb_core.h
@@ -1,0 +1,191 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : usb_core.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/08/08
+ * Description        : This file contains all the functions prototypes for the  
+ *                      USB cor firmware library.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/ 
+#ifndef __USB_CORE_H
+#define __USB_CORE_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#include "ch32v20x.h"
+
+	 
+typedef enum _CONTROL_STATE
+{
+  WAIT_SETUP,       /* 0 */
+  SETTING_UP,       /* 1 */
+  IN_DATA,          /* 2 */
+  OUT_DATA,         /* 3 */
+  LAST_IN_DATA,     /* 4 */
+  LAST_OUT_DATA,    /* 5 */
+  WAIT_STATUS_IN,   /* 7 */
+  WAIT_STATUS_OUT,  /* 8 */
+  STALLED,          /* 9 */
+  PAUSE             /* 10 */
+} CONTROL_STATE;    /* The state machine states of a control pipe */
+
+typedef struct OneDescriptor
+{
+  uint8_t *Descriptor;
+  uint16_t Descriptor_Size;
+}
+ONE_DESCRIPTOR, *PONE_DESCRIPTOR;
+
+typedef enum _RESULT
+{
+  USB_SUCCESS = 0,    /* Process successfully */
+  USB_ERROR,
+  USB_UNSUPPORT,
+  USB_NOT_READY       /* The process has not been finished, endpoint will be
+                         NAK to further request */
+} RESULT;
+
+
+/* Definitions for endpoint level */
+typedef struct _ENDPOINT_INFO
+{
+  uint16_t  Usb_wLength;
+  uint16_t  Usb_wOffset;
+  uint16_t  PacketSize;
+  uint8_t   *(*CopyData)(uint16_t Length);
+}ENDPOINT_INFO;
+
+/* Definitions for device level */
+typedef struct _DEVICE
+{
+  uint8_t Total_Endpoint;     /* Number of endpoints that are used */
+  uint8_t Total_Configuration;/* Number of configuration available */
+}
+DEVICE;
+
+typedef union
+{
+  uint16_t w;
+  struct BW
+  {
+    uint8_t bb1;
+    uint8_t bb0;
+  }
+  bw;
+} uint16_t_uint8_t;
+
+typedef struct _DEVICE_INFO
+{
+  uint8_t USBbmRequestType;       /* bmRequestType */
+  uint8_t USBbRequest;            /* bRequest */
+  uint16_t_uint8_t USBwValues;         /* wValue */
+  uint16_t_uint8_t USBwIndexs;         /* wIndex */
+  uint16_t_uint8_t USBwLengths;        /* wLength */
+
+  uint8_t ControlState;           /* of type CONTROL_STATE */
+  uint8_t Current_Feature;
+  uint8_t Current_Configuration;   /* Selected configuration */
+  uint8_t Current_Interface;       /* Selected interface of current configuration */
+  uint8_t Current_AlternateSetting;/* Selected Alternate Setting of current
+                                     interface*/
+
+  ENDPOINT_INFO Ctrl_Info;
+}DEVICE_INFO;
+
+typedef struct _DEVICE_PROP
+{
+  void (*Init)(void);        /* Initialize the device */
+  void (*Reset)(void);       /* Reset routine of this device */
+  void (*Process_Status_IN)(void);
+  void (*Process_Status_OUT)(void);
+
+  RESULT (*Class_Data_Setup)(uint8_t RequestNo);
+
+  RESULT (*Class_NoData_Setup)(uint8_t RequestNo);
+
+  RESULT  (*Class_Get_Interface_Setting)(uint8_t Interface, uint8_t AlternateSetting);
+
+  uint8_t* (*GetDeviceDescriptor)(uint16_t Length);
+  uint8_t* (*GetConfigDescriptor)(uint16_t Length);
+  uint8_t* (*GetStringDescriptor)(uint16_t Length);
+
+  void* RxEP_buffer;
+   
+  uint8_t MaxPacketSize;
+
+}DEVICE_PROP;
+
+typedef struct _USER_STANDARD_REQUESTS
+{
+  void (*User_GetConfiguration)(void);       /* Get Configuration */
+  void (*User_SetConfiguration)(void);       /* Set Configuration */
+  void (*User_GetInterface)(void);           /* Get Interface */
+  void (*User_SetInterface)(void);           /* Set Interface */
+  void (*User_GetStatus)(void);              /* Get Status */
+  void (*User_ClearFeature)(void);           /* Clear Feature */
+  void (*User_SetEndPointFeature)(void);     /* Set Endpoint Feature */
+  void (*User_SetDeviceFeature)(void);       /* Set Device Feature */
+  void (*User_SetDeviceAddress)(void);       /* Set Device Address */
+}
+USER_STANDARD_REQUESTS;
+
+
+#define Type_Recipient (pInformation->USBbmRequestType & (REQUEST_TYPE | RECIPIENT))
+
+#define Usb_rLength Usb_wLength
+#define Usb_rOffset Usb_wOffset
+
+#define USBwValue USBwValues.w
+#define USBwValue0 USBwValues.bw.bb0
+#define USBwValue1 USBwValues.bw.bb1
+#define USBwIndex USBwIndexs.w
+#define USBwIndex0 USBwIndexs.bw.bb0
+#define USBwIndex1 USBwIndexs.bw.bb1
+#define USBwLength USBwLengths.w
+#define USBwLength0 USBwLengths.bw.bb0
+#define USBwLength1 USBwLengths.bw.bb1
+
+
+uint8_t Setup0_Process(void);
+uint8_t Post0_Process(void);
+uint8_t Out0_Process(void);
+uint8_t In0_Process(void);
+
+RESULT Standard_SetEndPointFeature(void);
+RESULT Standard_SetDeviceFeature(void);
+
+uint8_t *Standard_GetConfiguration(uint16_t Length);
+RESULT Standard_SetConfiguration(void);
+uint8_t *Standard_GetInterface(uint16_t Length);
+RESULT Standard_SetInterface(void);
+uint8_t *Standard_GetDescriptorData(uint16_t Length, PONE_DESCRIPTOR pDesc);
+
+uint8_t *Standard_GetStatus(uint16_t Length);
+RESULT Standard_ClearFeature(void);
+void SetDeviceAddress(uint8_t);
+void NOP_Process(void);
+
+extern DEVICE_PROP Device_Property;
+extern  USER_STANDARD_REQUESTS User_Standard_Requests;
+extern  DEVICE  Device_Table;
+extern DEVICE_INFO Device_Info;
+
+/* cells saving status during interrupt servicing */
+extern __IO uint16_t SaveRState;
+extern __IO uint16_t SaveTState;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __USB_CORE_H */
+
+
+
+
+

--- a/Sources/source/LanaKBD/User/USBLIB/USB-Driver/inc/usb_def.h
+++ b/Sources/source/LanaKBD/User/USBLIB/USB-Driver/inc/usb_def.h
@@ -1,0 +1,82 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : usb_def.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/08/08
+ * Description        : This file contains all the functions prototypes for the  
+ *                      USB definition firmware library.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/ 
+#ifndef __USB_DEF_H
+#define __USB_DEF_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#include "ch32v20x.h"
+
+typedef enum _RECIPIENT_TYPE
+{
+  DEVICE_RECIPIENT,     
+  INTERFACE_RECIPIENT,  
+  ENDPOINT_RECIPIENT,   
+  OTHER_RECIPIENT
+} RECIPIENT_TYPE;
+
+typedef enum _STANDARD_REQUESTS
+{
+  GET_STATUS = 0,
+  CLEAR_FEATURE,
+  RESERVED1,
+  SET_FEATURE,
+  RESERVED2,
+  SET_ADDRESS,
+  GET_DESCRIPTOR,
+  SET_DESCRIPTOR,
+  GET_CONFIGURATION,
+  SET_CONFIGURATION,
+  GET_INTERFACE,
+  SET_INTERFACE,
+  TOTAL_sREQUEST,  
+  SYNCH_FRAME = 12
+} STANDARD_REQUESTS;
+
+/* Definition of "USBwValue" */
+typedef enum _DESCRIPTOR_TYPE
+{
+  DEVICE_DESCRIPTOR = 1,
+  CONFIG_DESCRIPTOR,
+  STRING_DESCRIPTOR,
+  INTERFACE_DESCRIPTOR,
+  ENDPOINT_DESCRIPTOR
+} DESCRIPTOR_TYPE;
+
+/* Feature selector of a SET_FEATURE or CLEAR_FEATURE */
+typedef enum _FEATURE_SELECTOR
+{
+  ENDPOINT_STALL,
+  DEVICE_REMOTE_WAKEUP
+} FEATURE_SELECTOR;
+
+/* Definition of "USBbmRequestType" */
+#define REQUEST_TYPE      0x60  
+#define STANDARD_REQUEST  0x00  
+#define CLASS_REQUEST     0x20 
+#define VENDOR_REQUEST    0x40  
+#define RECIPIENT         0x1F  
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __USB_DEF_H */
+
+
+
+
+
+

--- a/Sources/source/LanaKBD/User/USBLIB/USB-Driver/inc/usb_init.h
+++ b/Sources/source/LanaKBD/User/USBLIB/USB-Driver/inc/usb_init.h
@@ -1,0 +1,42 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : usb_init.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/08/08
+ * Description        : This file contains all the functions prototypes for the  
+ *                      USB Initialization firmware library.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/ 
+#ifndef __USB_INIT_H
+#define __USB_INIT_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+	 
+#include "ch32v20x.h"
+
+	 
+void USB_Init(void);
+extern uint8_t	EPindex;
+extern DEVICE_INFO*	pInformation;
+extern DEVICE_PROP*	pProperty;
+extern USER_STANDARD_REQUESTS *pUser_Standard_Requests;
+extern uint16_t	SaveState ;
+extern uint16_t wInterrupt_Mask;
+
+#ifdef __cplusplus
+}
+
+#endif
+
+
+#endif /* __USB_INIT_H */
+
+
+
+
+

--- a/Sources/source/LanaKBD/User/USBLIB/USB-Driver/inc/usb_int.h
+++ b/Sources/source/LanaKBD/User/USBLIB/USB-Driver/inc/usb_int.h
@@ -1,0 +1,25 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : usb_int.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/08/08
+ * Description        : This file contains all the functions prototypes for the  
+ *                      USB Endpoint firmware library.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/ 
+#ifndef __USB_INT_H
+#define __USB_INT_H
+
+void CTR_LP(void);
+void CTR_HP(void);
+
+#endif /* __USB_INT_H */
+
+
+
+
+
+

--- a/Sources/source/LanaKBD/User/USBLIB/USB-Driver/inc/usb_lib.h
+++ b/Sources/source/LanaKBD/User/USBLIB/USB-Driver/inc/usb_lib.h
@@ -1,0 +1,30 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : usb_lib.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/08/08
+ * Description        : Library configuration file for USB.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/ 
+#ifndef __USB_LIB_H
+#define __USB_LIB_H
+
+#include "hw_config.h"
+#include "usb_type.h"
+#include "usb_regs.h"
+#include "usb_def.h"
+#include "usb_core.h"
+#include "usb_init.h"
+#include "usb_sil.h"
+#include "usb_mem.h"
+#include "usb_int.h"
+//#include "ch32f20x_usb.h"
+
+#endif /* __USB_LIB_H */
+
+
+
+

--- a/Sources/source/LanaKBD/User/USBLIB/USB-Driver/inc/usb_mem.h
+++ b/Sources/source/LanaKBD/User/USBLIB/USB-Driver/inc/usb_mem.h
@@ -1,0 +1,36 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : usb_mem.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/08/08
+ * Description        : This file contains all the functions prototypes for the  
+ *                      USB Initialization firmware library.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/ 
+#ifndef __USB_MEM_H
+#define __USB_MEM_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#include "ch32v20x.h"
+
+void UserToPMABufferCopy(uint8_t *pbUsrBuf, uint16_t wPMABufAddr, uint16_t wNBytes);
+void PMAToUserBufferCopy(uint8_t *pbUsrBuf, uint16_t wPMABufAddr, uint16_t wNBytes);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /*__USB_MEM_H*/
+
+
+
+
+
+

--- a/Sources/source/LanaKBD/User/USBLIB/USB-Driver/inc/usb_regs.h
+++ b/Sources/source/LanaKBD/User/USBLIB/USB-Driver/inc/usb_regs.h
@@ -1,0 +1,675 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : usb_regs.h
+ * Author             : WCH
+ * Version            : V1.0.1
+ * Date               : 2022/12/28
+ * Description        : This file contains all the functions prototypes for the  
+ *                      USB cell registers firmware library.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/ 
+#ifndef __USB_REGS_H
+#define __USB_REGS_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#include "ch32v20x.h"
+	 
+typedef enum _EP_DBUF_DIR
+{
+  EP_DBUF_ERR,
+  EP_DBUF_OUT,
+  EP_DBUF_IN
+}EP_DBUF_DIR;
+
+/* endpoint buffer number */
+enum EP_BUF_NUM
+{
+  EP_NOBUF,
+  EP_BUF0,
+  EP_BUF1
+};
+
+extern uint16_t Ep0RxBlks;
+
+#define RegBase  (0x40005C00L)  
+#define PMAAddr  (0x40006000L)  
+
+/******************************************************************************/
+/*                         General registers                                  */
+/******************************************************************************/
+
+/* Control register */
+#define CNTLR    ((__IO unsigned *)(RegBase + 0x40))
+/* Interrupt status register */
+#define ISTR    ((__IO unsigned *)(RegBase + 0x44))
+/* Frame number register */
+#define FNR     ((__IO unsigned *)(RegBase + 0x48))
+/* Device address register */
+#define DADDR   ((__IO unsigned *)(RegBase + 0x4C))
+/* Buffer Table address register */
+#define BTABLE  ((__IO unsigned *)(RegBase + 0x50))
+/******************************************************************************/
+/*                         Endpoint registers                                 */
+/******************************************************************************/
+#define EP0REG  ((__IO unsigned *)(RegBase)) /* endpoint 0 register address */
+
+/* Endpoint Addresses (w/direction) */
+#define EP0_OUT     ((uint8_t)0x00)  
+#define EP0_IN      ((uint8_t)0x80) 
+#define EP1_OUT     ((uint8_t)0x01)  
+#define EP1_IN      ((uint8_t)0x81)  
+#define EP2_OUT     ((uint8_t)0x02)  
+#define EP2_IN      ((uint8_t)0x82)  
+#define EP3_OUT     ((uint8_t)0x03)  
+#define EP3_IN      ((uint8_t)0x83) 
+#define EP4_OUT     ((uint8_t)0x04)  
+#define EP4_IN      ((uint8_t)0x84)
+#define EP5_OUT     ((uint8_t)0x05)  
+#define EP5_IN      ((uint8_t)0x85)
+#define EP6_OUT     ((uint8_t)0x06)  
+#define EP6_IN      ((uint8_t)0x86)
+#define EP7_OUT     ((uint8_t)0x07)  
+#define EP7_IN      ((uint8_t)0x87)
+
+/* endpoints enumeration */
+#define ENDP0       ((uint8_t)0)
+#define ENDP1       ((uint8_t)1)
+#define ENDP2       ((uint8_t)2)
+#define ENDP3       ((uint8_t)3)
+#define ENDP4       ((uint8_t)4)
+#define ENDP5       ((uint8_t)5)
+#define ENDP6       ((uint8_t)6)
+#define ENDP7       ((uint8_t)7)
+
+/******************************************************************************/
+/*                       ISTR interrupt events                                */
+/******************************************************************************/
+#define ISTR_CTR    (0x8000) /* Correct TRansfer (clear-only bit) */
+#define ISTR_DOVR   (0x4000) /* DMA OVeR/underrun (clear-only bit) */
+#define ISTR_ERR    (0x2000) /* ERRor (clear-only bit) */
+#define ISTR_WKUP   (0x1000) /* WaKe UP (clear-only bit) */
+#define ISTR_SUSP   (0x0800) /* SUSPend (clear-only bit) */
+#define ISTR_RESET  (0x0400) /* RESET (clear-only bit) */
+#define ISTR_SOF    (0x0200) /* Start Of Frame (clear-only bit) */
+#define ISTR_ESOF   (0x0100) /* Expected Start Of Frame (clear-only bit) */
+
+
+#define ISTR_DIR    (0x0010)  /* DIRection of transaction (read-only bit)  */
+#define ISTR_EP_ID  (0x000F)  /* EndPoint IDentifier (read-only bit)  */
+
+#define CLR_CTR    (~ISTR_CTR)   /* clear Correct TRansfer bit */
+#define CLR_DOVR   (~ISTR_DOVR)  /* clear DMA OVeR/underrun bit*/
+#define CLR_ERR    (~ISTR_ERR)   /* clear ERRor bit */
+#define CLR_WKUP   (~ISTR_WKUP)  /* clear WaKe UP bit     */
+#define CLR_SUSP   (~ISTR_SUSP)  /* clear SUSPend bit     */
+#define CLR_RESET  (~ISTR_RESET) /* clear RESET bit      */
+#define CLR_SOF    (~ISTR_SOF)   /* clear Start Of Frame bit   */
+#define CLR_ESOF   (~ISTR_ESOF)  /* clear Expected Start Of Frame bit */
+
+/******************************************************************************/
+/*             CNTR control register bits definitions                         */
+/******************************************************************************/
+#define CNTR_CTRM   (0x8000) /* Correct TRansfer Mask */
+#define CNTR_DOVRM  (0x4000) /* DMA OVeR/underrun Mask */
+#define CNTR_ERRM   (0x2000) /* ERRor Mask */
+#define CNTR_WKUPM  (0x1000) /* WaKe UP Mask */
+#define CNTR_SUSPM  (0x0800) /* SUSPend Mask */
+#define CNTR_RESETM (0x0400) /* RESET Mask   */
+#define CNTR_SOFM   (0x0200) /* Start Of Frame Mask */
+#define CNTR_ESOFM  (0x0100) /* Expected Start Of Frame Mask */
+
+
+#define CNTR_RESUME (0x0010) /* RESUME request */
+#define CNTR_FSUSP  (0x0008) /* Force SUSPend */
+#define CNTR_LPMODE (0x0004) /* Low-power MODE */
+#define CNTR_PDWN   (0x0002) /* Power DoWN */
+#define CNTR_FRES   (0x0001) /* Force USB RESet */
+
+/******************************************************************************/
+/*                FNR Frame Number Register bit definitions                   */
+/******************************************************************************/
+#define FNR_RXDP    (0x8000) /* status of D+ data line */
+#define FNR_RXDM    (0x4000) /* status of D- data line */
+#define FNR_LCK     (0x2000) /* LoCKed */
+#define FNR_LSOF    (0x1800) /* Lost SOF */
+#define FNR_FN      (0x07FF) /* Frame Number */
+/******************************************************************************/
+/*               DADDR Device ADDRess bit definitions                         */
+/******************************************************************************/
+#define DADDR_EF    (0x80)
+#define DADDR_ADD   (0x7F)
+/******************************************************************************/
+/*                            Endpoint register                               */
+/******************************************************************************/
+/* bit positions */
+#define EP_CTR_RX      (0x8000) /* EndPoint Correct TRansfer RX */
+#define EP_DTOG_RX     (0x4000) /* EndPoint Data TOGGLE RX */
+#define EPRX_STAT      (0x3000) /* EndPoint RX STATus bit field */
+#define EP_SETUP       (0x0800) /* EndPoint SETUP */
+#define EP_T_FIELD     (0x0600) /* EndPoint TYPE */
+#define EP_KIND        (0x0100) /* EndPoint KIND */
+#define EP_CTR_TX      (0x0080) /* EndPoint Correct TRansfer TX */
+#define EP_DTOG_TX     (0x0040) /* EndPoint Data TOGGLE TX */
+#define EPTX_STAT      (0x0030) /* EndPoint TX STATus bit field */
+#define EPADDR_FIELD   (0x000F) /* EndPoint ADDRess FIELD */
+
+/* EndPoint REGister MASK (no toggle fields) */
+#define EPREG_MASK     (EP_CTR_RX|EP_SETUP|EP_T_FIELD|EP_KIND|EP_CTR_TX|EPADDR_FIELD)
+
+/* EP_TYPE[1:0] EndPoint TYPE */
+#define EP_TYPE_MASK   (0x0600) /* EndPoint TYPE Mask */
+#define EP_BULK        (0x0000) /* EndPoint BULK */
+#define EP_CONTROL     (0x0200) /* EndPoint CONTROL */
+#define EP_ISOCHRONOUS (0x0400) /* EndPoint ISOCHRONOUS */
+#define EP_INTERRUPT   (0x0600) /* EndPoint INTERRUPT */
+#define EP_T_MASK      (~EP_T_FIELD & EPREG_MASK)
+
+
+/* EP_KIND EndPoint KIND */
+#define EPKIND_MASK    (~EP_KIND & EPREG_MASK)
+
+/* STAT_TX[1:0] STATus for TX transfer */
+#define EP_TX_DIS      (0x0000) /* EndPoint TX DISabled */
+#define EP_TX_STALL    (0x0010) /* EndPoint TX STALLed */
+#define EP_TX_NAK      (0x0020) /* EndPoint TX NAKed */
+#define EP_TX_VALID    (0x0030) /* EndPoint TX VALID */
+#define EPTX_DTOG1     (0x0010) /* EndPoint TX Data TOGgle bit1 */
+#define EPTX_DTOG2     (0x0020) /* EndPoint TX Data TOGgle bit2 */
+#define EPTX_DTOGMASK  (EPTX_STAT|EPREG_MASK)
+
+/* STAT_RX[1:0] STATus for RX transfer */
+#define EP_RX_DIS      (0x0000) /* EndPoint RX DISabled */
+#define EP_RX_STALL    (0x1000) /* EndPoint RX STALLed */
+#define EP_RX_NAK      (0x2000) /* EndPoint RX NAKed */
+#define EP_RX_VALID    (0x3000) /* EndPoint RX VALID */
+#define EPRX_DTOG1     (0x1000) /* EndPoint RX Data TOGgle bit1 */
+#define EPRX_DTOG2     (0x2000) /* EndPoint RX Data TOGgle bit1 */
+#define EPRX_DTOGMASK  (EPRX_STAT|EPREG_MASK)
+
+/* SetCNTR */
+#define _SetCNTR(wRegValue)  (*CNTLR   = (uint16_t)wRegValue)
+
+/* SetISTR */
+#define _SetISTR(wRegValue)  (*ISTR   = (uint16_t)wRegValue)
+
+/* SetDADDR */
+#define _SetDADDR(wRegValue) (*DADDR  = (uint16_t)wRegValue)
+
+/* SetBTABLE */
+#define _SetBTABLE(wRegValue)(*BTABLE = (uint16_t)(wRegValue & 0xFFF8))
+
+/* GetCNTR */
+#define _GetCNTR()   ((uint16_t) *CNTLR)
+
+/* GetISTR */
+#define _GetISTR()   ((uint16_t) *ISTR)
+
+/* GetFNR */
+#define _GetFNR()    ((uint16_t) *FNR)
+
+/* GetDADDR */
+#define _GetDADDR()  ((uint16_t) *DADDR)
+
+/* GetBTABLE */
+#define _GetBTABLE() ((uint16_t) *BTABLE)
+
+/* SetENDPOINT */
+#define _SetENDPOINT(bEpNum,wRegValue)  (*(EP0REG + bEpNum)= \
+    (uint16_t)wRegValue)
+
+/* GetENDPOINT */
+#define _GetENDPOINT(bEpNum)        ((uint16_t)(*(EP0REG + bEpNum)))
+
+#define _SetEPType(bEpNum,wType) (_SetENDPOINT(bEpNum,\
+                                  ((_GetENDPOINT(bEpNum) & EP_T_MASK) | wType )))
+
+#define _GetEPType(bEpNum) (_GetENDPOINT(bEpNum) & EP_T_FIELD)
+
+/*******************************************************************************
+* Macro Name     : SetEPTxStatus
+* Description    : sets the status for tx transfer (bits STAT_TX[1:0]).
+* Input          : bEpNum: Endpoint Number. 
+*                  wState: new state
+* Return         : None.
+*******************************************************************************/
+#define _SetEPTxStatus(bEpNum,wState) {\
+    register uint16_t _wRegVal;       \
+    _wRegVal = _GetENDPOINT(bEpNum) & EPTX_DTOGMASK;\
+    /* toggle first bit ? */     \
+    if((EPTX_DTOG1 & wState)!= 0)      \
+      _wRegVal ^= EPTX_DTOG1;        \
+    /* toggle second bit ?  */         \
+    if((EPTX_DTOG2 & wState)!= 0)      \
+      _wRegVal ^= EPTX_DTOG2;        \
+    _SetENDPOINT(bEpNum, (_wRegVal | EP_CTR_RX|EP_CTR_TX));    \
+    while( ( _GetENDPOINT(bEpNum) & EPTX_STAT ) != wState ) \
+    { \
+        _SetENDPOINT(bEpNum, (_wRegVal | EP_CTR_RX|EP_CTR_TX));    \
+    }; \
+  } /* _SetEPTxStatus */
+
+/*******************************************************************************
+* Macro Name     : SetEPRxStatus
+* Description    : sets the status for rx transfer (bits STAT_TX[1:0])
+* Input          : bEpNum: Endpoint Number. 
+*                  wState: new state.
+* Return         : None.
+*******************************************************************************/
+#define _SetEPRxStatus(bEpNum,wState) {\
+    register uint16_t _wRegVal;   \
+    \
+    _wRegVal = _GetENDPOINT(bEpNum) & EPRX_DTOGMASK;\
+    /* toggle first bit ? */  \
+    if((EPRX_DTOG1 & wState)!= 0) \
+      _wRegVal ^= EPRX_DTOG1;  \
+    /* toggle second bit ? */  \
+    if((EPRX_DTOG2 & wState)!= 0) \
+      _wRegVal ^= EPRX_DTOG2;  \
+    _SetENDPOINT(bEpNum, (_wRegVal | EP_CTR_RX|EP_CTR_TX)); \
+    while( ( _GetENDPOINT(bEpNum) & EPRX_STAT ) != wState ) \
+    { \
+        _SetENDPOINT(bEpNum, (_wRegVal | EP_CTR_RX|EP_CTR_TX)); \
+    } \
+  } /* _SetEPRxStatus */
+
+/*******************************************************************************
+* Macro Name     : SetEPRxTxStatus
+* Description    : sets the status for rx & tx (bits STAT_TX[1:0] & STAT_RX[1:0])
+* Input          : bEpNum: Endpoint Number. 
+*                  wStaterx: new state.
+*                  wStatetx: new state.
+* Output         : None.
+* Return         : None.
+*******************************************************************************/
+#define _SetEPRxTxStatus(bEpNum,wStaterx,wStatetx) {\
+    register uint32_t _wRegVal_T, _wRegVal_R;   \
+    \
+    _wRegVal_T = _GetENDPOINT(bEpNum) & EPTX_DTOGMASK;  \
+    _wRegVal_R = _GetENDPOINT(bEpNum) & EPRX_DTOGMASK;  \
+    /* toggle first bit ? */  \
+    if((EPRX_DTOG1 & wStaterx)!= 0) \
+      _wRegVal_R ^= EPRX_DTOG1;  \
+    /* toggle second bit ? */  \
+    if((EPRX_DTOG2 & wStaterx)!= 0) \
+      _wRegVal_R ^= EPRX_DTOG2;  \
+    /* toggle first bit ? */   \
+    if((EPTX_DTOG1 & wStatetx)!= 0) \
+      _wRegVal_T ^= EPTX_DTOG1;  \
+    /* toggle second bit ?  */ \
+    if((EPTX_DTOG2 & wStatetx)!= 0) \
+      _wRegVal_T ^= EPTX_DTOG2;  \
+    _SetENDPOINT(bEpNum, _wRegVal_T |_wRegVal_R | EP_CTR_RX | EP_CTR_TX);  \
+    while( ( _GetENDPOINT(bEpNum) & EPTX_STAT ) != wStatetx ) \
+    { \
+        _SetENDPOINT(bEpNum, _wRegVal_T | EP_CTR_RX | EP_CTR_TX);  \
+    } \
+    while( ( _GetENDPOINT(bEpNum) & EPRX_STAT ) != wStaterx ) \
+    { \
+        _SetENDPOINT(bEpNum, _wRegVal_R | EP_CTR_RX | EP_CTR_TX);  \
+    } \
+  } /* _SetEPRxTxStatus */
+  
+/*******************************************************************************
+* Macro Name     : GetEPTxStatus / GetEPRxStatus 
+* Description    : gets the status for tx/rx transfer (bits STAT_TX[1:0]
+*                  /STAT_RX[1:0])
+* Input          : bEpNum: Endpoint Number. 
+* Return         : status .
+*******************************************************************************/
+#define _GetEPTxStatus(bEpNum) ((uint16_t)_GetENDPOINT(bEpNum) & EPTX_STAT)
+
+#define _GetEPRxStatus(bEpNum) ((uint16_t)_GetENDPOINT(bEpNum) & EPRX_STAT)
+
+/*******************************************************************************
+* Macro Name     : SetEPTxValid / SetEPRxValid 
+* Description    : sets directly the VALID tx/rx-status into the enpoint register
+* Input          : bEpNum: Endpoint Number. 
+* Return         : None.
+*******************************************************************************/
+#define _SetEPTxValid(bEpNum)     (_SetEPTxStatus(bEpNum, EP_TX_VALID))
+
+#define _SetEPRxValid(bEpNum)     (_SetEPRxStatus(bEpNum, EP_RX_VALID))
+
+/*******************************************************************************
+* Macro Name     : GetTxStallStatus / GetRxStallStatus.
+* Description    : checks stall condition in an endpoint.
+* Input          : bEpNum: Endpoint Number. 
+* Return         : TRUE = endpoint in stall condition.
+*******************************************************************************/
+#define _GetTxStallStatus(bEpNum) (_GetEPTxStatus(bEpNum) \
+                                   == EP_TX_STALL)
+#define _GetRxStallStatus(bEpNum) (_GetEPRxStatus(bEpNum) \
+                                   == EP_RX_STALL)
+
+/*******************************************************************************
+* Macro Name     : SetEP_KIND / ClearEP_KIND.
+* Description    : set & clear EP_KIND bit.
+* Input          : bEpNum: Endpoint Number. 
+* Return         : None.
+*******************************************************************************/
+#define _SetEP_KIND(bEpNum)    (_SetENDPOINT(bEpNum, \
+                                (EP_CTR_RX|EP_CTR_TX|((_GetENDPOINT(bEpNum) | EP_KIND) & EPREG_MASK))))
+#define _ClearEP_KIND(bEpNum)  (_SetENDPOINT(bEpNum, \
+                                (EP_CTR_RX|EP_CTR_TX|(_GetENDPOINT(bEpNum) & EPKIND_MASK))))
+
+/*******************************************************************************
+* Macro Name     : Set_Status_Out / Clear_Status_Out.
+* Description    : Sets/clears directly STATUS_OUT bit in the endpoint register.
+* Input          : bEpNum: Endpoint Number. 
+* Return         : None.
+*******************************************************************************/
+#define _Set_Status_Out(bEpNum)    _SetEP_KIND(bEpNum)
+#define _Clear_Status_Out(bEpNum)  _ClearEP_KIND(bEpNum)
+
+/*******************************************************************************
+* Macro Name     : SetEPDoubleBuff / ClearEPDoubleBuff.
+* Description    : Sets/clears directly EP_KIND bit in the endpoint register.
+* Input          : bEpNum: Endpoint Number. 
+* Return         : None.
+*******************************************************************************/
+#define _SetEPDoubleBuff(bEpNum)   _SetEP_KIND(bEpNum)
+#define _ClearEPDoubleBuff(bEpNum) _ClearEP_KIND(bEpNum)
+
+/*******************************************************************************
+* Macro Name     : ClearEP_CTR_RX / ClearEP_CTR_TX.
+* Description    : Clears bit CTR_RX / CTR_TX in the endpoint register.
+* Input          : bEpNum: Endpoint Number. 
+* Return         : None.
+*******************************************************************************/
+#define _ClearEP_CTR_RX(bEpNum)   (_SetENDPOINT(bEpNum,\
+                                   _GetENDPOINT(bEpNum) & 0x7FFF & EPREG_MASK))
+#define _ClearEP_CTR_TX(bEpNum)   (_SetENDPOINT(bEpNum,\
+                                   _GetENDPOINT(bEpNum) & 0xFF7F & EPREG_MASK))
+
+/*******************************************************************************
+* Macro Name     : ToggleDTOG_RX / ToggleDTOG_TX .
+* Description    : Toggles DTOG_RX / DTOG_TX bit in the endpoint register.
+* Input          : bEpNum: Endpoint Number. 
+* Return         : None.
+*******************************************************************************/
+#define _ToggleDTOG_RX(bEpNum)    (_SetENDPOINT(bEpNum, \
+                                   EP_CTR_RX|EP_CTR_TX|EP_DTOG_RX | (_GetENDPOINT(bEpNum) & EPREG_MASK)))
+#define _ToggleDTOG_TX(bEpNum)    (_SetENDPOINT(bEpNum, \
+                                   EP_CTR_RX|EP_CTR_TX|EP_DTOG_TX | (_GetENDPOINT(bEpNum) & EPREG_MASK)))
+
+/*******************************************************************************
+* Macro Name     : ClearDTOG_RX / ClearDTOG_TX.
+* Description    : Clears DTOG_RX / DTOG_TX bit in the endpoint register.
+* Input          : bEpNum: Endpoint Number. 
+* Return         : None.
+*******************************************************************************/
+#define _ClearDTOG_RX(bEpNum)  if((_GetENDPOINT(bEpNum) & EP_DTOG_RX) != 0)\
+    _ToggleDTOG_RX(bEpNum)
+#define _ClearDTOG_TX(bEpNum)  if((_GetENDPOINT(bEpNum) & EP_DTOG_TX) != 0)\
+    _ToggleDTOG_TX(bEpNum)
+/*******************************************************************************
+* Macro Name     : SetEPAddress.
+* Description    : Sets address in an endpoint register.
+* Input          : bEpNum: Endpoint Number.
+*                  bAddr: Address. 
+* Return         : None.
+*******************************************************************************/
+#define _SetEPAddress(bEpNum,bAddr) _SetENDPOINT(bEpNum,\
+    EP_CTR_RX|EP_CTR_TX|(_GetENDPOINT(bEpNum) & EPREG_MASK) | bAddr)
+
+/*******************************************************************************
+* Macro Name     : GetEPAddress.
+* Description    : Gets address in an endpoint register.
+* Input          : bEpNum: Endpoint Number.
+* Return         : None.
+*******************************************************************************/
+#define _GetEPAddress(bEpNum) ((uint8_t)(_GetENDPOINT(bEpNum) & EPADDR_FIELD))
+
+#define _pEPTxAddr(bEpNum) ((uint32_t *)((_GetBTABLE()+bEpNum*8  )*2 + PMAAddr))
+#define _pEPTxCount(bEpNum) ((uint32_t *)((_GetBTABLE()+bEpNum*8+2)*2 + PMAAddr))
+#define _pEPRxAddr(bEpNum) ((uint32_t *)((_GetBTABLE()+bEpNum*8+4)*2 + PMAAddr))
+#define _pEPRxCount(bEpNum) ((uint32_t *)((_GetBTABLE()+bEpNum*8+6)*2 + PMAAddr))
+
+/*******************************************************************************
+* Macro Name     : SetEPTxAddr / SetEPRxAddr.
+* Description    : sets address of the tx/rx buffer.
+* Input          : bEpNum: Endpoint Number.
+*                  wAddr: address to be set (must be word aligned).
+* Return         : None.
+*******************************************************************************/
+#define _SetEPTxAddr(bEpNum,wAddr) (*_pEPTxAddr(bEpNum) = ((wAddr >> 1) << 1))
+#define _SetEPRxAddr(bEpNum,wAddr) (*_pEPRxAddr(bEpNum) = ((wAddr >> 1) << 1))
+
+/*******************************************************************************
+* Macro Name     : GetEPTxAddr / GetEPRxAddr.
+* Description    : Gets address of the tx/rx buffer.
+* Input          : bEpNum: Endpoint Number.
+* Return         : address of the buffer.
+*******************************************************************************/
+#define _GetEPTxAddr(bEpNum) ((uint16_t)*_pEPTxAddr(bEpNum))
+#define _GetEPRxAddr(bEpNum) ((uint16_t)*_pEPRxAddr(bEpNum))
+
+/*******************************************************************************
+* Macro Name     : SetEPCountRxReg.
+* Description    : Sets counter of rx buffer with no. of blocks.
+* Input          : pdwReg: pointer to counter.
+*                  wCount: Counter.
+* Return         : None.
+*******************************************************************************/
+#define _BlocksOf32(dwReg,wCount,wNBlocks) {\
+    wNBlocks = wCount >> 5;\
+    if((wCount & 0x1f) == 0)\
+      wNBlocks--;\
+    *pdwReg = (uint32_t)((wNBlocks << 10) | 0x8000);\
+  }/* _BlocksOf32 */
+
+#define _BlocksOf2(dwReg,wCount,wNBlocks) {\
+    wNBlocks = wCount >> 1;\
+    if((wCount & 0x1) != 0)\
+      wNBlocks++;\
+    *pdwReg = (uint32_t)(wNBlocks << 10);\
+  }/* _BlocksOf2 */
+
+#define _SetEPCountRxReg(dwReg,wCount)  {\
+    uint16_t wNBlocks;\
+    if(wCount > 62){_BlocksOf32(dwReg,wCount,wNBlocks);}\
+    else {_BlocksOf2(dwReg,wCount,wNBlocks);}\
+  }/* _SetEPCountRxReg */
+
+#define _GetNumBlock(wCount,wValue)  {\
+    uint16_t wNBlocks;\
+    if(wCount > 62){\
+      wNBlocks = wCount >> 5;\
+      if((wCount & 0x1f) == 0) wNBlocks--;\
+      wValue = (uint32_t)((wNBlocks << 10) | 0x8000);\
+    }\
+    else {wNBlocks = wCount >> 1;\
+      if((wCount & 0x1) != 0) wNBlocks++;\
+      wValue = (uint32_t)(wNBlocks << 10);\
+    }\
+}
+
+#define _SetEPRxDblBuf0Count(bEpNum,wCount) {\
+    uint32_t *pdwReg = _pEPTxCount(bEpNum); \
+    _SetEPCountRxReg(pdwReg, wCount);\
+  }
+
+/*******************************************************************************
+* Macro Name     : SetEPTxCount / SetEPRxCount.
+* Description    : sets counter for the tx/rx buffer.
+* Input          : bEpNum: endpoint number.
+*                  wCount: Counter value.
+* Return         : None.
+*******************************************************************************/
+#define _SetEPTxCount(bEpNum,wCount) (*_pEPTxCount(bEpNum) = wCount)
+#define _SetEPRxCount(bEpNum,wCount) {\
+    uint32_t *pdwReg = _pEPRxCount(bEpNum); \
+    _SetEPCountRxReg(pdwReg, wCount);\
+    if (bEpNum == ENDP0) \
+      _GetNumBlock(Device_Property.MaxPacketSize,Ep0RxBlks);\
+  }
+
+/*******************************************************************************
+* Macro Name     : GetEPTxCount / GetEPRxCount.
+* Description    : gets counter of the tx buffer.
+* Input          : bEpNum: endpoint number.
+* Return         : Counter value.
+*******************************************************************************/
+#define _GetEPTxCount(bEpNum)((uint16_t)(*_pEPTxCount(bEpNum)) & 0x3ff)
+#define _GetEPRxCount(bEpNum)((uint16_t)(*_pEPRxCount(bEpNum)) & 0x3ff)
+
+/*******************************************************************************
+* Macro Name     : SetEPDblBuf0Addr / SetEPDblBuf1Addr.
+* Description    : Sets buffer 0/1 address in a double buffer endpoint.
+* Input          : bEpNum: endpoint number.
+*                : wBuf0Addr: buffer 0 address.
+* Output         : None.
+* Return         : None.
+*******************************************************************************/
+#define _SetEPDblBuf0Addr(bEpNum,wBuf0Addr) {_SetEPTxAddr(bEpNum, wBuf0Addr);}
+#define _SetEPDblBuf1Addr(bEpNum,wBuf1Addr) {_SetEPRxAddr(bEpNum, wBuf1Addr);}
+
+/*******************************************************************************
+* Macro Name     : SetEPDblBuffAddr.
+* Description    : Sets addresses in a double buffer endpoint.
+* Input          : bEpNum: endpoint number.
+*                : wBuf0Addr: buffer 0 address.
+*                : wBuf1Addr = buffer 1 address.
+* Return         : None.
+*******************************************************************************/
+#define _SetEPDblBuffAddr(bEpNum,wBuf0Addr,wBuf1Addr) { \
+    _SetEPDblBuf0Addr(bEpNum, wBuf0Addr);\
+    _SetEPDblBuf1Addr(bEpNum, wBuf1Addr);\
+  } /* _SetEPDblBuffAddr */
+
+/*******************************************************************************
+* Macro Name     : GetEPDblBuf0Addr / GetEPDblBuf1Addr.
+* Description    : Gets buffer 0/1 address of a double buffer endpoint.
+* Input          : bEpNum: endpoint number.
+* Return         : None.
+*******************************************************************************/
+#define _GetEPDblBuf0Addr(bEpNum) (_GetEPTxAddr(bEpNum))
+#define _GetEPDblBuf1Addr(bEpNum) (_GetEPRxAddr(bEpNum))
+
+/*******************************************************************************
+* Macro Name     : SetEPDblBuffCount / SetEPDblBuf0Count / SetEPDblBuf1Count.
+* Description    : Gets buffer 0/1 address of a double buffer endpoint.
+* Input          : bEpNum: endpoint number.
+*                : bDir: endpoint dir  EP_DBUF_OUT = OUT 
+*                                      EP_DBUF_IN  = IN 
+*                : wCount: Counter value    
+* Return         : None.
+*******************************************************************************/
+#define _SetEPDblBuf0Count(bEpNum, bDir, wCount)  { \
+    if(bDir == EP_DBUF_OUT)\
+      /* OUT endpoint */ \
+    {_SetEPRxDblBuf0Count(bEpNum,wCount);} \
+    else if(bDir == EP_DBUF_IN)\
+      /* IN endpoint */ \
+      *_pEPTxCount(bEpNum) = (uint32_t)wCount;  \
+  } /* SetEPDblBuf0Count*/
+
+#define _SetEPDblBuf1Count(bEpNum, bDir, wCount)  { \
+    if(bDir == EP_DBUF_OUT)\
+      /* OUT endpoint */ \
+    {_SetEPRxCount(bEpNum,wCount);}\
+    else if(bDir == EP_DBUF_IN)\
+      /* IN endpoint */\
+      *_pEPRxCount(bEpNum) = (uint32_t)wCount; \
+  } /* SetEPDblBuf1Count */
+
+#define _SetEPDblBuffCount(bEpNum, bDir, wCount) {\
+    _SetEPDblBuf0Count(bEpNum, bDir, wCount); \
+    _SetEPDblBuf1Count(bEpNum, bDir, wCount); \
+  } /* _SetEPDblBuffCount  */
+
+/*******************************************************************************
+* Macro Name     : GetEPDblBuf0Count / GetEPDblBuf1Count.
+* Description    : Gets buffer 0/1 rx/tx counter for double buffering.
+* Input          : bEpNum: endpoint number.
+* Return         : None.
+*******************************************************************************/
+#define _GetEPDblBuf0Count(bEpNum) (_GetEPTxCount(bEpNum))
+#define _GetEPDblBuf1Count(bEpNum) (_GetEPRxCount(bEpNum))
+
+	
+extern __IO uint16_t wIstr;  /* ISTR register last read value */
+
+
+void SetCNTR(uint16_t /*wRegValue*/);
+void SetISTR(uint16_t /*wRegValue*/);
+void SetDADDR(uint16_t /*wRegValue*/);
+void SetBTABLE(uint16_t /*wRegValue*/);
+void SetBTABLE(uint16_t /*wRegValue*/);
+uint16_t GetCNTR(void);
+uint16_t GetISTR(void);
+uint16_t GetFNR(void);
+uint16_t GetDADDR(void);
+uint16_t GetBTABLE(void);
+void SetENDPOINT(uint8_t /*bEpNum*/, uint16_t /*wRegValue*/);
+uint16_t GetENDPOINT(uint8_t /*bEpNum*/);
+void SetEPType(uint8_t /*bEpNum*/, uint16_t /*wType*/);
+uint16_t GetEPType(uint8_t /*bEpNum*/);
+void SetEPTxStatus(uint8_t /*bEpNum*/, uint16_t /*wState*/);
+void SetEPRxStatus(uint8_t /*bEpNum*/, uint16_t /*wState*/);
+void SetDouBleBuffEPStall(uint8_t /*bEpNum*/, uint8_t bDir);
+uint16_t GetEPTxStatus(uint8_t /*bEpNum*/);
+uint16_t GetEPRxStatus(uint8_t /*bEpNum*/);
+void SetEPTxValid(uint8_t /*bEpNum*/);
+void SetEPRxValid(uint8_t /*bEpNum*/);
+uint16_t GetTxStallStatus(uint8_t /*bEpNum*/);
+uint16_t GetRxStallStatus(uint8_t /*bEpNum*/);
+void SetEP_KIND(uint8_t /*bEpNum*/);
+void ClearEP_KIND(uint8_t /*bEpNum*/);
+void Set_Status_Out(uint8_t /*bEpNum*/);
+void Clear_Status_Out(uint8_t /*bEpNum*/);
+void SetEPDoubleBuff(uint8_t /*bEpNum*/);
+void ClearEPDoubleBuff(uint8_t /*bEpNum*/);
+void ClearEP_CTR_RX(uint8_t /*bEpNum*/);
+void ClearEP_CTR_TX(uint8_t /*bEpNum*/);
+void ToggleDTOG_RX(uint8_t /*bEpNum*/);
+void ToggleDTOG_TX(uint8_t /*bEpNum*/);
+void ClearDTOG_RX(uint8_t /*bEpNum*/);
+void ClearDTOG_TX(uint8_t /*bEpNum*/);
+void SetEPAddress(uint8_t /*bEpNum*/, uint8_t /*bAddr*/);
+uint8_t GetEPAddress(uint8_t /*bEpNum*/);
+void SetEPTxAddr(uint8_t /*bEpNum*/, uint16_t /*wAddr*/);
+void SetEPRxAddr(uint8_t /*bEpNum*/, uint16_t /*wAddr*/);
+uint16_t GetEPTxAddr(uint8_t /*bEpNum*/);
+uint16_t GetEPRxAddr(uint8_t /*bEpNum*/);
+void SetEPCountRxReg(uint32_t * /*pdwReg*/, uint16_t /*wCount*/);
+void SetEPTxCount(uint8_t /*bEpNum*/, uint16_t /*wCount*/);
+void SetEPRxCount(uint8_t /*bEpNum*/, uint16_t /*wCount*/);
+uint16_t GetEPTxCount(uint8_t /*bEpNum*/);
+uint16_t GetEPRxCount(uint8_t /*bEpNum*/);
+void SetEPDblBuf0Addr(uint8_t /*bEpNum*/, uint16_t /*wBuf0Addr*/);
+void SetEPDblBuf1Addr(uint8_t /*bEpNum*/, uint16_t /*wBuf1Addr*/);
+void SetEPDblBuffAddr(uint8_t /*bEpNum*/, uint16_t /*wBuf0Addr*/, uint16_t /*wBuf1Addr*/);
+uint16_t GetEPDblBuf0Addr(uint8_t /*bEpNum*/);
+uint16_t GetEPDblBuf1Addr(uint8_t /*bEpNum*/);
+void SetEPDblBuffCount(uint8_t /*bEpNum*/, uint8_t /*bDir*/, uint16_t /*wCount*/);
+void SetEPDblBuf0Count(uint8_t /*bEpNum*/, uint8_t /*bDir*/, uint16_t /*wCount*/);
+void SetEPDblBuf1Count(uint8_t /*bEpNum*/, uint8_t /*bDir*/, uint16_t /*wCount*/);
+uint16_t GetEPDblBuf0Count(uint8_t /*bEpNum*/);
+uint16_t GetEPDblBuf1Count(uint8_t /*bEpNum*/);
+EP_DBUF_DIR GetEPDblBufDir(uint8_t /*bEpNum*/);
+void FreeUserBuffer(uint8_t bEpNum/*bEpNum*/, uint8_t bDir);
+uint16_t ToWord(uint8_t, uint8_t);
+uint16_t ByteSwap(uint16_t);
+
+#ifdef __cplusplus
+}
+
+#endif
+
+#endif /* __USB_REGS_H */
+
+
+
+
+
+
+
+
+
+

--- a/Sources/source/LanaKBD/User/USBLIB/USB-Driver/inc/usb_sil.h
+++ b/Sources/source/LanaKBD/User/USBLIB/USB-Driver/inc/usb_sil.h
@@ -1,0 +1,36 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : usb_sil.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/08/08
+ * Description        : This file contains all the functions prototypes for the  
+ *                      USB Simplified Interface Layer firmware library.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/ 
+#ifndef __USB_SIL_H
+#define __USB_SIL_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#include "ch32v20x.h"
+
+uint32_t USB_SIL_Init(void);
+uint32_t USB_SIL_Write(uint8_t bEpAddr, uint8_t* pBufferPointer, uint32_t wBufferSize);
+uint32_t USB_SIL_Read(uint8_t bEpAddr, uint8_t* pBufferPointer);
+	 
+#ifdef __cplusplus
+}
+
+#endif
+
+#endif /* __USB_SIL_H */
+
+
+
+
+

--- a/Sources/source/LanaKBD/User/USBLIB/USB-Driver/inc/usb_type.h
+++ b/Sources/source/LanaKBD/User/USBLIB/USB-Driver/inc/usb_type.h
@@ -1,0 +1,33 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : usb_type.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/08/08
+ * Description        : This file contains all the functions prototypes for the  
+ *                      USB types firmware library.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/ 
+#ifndef __USB_TYPE_H
+#define __USB_TYPE_H
+#include "debug.h"
+#include "usb_conf.h"
+
+#ifndef NULL
+#define NULL ((void *)0)
+#endif
+
+typedef enum
+{
+  FALSE = 0, TRUE  = !FALSE
+}
+bool;
+
+#endif /* __USB_TYPE_H */
+
+
+
+
+

--- a/Sources/source/LanaKBD/User/USBLIB/USB-Driver/src/usb_core.c
+++ b/Sources/source/LanaKBD/User/USBLIB/USB-Driver/src/usb_core.c
@@ -1,0 +1,954 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : usb_core.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/08/08
+ * Description        : Standard protocol processing (USB v2.0)
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/ 
+#include "usb_lib.h"
+
+/* Global define */
+#define ValBit(VAR,Place)    (VAR & (1 << Place))
+#define SetBit(VAR,Place)    (VAR |= (1 << Place))
+#define ClrBit(VAR,Place)    (VAR &= ((1 << Place) ^ 255))
+#define Send0LengthData() { _SetEPTxCount(ENDP0, 0); \
+    vSetEPTxStatus(EP_TX_VALID); \
+  }
+
+#define vSetEPRxStatus(st) (SaveRState = st)
+#define vSetEPTxStatus(st) (SaveTState = st)
+
+#define USB_StatusIn() Send0LengthData()
+#define USB_StatusOut() vSetEPRxStatus(EP_RX_VALID)
+
+#define StatusInfo0 StatusInfo.bw.bb1 
+#define StatusInfo1 StatusInfo.bw.bb0
+
+uint16_t_uint8_t StatusInfo;
+
+bool Data_Mul_MaxPacketSize = FALSE;
+
+static void DataStageOut(void);
+static void DataStageIn(void);
+static void NoData_Setup0(void);
+static void Data_Setup0(void);
+
+/*********************************************************************
+ * @fn      Standard_GetConfiguration
+ *
+ * @brief   Return the current configuration variable address.
+ *
+ * @param   Length - How many bytes are needed.
+ *
+ * @return  Return 1 - if the request is invalid when "Length" is 0.
+ *          Return "Buffer" if the "Length" is not 0.
+ */
+uint8_t *Standard_GetConfiguration(uint16_t Length)
+{
+  if (Length == 0)
+  {
+    pInformation->Ctrl_Info.Usb_wLength = sizeof(pInformation->Current_Configuration);
+    return 0;
+  }
+  pUser_Standard_Requests->User_GetConfiguration();
+	
+  return (uint8_t *)&pInformation->Current_Configuration;
+}
+
+/*********************************************************************
+ * @fn      Standard_SetConfiguration
+ *
+ * @brief   This routine is called to set the configuration value
+ *          Then each class should configure device itself.
+ *
+ * @param   None.
+ *
+ * @return  Return USB_SUCCESS - if the request is performed.
+ *          Return USB_UNSUPPORT - if the request is invalid.
+ */
+RESULT Standard_SetConfiguration(void)
+{
+  if ((pInformation->USBwValue0 <=
+      Device_Table.Total_Configuration) && (pInformation->USBwValue1 == 0)
+      && (pInformation->USBwIndex == 0)) 
+  {
+    pInformation->Current_Configuration = pInformation->USBwValue0;
+    pUser_Standard_Requests->User_SetConfiguration();
+    return USB_SUCCESS;
+  }
+  else
+  {
+    return USB_UNSUPPORT;
+  }
+}
+
+/*********************************************************************
+ * @fn      Standard_GetInterface
+ *
+ * @brief   Return the Alternate Setting of the current interface.
+ *
+ * @param   Length - How many bytes are needed.
+ *
+ * @return  Return 0 - if the request is invalid when "Length" is 0.
+ *          Return "Buffer" if the "Length" is not 0.
+ */
+uint8_t *Standard_GetInterface(uint16_t Length)
+{
+  if (Length == 0)
+  {
+    pInformation->Ctrl_Info.Usb_wLength = sizeof(pInformation->Current_AlternateSetting);
+    return 0;
+  }
+  pUser_Standard_Requests->User_GetInterface();
+	
+  return (uint8_t *)&pInformation->Current_AlternateSetting;
+}
+
+/*********************************************************************
+ * @fn      Standard_SetInterface
+ *
+ * @brief   This routine is called to set the interface.
+ *          Then each class should configure the interface them self.
+ *
+ * @param   None
+ *
+ * @return  Return USB_SUCCESS - if the request is performed.
+ *          Return USB_UNSUPPORT - if the request is invalid.
+ */
+RESULT Standard_SetInterface(void)
+{
+  RESULT Re;
+  Re = (*pProperty->Class_Get_Interface_Setting)(pInformation->USBwIndex0, pInformation->USBwValue0);
+
+  if (pInformation->Current_Configuration != 0)
+  {
+    if ((Re != USB_SUCCESS) || (pInformation->USBwIndex1 != 0)
+        || (pInformation->USBwValue1 != 0))
+    {
+      return  USB_UNSUPPORT;
+    }
+    else if (Re == USB_SUCCESS)
+    {
+      pUser_Standard_Requests->User_SetInterface();
+      pInformation->Current_Interface = pInformation->USBwIndex0;
+      pInformation->Current_AlternateSetting = pInformation->USBwValue0;
+      return USB_SUCCESS;
+    }
+  }
+
+  return USB_UNSUPPORT;
+}
+
+/*********************************************************************
+ * @fn      Standard_GetStatus
+ *
+ * @brief   Copy the device request data to "StatusInfo buffer".
+ *
+ * @param   Length - How many bytes are needed.
+ *
+ * @return  Return 0 - if the request is at end of data block,
+ *          or is invalid when "Length" is 0.
+ */
+uint8_t *Standard_GetStatus(uint16_t Length)
+{
+  if (Length == 0)
+  {
+    pInformation->Ctrl_Info.Usb_wLength = 2;
+    return 0;
+  }
+  StatusInfo.w = 0;
+
+  if (Type_Recipient == (STANDARD_REQUEST | DEVICE_RECIPIENT))
+  {
+    uint8_t Feature = pInformation->Current_Feature;
+
+    if (ValBit(Feature, 5))
+    {
+      SetBit(StatusInfo0, 1);
+    }
+    else
+    {
+      ClrBit(StatusInfo0, 1);
+    }      
+    if (ValBit(Feature, 6))
+    {
+      SetBit(StatusInfo0, 0);
+    }
+    else 
+    {
+      ClrBit(StatusInfo0, 0);
+    }
+  }
+  else if (Type_Recipient == (STANDARD_REQUEST | INTERFACE_RECIPIENT))
+  {
+    return (uint8_t *)&StatusInfo;
+  }
+  else if (Type_Recipient == (STANDARD_REQUEST | ENDPOINT_RECIPIENT))
+  {
+    uint8_t Related_Endpoint;
+    uint8_t wIndex0 = pInformation->USBwIndex0;
+
+    Related_Endpoint = (wIndex0 & 0x0f);
+    if (ValBit(wIndex0, 7))
+    {
+      if (_GetTxStallStatus(Related_Endpoint))
+      {
+        SetBit(StatusInfo0, 0); 
+      }
+    }
+    else
+    {
+      if (_GetRxStallStatus(Related_Endpoint))
+      {
+        SetBit(StatusInfo0, 0); 
+      }
+    }
+
+  }
+  else
+  {
+    return NULL;
+  }
+  pUser_Standard_Requests->User_GetStatus();
+	
+  return (uint8_t *)&StatusInfo;
+}
+
+/*********************************************************************
+ * @fn      Standard_ClearFeature
+ *
+ * @brief   Clear or disable a specific feature.
+ *
+ * @return  Return USB_SUCCESS - if the request is performed.
+ *          Return USB_UNSUPPORT - if the request is invalid.
+ */
+RESULT Standard_ClearFeature(void)
+{
+  uint32_t     Type_Rec = Type_Recipient;
+  uint32_t     Status;
+	
+  if (Type_Rec == (STANDARD_REQUEST | DEVICE_RECIPIENT))
+  {
+    ClrBit(pInformation->Current_Feature, 5);
+    return USB_SUCCESS;
+  }
+  else if (Type_Rec == (STANDARD_REQUEST | ENDPOINT_RECIPIENT))
+  {
+    DEVICE* pDev;
+    uint32_t Related_Endpoint;
+    uint32_t wIndex0;
+    uint32_t rEP;
+
+    if ((pInformation->USBwValue != ENDPOINT_STALL)
+        || (pInformation->USBwIndex1 != 0))
+    {
+      return USB_UNSUPPORT;
+    }
+
+    pDev = &Device_Table;
+    wIndex0 = pInformation->USBwIndex0;
+    rEP = wIndex0 & ~0x80;
+    Related_Endpoint = ENDP0 + rEP;
+
+    if (ValBit(pInformation->USBwIndex0, 7))
+    {
+      Status = _GetEPTxStatus(Related_Endpoint);
+    }
+    else
+    {
+      Status = _GetEPRxStatus(Related_Endpoint);
+    }
+
+    if ((rEP >= pDev->Total_Endpoint) || (Status == 0)
+        || (pInformation->Current_Configuration == 0))
+    {
+      return USB_UNSUPPORT;
+    }
+
+    if (wIndex0 & 0x80)
+    {
+      if (_GetTxStallStatus(Related_Endpoint ))
+      {
+        ClearDTOG_TX(Related_Endpoint);
+        SetEPTxStatus(Related_Endpoint, EP_TX_VALID);
+      }
+    }
+    else
+    {
+      if (_GetRxStallStatus(Related_Endpoint))
+      {
+        if (Related_Endpoint == ENDP0)
+        {
+          SetEPRxCount(Related_Endpoint, Device_Property.MaxPacketSize);
+          _SetEPRxStatus(Related_Endpoint, EP_RX_VALID);
+        }
+        else
+        {
+          ClearDTOG_RX(Related_Endpoint);
+          _SetEPRxStatus(Related_Endpoint, EP_RX_VALID);
+        }
+      }
+    }
+    pUser_Standard_Requests->User_ClearFeature();
+    return USB_SUCCESS;
+  }
+
+  return USB_UNSUPPORT;
+}
+
+/*********************************************************************
+ * @fn      Standard_SetEndPointFeature
+ *
+ * @brief   Set or enable a specific feature of EndPoint
+ *
+ * @return  Return USB_SUCCESS - if the request is performed.
+ *          Return USB_UNSUPPORT - if the request is invalid.
+ */
+RESULT Standard_SetEndPointFeature(void)
+{
+  uint32_t    wIndex0;
+  uint32_t    Related_Endpoint;
+  uint32_t    rEP;
+  uint32_t    Status;
+
+  wIndex0 = pInformation->USBwIndex0;
+  rEP = wIndex0 & ~0x80;
+  Related_Endpoint = ENDP0 + rEP;
+
+  if (ValBit(pInformation->USBwIndex0, 7))
+  {
+    Status = _GetEPTxStatus(Related_Endpoint);
+  }
+  else
+  {
+    Status = _GetEPRxStatus(Related_Endpoint);
+  }
+
+  if (Related_Endpoint >= Device_Table.Total_Endpoint
+      || pInformation->USBwValue != 0 || Status == 0
+      || pInformation->Current_Configuration == 0)
+  {
+    return USB_UNSUPPORT;
+  }
+  else
+  {
+    if (wIndex0 & 0x80)
+    {
+      _SetEPTxStatus(Related_Endpoint, EP_TX_STALL);
+    }
+    else
+    {
+      _SetEPRxStatus(Related_Endpoint, EP_RX_STALL);
+    }
+  }
+  pUser_Standard_Requests->User_SetEndPointFeature();
+	
+  return USB_SUCCESS;
+}
+
+/*********************************************************************
+ * @fn      Standard_SetDeviceFeature
+ *
+ * @brief   Set or enable a specific feature of Device.
+ *
+ * @return  Return USB_SUCCESS - if the request is performed.
+ *          Return USB_UNSUPPORT - if the request is invalid.
+ */
+RESULT Standard_SetDeviceFeature(void)
+{
+  SetBit(pInformation->Current_Feature, 5);
+  pUser_Standard_Requests->User_SetDeviceFeature();
+	
+  return USB_SUCCESS;
+}
+
+/*********************************************************************
+ * @fn      Standard_GetDescriptorData
+ *
+ * @brief   This routine is used for the descriptors resident in Flash
+ *        or RAM pDesc can be in either Flash or RAM
+ *        The purpose of this routine is to have a versatile way to
+ *        response descriptors request. It allows user to generate
+ *        certain descriptors with software or read descriptors from
+ *        external storage part by part.
+ *
+ * @param   Length - Length of the data in this transfer.
+ *          pDesc - A pointer points to descriptor struct.
+ *            The structure gives the initial address of the descriptor and
+ *        its original size.
+ *
+ * @return  Address of a part of the descriptor pointed by the Usb_
+ *        wOffset The buffer pointed by this address contains at least 
+ *        Length bytes.
+ */
+uint8_t *Standard_GetDescriptorData(uint16_t Length, ONE_DESCRIPTOR *pDesc)
+{
+  uint32_t  wOffset;
+
+  wOffset = pInformation->Ctrl_Info.Usb_wOffset;
+	
+  if (Length == 0)
+  {
+    pInformation->Ctrl_Info.Usb_wLength = pDesc->Descriptor_Size - wOffset;
+    return 0;
+  }
+
+  return pDesc->Descriptor + wOffset;
+}
+
+/*********************************************************************
+ * @fn      DataStageOut
+ *
+ * @brief   Data stage of a Control Write Transfer.
+ *
+ * @return  none
+ */
+void DataStageOut(void)
+{
+  ENDPOINT_INFO *pEPinfo = &pInformation->Ctrl_Info;
+  uint32_t save_rLength;
+
+  save_rLength = pEPinfo->Usb_rLength;
+
+  if (pEPinfo->CopyData && save_rLength)
+  {
+    uint8_t *Buffer;
+    uint32_t Length;
+
+    Length = pEPinfo->PacketSize;
+		
+    if (Length > save_rLength)
+    {
+      Length = save_rLength;
+    }
+
+    Buffer = (*pEPinfo->CopyData)(Length);
+    pEPinfo->Usb_rLength -= Length;
+    pEPinfo->Usb_rOffset += Length;
+    PMAToUserBufferCopy(Buffer, GetEPRxAddr(ENDP0), Length);
+  }
+
+  if (pEPinfo->Usb_rLength != 0)
+  {
+    vSetEPRxStatus(EP_RX_VALID);
+    SetEPTxCount(ENDP0, 0);
+    vSetEPTxStatus(EP_TX_VALID);
+  }
+	
+  if (pEPinfo->Usb_rLength >= pEPinfo->PacketSize)
+  {
+    pInformation->ControlState = OUT_DATA;
+  }
+  else
+  {
+    if (pEPinfo->Usb_rLength > 0)
+    {
+      pInformation->ControlState = LAST_OUT_DATA;
+    }
+    else if (pEPinfo->Usb_rLength == 0)
+    {
+      pInformation->ControlState = WAIT_STATUS_IN;
+      USB_StatusIn();
+    }
+  }
+}
+
+/*********************************************************************
+ * @fn      DataStageIn
+ *
+ * @brief   Data stage of a Control Read Transfer.
+ *
+ * @return  none
+ */
+void DataStageIn(void)
+{
+  ENDPOINT_INFO *pEPinfo = &pInformation->Ctrl_Info;
+  uint32_t save_wLength = pEPinfo->Usb_wLength;
+  uint32_t ControlState = pInformation->ControlState;
+
+  uint8_t *DataBuffer;
+  uint32_t Length;
+
+  if ((save_wLength == 0) && (ControlState == LAST_IN_DATA))
+  {
+    if(Data_Mul_MaxPacketSize == TRUE)
+    {
+      Send0LengthData();
+      ControlState = LAST_IN_DATA;
+      Data_Mul_MaxPacketSize = FALSE;
+    }
+    else 
+    {
+      ControlState = WAIT_STATUS_OUT;
+      vSetEPTxStatus(EP_TX_STALL);
+ 
+    }
+		
+    goto Expect_Status_Out;
+  }
+
+  Length = pEPinfo->PacketSize;
+  ControlState = (save_wLength <= Length) ? LAST_IN_DATA : IN_DATA;
+
+  if (Length > save_wLength)
+  {
+    Length = save_wLength;
+  }
+
+  DataBuffer = (*pEPinfo->CopyData)(Length);
+  
+  UserToPMABufferCopy(DataBuffer, GetEPTxAddr(ENDP0), Length);
+
+  SetEPTxCount(ENDP0, Length);
+
+  pEPinfo->Usb_wLength -= Length;
+  pEPinfo->Usb_wOffset += Length;
+  vSetEPTxStatus(EP_TX_VALID);
+
+  USB_StatusOut();
+
+Expect_Status_Out:
+  pInformation->ControlState = ControlState;
+}
+
+/*********************************************************************
+ * @fn      NoData_Setup0
+ *
+ * @brief   Proceed the processing of setup request without data stage.
+ *
+ * @return  none
+ */
+void NoData_Setup0(void)
+{
+  RESULT Result = USB_UNSUPPORT;
+  uint32_t RequestNo = pInformation->USBbRequest;
+  uint32_t ControlState;
+
+  if (Type_Recipient == (STANDARD_REQUEST | DEVICE_RECIPIENT))
+  {
+    if (RequestNo == SET_CONFIGURATION)
+    {
+      Result = Standard_SetConfiguration();
+    }
+    else if (RequestNo == SET_ADDRESS)
+    {
+      if ((pInformation->USBwValue0 > 127) || (pInformation->USBwValue1 != 0)
+          || (pInformation->USBwIndex != 0)
+          || (pInformation->Current_Configuration != 0))
+      {
+        ControlState = STALLED;
+        goto exit_NoData_Setup0;
+      }
+      else
+      {
+        Result = USB_SUCCESS;
+      }
+    }
+    else if (RequestNo == SET_FEATURE)
+    {
+      if ((pInformation->USBwValue0 == DEVICE_REMOTE_WAKEUP) \
+          && (pInformation->USBwIndex == 0))
+      {
+        Result = Standard_SetDeviceFeature();
+      }
+      else
+      {
+        Result = USB_UNSUPPORT;
+      }
+    }
+    else if (RequestNo == CLEAR_FEATURE)
+    {
+      if (pInformation->USBwValue0 == DEVICE_REMOTE_WAKEUP
+          && pInformation->USBwIndex == 0
+          && ValBit(pInformation->Current_Feature, 5))
+      {
+        Result = Standard_ClearFeature();
+      }
+      else
+      {
+        Result = USB_UNSUPPORT;
+      }
+    }
+
+  }
+  else if (Type_Recipient == (STANDARD_REQUEST | INTERFACE_RECIPIENT))
+  {
+    if (RequestNo == SET_INTERFACE)
+    {
+      Result = Standard_SetInterface();
+    }
+  }
+
+  else if (Type_Recipient == (STANDARD_REQUEST | ENDPOINT_RECIPIENT))
+  {
+    if (RequestNo == CLEAR_FEATURE)
+    {
+      Result = Standard_ClearFeature();
+    }
+    else if (RequestNo == SET_FEATURE)
+    {
+      Result = Standard_SetEndPointFeature();
+    }
+  }
+  else
+  {
+    Result = USB_UNSUPPORT;
+  }
+
+  if (Result != USB_SUCCESS)
+  {
+    Result = (*pProperty->Class_NoData_Setup)(RequestNo);
+    if (Result == USB_NOT_READY)
+    {
+      ControlState = PAUSE;
+      goto exit_NoData_Setup0;
+    }
+  }
+
+  if (Result != USB_SUCCESS)
+  {
+    ControlState = STALLED;
+    goto exit_NoData_Setup0;
+  }
+
+  ControlState = WAIT_STATUS_IN;
+
+  USB_StatusIn();
+
+exit_NoData_Setup0:
+  pInformation->ControlState = ControlState;
+  return;
+}
+
+/*********************************************************************
+ * @fn      Data_Setup0
+ *
+ * @brief   Proceed the processing of setup request with data stage.
+ *
+ * @return  none
+ */
+void Data_Setup0(void)
+{
+  uint8_t *(*CopyRoutine)(uint16_t);
+  RESULT Result;
+  uint32_t Request_No = pInformation->USBbRequest;
+  uint32_t Related_Endpoint, Reserved;
+  uint32_t wOffset, Status;
+
+  CopyRoutine = NULL;
+  wOffset = 0;
+	
+  if (Request_No == GET_DESCRIPTOR)
+  {
+    if (Type_Recipient == (STANDARD_REQUEST | DEVICE_RECIPIENT))
+    {
+      uint8_t wValue1 = pInformation->USBwValue1;
+      if (wValue1 == DEVICE_DESCRIPTOR)
+      {
+        CopyRoutine = pProperty->GetDeviceDescriptor;
+      }
+      else if (wValue1 == CONFIG_DESCRIPTOR)
+      {
+        CopyRoutine = pProperty->GetConfigDescriptor;
+      }
+      else if (wValue1 == STRING_DESCRIPTOR)
+      {
+        CopyRoutine = pProperty->GetStringDescriptor;
+      } 
+    }
+  }
+  else if ((Request_No == GET_STATUS) && (pInformation->USBwValue == 0)
+           && (pInformation->USBwLength == 0x0002)
+           && (pInformation->USBwIndex1 == 0))
+  {
+  
+    if ((Type_Recipient == (STANDARD_REQUEST | DEVICE_RECIPIENT))
+        && (pInformation->USBwIndex == 0))
+    {
+      CopyRoutine = Standard_GetStatus;
+    }
+    else if (Type_Recipient == (STANDARD_REQUEST | INTERFACE_RECIPIENT))
+    {
+      if (((*pProperty->Class_Get_Interface_Setting)(pInformation->USBwIndex0, 0) == USB_SUCCESS)
+          && (pInformation->Current_Configuration != 0))
+      {
+        CopyRoutine = Standard_GetStatus;
+      }
+    }
+    else if (Type_Recipient == (STANDARD_REQUEST | ENDPOINT_RECIPIENT))
+    {
+      Related_Endpoint = (pInformation->USBwIndex0 & 0x0f);
+      Reserved = pInformation->USBwIndex0 & 0x70;
+
+      if (ValBit(pInformation->USBwIndex0, 7))
+      {
+        Status = _GetEPTxStatus(Related_Endpoint);
+      }
+      else
+      {
+        Status = _GetEPRxStatus(Related_Endpoint);
+      }
+
+      if ((Related_Endpoint < Device_Table.Total_Endpoint) && (Reserved == 0)
+          && (Status != 0))
+      {
+        CopyRoutine = Standard_GetStatus;
+      }
+    }
+
+  }
+  else if (Request_No == GET_CONFIGURATION)
+  {
+    if (Type_Recipient == (STANDARD_REQUEST | DEVICE_RECIPIENT))
+    {
+      CopyRoutine = Standard_GetConfiguration;
+    }
+  }
+  else if (Request_No == GET_INTERFACE)
+  {
+    if ((Type_Recipient == (STANDARD_REQUEST | INTERFACE_RECIPIENT))
+        && (pInformation->Current_Configuration != 0) && (pInformation->USBwValue == 0)
+        && (pInformation->USBwIndex1 == 0) && (pInformation->USBwLength == 0x0001)
+        && ((*pProperty->Class_Get_Interface_Setting)(pInformation->USBwIndex0, 0) == USB_SUCCESS))
+    {
+      CopyRoutine = Standard_GetInterface;
+    }
+
+  }
+  
+  if (CopyRoutine)
+  {
+    pInformation->Ctrl_Info.Usb_wOffset = wOffset;
+    pInformation->Ctrl_Info.CopyData = CopyRoutine;
+    (*CopyRoutine)(0);
+    Result = USB_SUCCESS;
+  }
+  else
+  {
+    Result = (*pProperty->Class_Data_Setup)(pInformation->USBbRequest);
+		
+    if (Result == USB_NOT_READY)
+    {
+      pInformation->ControlState = PAUSE;
+      return;
+    }
+  }
+
+  if (pInformation->Ctrl_Info.Usb_wLength == 0xFFFF)
+  {
+    pInformation->ControlState = PAUSE;
+    return;
+  }
+	
+  if ((Result == USB_UNSUPPORT) || (pInformation->Ctrl_Info.Usb_wLength == 0))
+  {
+    pInformation->ControlState = STALLED;
+    return;
+  }
+
+  if (ValBit(pInformation->USBbmRequestType, 7))
+  {
+    __IO uint32_t wLength = pInformation->USBwLength;
+    if (pInformation->Ctrl_Info.Usb_wLength > wLength)
+    {
+      pInformation->Ctrl_Info.Usb_wLength = wLength;
+    } 
+    else if (pInformation->Ctrl_Info.Usb_wLength < pInformation->USBwLength)
+    {
+      if (pInformation->Ctrl_Info.Usb_wLength < pProperty->MaxPacketSize)
+      {
+        Data_Mul_MaxPacketSize = FALSE;
+      }
+      else if ((pInformation->Ctrl_Info.Usb_wLength % pProperty->MaxPacketSize) == 0)
+      {
+        Data_Mul_MaxPacketSize = TRUE;
+      }
+    }   
+
+    pInformation->Ctrl_Info.PacketSize = pProperty->MaxPacketSize;
+    DataStageIn();
+  }
+  else
+  {
+    pInformation->ControlState = OUT_DATA;
+    vSetEPRxStatus(EP_RX_VALID); 
+  }
+
+  return;
+}
+
+/*********************************************************************
+ * @fn      Setup0_Process
+ *
+ * @brief   Get the device request data and dispatch to individual process.
+ *
+ * @return  Post0_Process.
+ */
+uint8_t Setup0_Process(void)
+{
+  union
+  {
+    uint8_t* b;
+    uint16_t* w;
+  } pBuf;
+  uint16_t offset = 1;
+  
+  pBuf.b = PMAAddr + (uint8_t *)(_GetEPRxAddr(ENDP0) * 2); /* *2 for 32 bits addr */
+
+  if (pInformation->ControlState != PAUSE)
+  {
+    pInformation->USBbmRequestType = *pBuf.b++; /* bmRequestType */
+    pInformation->USBbRequest = *pBuf.b++; /* bRequest */
+    pBuf.w += offset;  /* word not accessed because of 32 bits addressing */
+    pInformation->USBwValue = ByteSwap(*pBuf.w++); /* wValue */
+    pBuf.w += offset;  /* word not accessed because of 32 bits addressing */
+    pInformation->USBwIndex  = ByteSwap(*pBuf.w++); /* wIndex */
+    pBuf.w += offset;  /* word not accessed because of 32 bits addressing */
+    pInformation->USBwLength = *pBuf.w; /* wLength */
+  }
+  pInformation->ControlState = SETTING_UP;
+	
+  if (pInformation->USBwLength == 0)
+  {
+    NoData_Setup0();
+  }
+  else
+  {
+    Data_Setup0();
+  }
+  return Post0_Process();
+}
+
+/*********************************************************************
+ * @fn      In0_Process
+ *
+ * @brief   Process the IN token on all default endpoint.
+ *
+ * @return  none
+ */
+uint8_t In0_Process(void)
+{
+  uint32_t ControlState = pInformation->ControlState;
+
+  if ((ControlState == IN_DATA) || (ControlState == LAST_IN_DATA))
+  {
+    DataStageIn();
+    ControlState = pInformation->ControlState;
+  }
+  else if (ControlState == WAIT_STATUS_IN)
+  {
+    if ((pInformation->USBbRequest == SET_ADDRESS) &&
+        (Type_Recipient == (STANDARD_REQUEST | DEVICE_RECIPIENT)))
+    {
+      SetDeviceAddress(pInformation->USBwValue0);
+      pUser_Standard_Requests->User_SetDeviceAddress();
+    }
+    (*pProperty->Process_Status_IN)();
+    ControlState = STALLED;
+  }
+  else
+  {
+    ControlState = STALLED;
+  }
+
+  pInformation->ControlState = ControlState;
+
+  return Post0_Process();
+}
+
+/*********************************************************************
+ * @fn      Out0_Process
+ *
+ * @brief   Process the OUT token on all default endpoint.
+ *
+ * @return  none
+ */
+uint8_t Out0_Process(void)
+{
+  uint32_t ControlState = pInformation->ControlState;
+
+  if ((ControlState == IN_DATA) || (ControlState == LAST_IN_DATA))
+  {
+    ControlState = STALLED;
+  }
+  else if ((ControlState == OUT_DATA) || (ControlState == LAST_OUT_DATA))
+  {
+    DataStageOut();
+    ControlState = pInformation->ControlState; 
+  }
+  else if (ControlState == WAIT_STATUS_OUT)
+  {
+    (*pProperty->Process_Status_OUT)();
+    ControlState = STALLED;
+  }
+  else
+  {
+    ControlState = STALLED;
+  }
+
+  pInformation->ControlState = ControlState;
+
+  return Post0_Process();
+}
+
+/*********************************************************************
+ * @fn      Post0_Process
+ *
+ * @brief   Stall the Endpoint 0 in case of error.
+ *
+ * @return  0 - if the control State is in PAUSE
+ *          1 - if not.
+ */
+uint8_t Post0_Process(void)
+{  
+  SetEPRxCount(ENDP0, Device_Property.MaxPacketSize);
+
+  if (pInformation->ControlState == STALLED)
+  {
+    vSetEPRxStatus(EP_RX_STALL);
+    vSetEPTxStatus(EP_TX_STALL);
+  }
+
+  return (pInformation->ControlState == PAUSE);
+}
+
+/*********************************************************************
+ * @fn      SetDeviceAddress
+ *
+ * @brief   Set the device and all the used Endpoints addresses.
+ *
+ * @param   Val - device address.
+ *
+ * @return  none
+ */
+void SetDeviceAddress(uint8_t Val)
+{
+  uint32_t i;
+  uint32_t nEP = Device_Table.Total_Endpoint;
+	
+  for (i = 0; i < nEP; i++)
+  {
+    _SetEPAddress((uint8_t)i, (uint8_t)i);
+  } 
+	
+  _SetDADDR(Val | DADDR_EF); 
+}
+
+/*********************************************************************
+ * @fn      NOP_Process
+ *
+ * @brief   No operation function.
+ *
+ * @return  none
+ */
+void NOP_Process(void)
+{
+}
+
+
+
+

--- a/Sources/source/LanaKBD/User/USBLIB/USB-Driver/src/usb_init.c
+++ b/Sources/source/LanaKBD/User/USBLIB/USB-Driver/src/usb_init.c
@@ -1,0 +1,42 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : usb_init.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/08/08
+ * Description        : Initialization routines & global variables
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/ 
+#include "usb_lib.h"
+
+uint8_t	EPindex;
+DEVICE_INFO *pInformation;
+DEVICE_PROP *pProperty;
+uint16_t	SaveState ;
+uint16_t  wInterrupt_Mask;
+DEVICE_INFO	Device_Info;
+USER_STANDARD_REQUESTS  *pUser_Standard_Requests;
+
+/*******************************************************************************
+ * @fn        USB_Init
+ *
+ * @brief     USB system initialization
+ *
+ * @return    None.
+ *
+ */
+void USB_Init(void)
+{
+  pInformation = &Device_Info;
+  pInformation->ControlState = 2;
+  pProperty = &Device_Property;
+  pUser_Standard_Requests = &User_Standard_Requests;
+  pProperty->Init();
+}
+
+
+
+
+

--- a/Sources/source/LanaKBD/User/USBLIB/USB-Driver/src/usb_int.c
+++ b/Sources/source/LanaKBD/User/USBLIB/USB-Driver/src/usb_int.c
@@ -1,0 +1,133 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : usb_int.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/08/08
+ * Description        : Endpoint CTR (Low and High) interrupt's service routines
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/ 
+#include "usb_lib.h"
+
+/* Private variables */
+__IO uint16_t SaveRState;
+__IO uint16_t SaveTState;
+
+/* Extern variables */
+extern void (*pEpInt_IN[7])(void);    /*  Handles IN  interrupts   */
+extern void (*pEpInt_OUT[7])(void);   /*  Handles OUT interrupts   */
+
+/*******************************************************************************
+ * @fn       CTR_LP.
+ *
+ * @brief    Low priority Endpoint Correct Transfer interrupt's service
+ *                  routine.
+ *
+ * @return  None.
+ */
+void CTR_LP(void)
+{
+  __IO uint16_t wEPVal = 0;
+	
+  while (((wIstr = _GetISTR()) & ISTR_CTR) != 0)
+  {
+    EPindex = (uint8_t)(wIstr & ISTR_EP_ID);
+		
+    if (EPindex == 0)
+    {
+	    SaveRState = _GetENDPOINT(ENDP0);
+	    SaveTState = SaveRState & EPTX_STAT;
+	    SaveRState &=  EPRX_STAT;	
+
+	    _SetEPRxTxStatus(ENDP0,EP_RX_NAK,EP_TX_NAK);
+			
+      if ((wIstr & ISTR_DIR) == 0)
+      {
+        _ClearEP_CTR_TX(ENDP0);
+        In0_Process();
+
+        _SetEPRxTxStatus(ENDP0,SaveRState,SaveTState);
+				
+				return;
+      }
+      else
+      {
+        wEPVal = _GetENDPOINT(ENDP0);
+        
+        if ((wEPVal &EP_SETUP) != 0)
+        {
+          _ClearEP_CTR_RX(ENDP0);
+          Setup0_Process();
+		      _SetEPRxTxStatus(ENDP0,SaveRState,SaveTState);
+					
+          return;
+        }
+        else if ((wEPVal & EP_CTR_RX) != 0)
+        {
+          _ClearEP_CTR_RX(ENDP0);
+          Out0_Process();
+		     _SetEPRxTxStatus(ENDP0,SaveRState,SaveTState);
+					
+          return;
+        }
+      }
+    }
+    else
+    {
+      wEPVal = _GetENDPOINT(EPindex);
+      if ((wEPVal & EP_CTR_RX) != 0)
+      {
+        _ClearEP_CTR_RX(EPindex);
+        (*pEpInt_OUT[EPindex-1])();
+      } 
+
+      if ((wEPVal & EP_CTR_TX) != 0)
+      {
+        _ClearEP_CTR_TX(EPindex);     
+        (*pEpInt_IN[EPindex-1])();
+      }
+    }
+  }
+}
+
+/*******************************************************************************
+ * @fn        CTR_HP.
+ *
+ * @brief     High Priority Endpoint Correct Transfer interrupt's service 
+ *                  routine.
+ *
+ * @return    None.
+ */
+void CTR_HP(void)
+{
+  uint32_t wEPVal = 0;
+
+  while (((wIstr = _GetISTR()) & ISTR_CTR) != 0)
+  {
+    _SetISTR((uint16_t)CLR_CTR); 
+    EPindex = (uint8_t)(wIstr & ISTR_EP_ID);   
+    wEPVal = _GetENDPOINT(EPindex);
+		
+    if ((wEPVal & EP_CTR_RX) != 0)
+    {
+      _ClearEP_CTR_RX(EPindex); 
+      (*pEpInt_OUT[EPindex-1])();
+    } 
+    else if ((wEPVal & EP_CTR_TX) != 0)
+    {
+      _ClearEP_CTR_TX(EPindex);   
+      (*pEpInt_IN[EPindex-1])();
+    } 
+  }
+}
+
+
+
+
+
+
+
+
+

--- a/Sources/source/LanaKBD/User/USBLIB/USB-Driver/src/usb_mem.c
+++ b/Sources/source/LanaKBD/User/USBLIB/USB-Driver/src/usb_mem.c
@@ -1,0 +1,74 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : usb_mem.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/08/08
+ * Description        : Utility functions for memory transfers to/from PMA
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/ 
+#include "usb_lib.h"
+
+
+/*******************************************************************************
+ * @fn           UserToPMABufferCopy
+ *
+ * @brief        Copy a buffer from user memory area to packet memory area (PMA)
+ *
+ * @param        pbUsrBuf: pointer to user memory area.
+ *                  wPMABufAddr: address into PMA.
+ *                  wNBytes: no. of bytes to be copied.
+ *
+ * @param        None	.
+ */
+void UserToPMABufferCopy(uint8_t *pbUsrBuf, uint16_t wPMABufAddr, uint16_t wNBytes)
+{
+  uint32_t n = (wNBytes + 1) >> 1;   
+  uint32_t i, temp1, temp2;
+  uint16_t *pdwVal;
+  pdwVal = (uint16_t *)(wPMABufAddr * 2 + PMAAddr);
+	
+  for (i = n; i != 0; i--)
+  {
+    temp1 = (uint16_t) * pbUsrBuf;
+    pbUsrBuf++;
+    temp2 = temp1 | (uint16_t) * pbUsrBuf << 8;
+    *pdwVal++ = temp2;
+    pdwVal++;
+    pbUsrBuf++;
+  }
+}
+
+/*******************************************************************************
+ * @fn          PMAToUserBufferCopy
+ *
+ * @brief       Copy a buffer from user memory area to packet memory area (PMA)
+ *
+ * @param       pbUsrBuf: pointer to user memory area.
+ *                  wPMABufAddr: address into PMA.
+ *                  wNBytes:  no. of bytes to be copied.
+ *
+ * @param       None. 
+ */
+void PMAToUserBufferCopy(uint8_t *pbUsrBuf, uint16_t wPMABufAddr, uint16_t wNBytes)
+{
+  uint32_t n = (wNBytes + 1) >> 1;
+  uint32_t i;
+  uint32_t *pdwVal;
+	
+  pdwVal = (uint32_t *)(wPMABufAddr * 2 + PMAAddr);
+	
+  for (i = n; i != 0; i--)
+  {
+    *(uint16_t*)pbUsrBuf++ = *pdwVal++;
+    pbUsrBuf++;
+  } 
+}
+
+
+
+
+
+

--- a/Sources/source/LanaKBD/User/USBLIB/USB-Driver/src/usb_regs.c
+++ b/Sources/source/LanaKBD/User/USBLIB/USB-Driver/src/usb_regs.c
@@ -1,0 +1,852 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : usb_regs.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/08/08
+ * Description        : Interface functions to USB cell registers
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/ 
+#include "usb_lib.h"
+
+/*******************************************************************************
+ * @fn         SetCNTR.
+ *
+ * @brief      Set the CNTR register value.
+ *
+ * @param      wRegValue: new register value.
+ *
+ * @return     None.
+ */
+void SetCNTR(uint16_t wRegValue)
+{
+  _SetCNTR(wRegValue);
+}
+
+/*******************************************************************************
+ * @fn         GetCNTR.
+ *
+ * @brief      returns the CNTR register value.
+ *
+ * @param      None.
+ *
+ * @return     CNTR register Value.
+ */
+uint16_t GetCNTR(void)
+{
+  return(_GetCNTR());
+}
+
+/*******************************************************************************
+ * @fn        SetISTR.
+ *
+ * @brief     Set the ISTR register value.
+ *
+ * @param     wRegValue: new register value.
+ *
+ * @return    None.
+ */
+void SetISTR(uint16_t wRegValue)
+{
+  _SetISTR(wRegValue);
+}
+
+/*******************************************************************************
+ * @fn        GetISTR
+ *
+ * @brief     Returns the ISTR register value.
+ *
+ * @param     None.
+ *
+ * @return   ISTR register Value
+ */
+uint16_t GetISTR(void)
+{
+  return(_GetISTR());
+}
+
+/*******************************************************************************
+ * @fn        GetFNR
+ *
+ * @brief     Returns the FNR register value.
+ *
+ * @param    None.
+ *
+ * @return    FNR register Value
+ */
+uint16_t GetFNR(void)
+{
+  return(_GetFNR());
+}
+
+/*******************************************************************************
+ * @fn        SetDADDR
+ *
+ * @brief     Set the DADDR register value.
+ *
+ * @param     wRegValue: new register value.
+ * 
+ * @return   None.
+ */
+void SetDADDR(uint16_t wRegValue)
+{
+  _SetDADDR(wRegValue);
+}
+
+/*******************************************************************************
+ * @fn          GetDADDR
+ *
+ * @brief       Returns the DADDR register value.
+ *
+ * @return     DADDR register Value
+ *
+ */
+uint16_t GetDADDR(void)
+{
+  return(_GetDADDR());
+}
+
+/*******************************************************************************
+ * @fn       SetBTABLE
+ *
+ * @brief    Set the BTABLE.
+ *
+ * @param    wRegValue: New register value.
+ *
+ * @return   None.
+ */
+void SetBTABLE(uint16_t wRegValue)
+{
+  _SetBTABLE(wRegValue);
+}
+
+/*******************************************************************************
+ * @fn      GetBTABLE.
+ *
+ * @param   Returns the BTABLE register value.
+ *
+ * @return  BTABLE address.
+ */
+uint16_t GetBTABLE(void)
+{
+  return(_GetBTABLE());
+}
+
+/*******************************************************************************
+ * @fn        SetENDPOINT
+ *
+ * @brief     Set the Endpoint register value.
+ *
+ * @param     bEpNum: Endpoint Number. 
+ *                  wRegValue.
+ *
+ * @return   None.
+ */
+void SetENDPOINT(uint8_t bEpNum, uint16_t wRegValue)
+{
+  _SetENDPOINT(bEpNum, wRegValue);
+}
+
+/*******************************************************************************
+ * @fn        GetENDPOINT
+ *
+ * @brief     Return the Endpoint register value.
+ *
+ * @param     bEpNum: Endpoint Number. 
+ *
+ * @return   Endpoint register value.
+ */
+uint16_t GetENDPOINT(uint8_t bEpNum)
+{
+  return(_GetENDPOINT(bEpNum));
+}
+
+/*******************************************************************************
+ * @fn       SetEPType
+ *
+ * @brief    sets the type in the endpoint register.
+ *
+ * @param    bEpNum: Endpoint Number. 
+ *                  wType: type definition.
+ *
+ * @return   None.
+ */
+void SetEPType(uint8_t bEpNum, uint16_t wType)
+{
+  _SetEPType(bEpNum, wType);
+}
+
+/*******************************************************************************
+ * @fn        GetEPType
+ *
+ * @brief     Returns the endpoint type.
+ *
+ * @param     bEpNum: Endpoint Number. 
+ *
+ * @return    Endpoint Type
+ */
+uint16_t GetEPType(uint8_t bEpNum)
+{
+  return(_GetEPType(bEpNum));
+}
+
+/*******************************************************************************
+ * @fn       SetEPTxStatus
+ *
+ * @brief    Set the status of Tx endpoint.
+ *
+ * @param    bEpNum: Endpoint Number. 
+ *                  wState: new state.
+ *
+ * @return    None.
+ */
+void SetEPTxStatus(uint8_t bEpNum, uint16_t wState)
+{
+  _SetEPTxStatus(bEpNum, wState);
+}
+
+/*******************************************************************************
+ * @fn         SetEPRxStatus
+ *
+ * @brief      Set the status of Rx endpoint.
+ *
+ * @param      bEpNum: Endpoint Number. 
+ *                  wState: new state.
+ *
+ * @return    None.
+ */
+void SetEPRxStatus(uint8_t bEpNum, uint16_t wState)
+{
+  _SetEPRxStatus(bEpNum, wState);
+}
+
+/*******************************************************************************
+ * @fn        SetDouBleBuffEPStall
+ *
+ * @brief     sets the status for Double Buffer Endpoint to STALL
+ *
+ * @param     bEpNum: Endpoint Number. 
+ *                  bDir: Endpoint direction.
+ *
+ * @return   None.
+ */
+void SetDouBleBuffEPStall(uint8_t bEpNum, uint8_t bDir)
+{
+  uint16_t Endpoint_DTOG_Status;
+	
+  Endpoint_DTOG_Status = GetENDPOINT(bEpNum);
+	
+  if (bDir == EP_DBUF_OUT)
+  { 
+    _SetENDPOINT(bEpNum, Endpoint_DTOG_Status & ~EPRX_DTOG1);
+  }
+  else if (bDir == EP_DBUF_IN)
+  { 
+    _SetENDPOINT(bEpNum, Endpoint_DTOG_Status & ~EPTX_DTOG1);
+  }
+}
+
+/*******************************************************************************
+ * @fn       GetEPTxStatus
+ *
+ * @brief    Returns the endpoint Tx status.
+ *
+ * @param   bEpNum: Endpoint Number. 
+ *
+ * @return  Endpoint TX Status
+ */
+uint16_t GetEPTxStatus(uint8_t bEpNum)
+{
+  return(_GetEPTxStatus(bEpNum));
+}
+
+/*******************************************************************************
+ * @fn       GetEPRxStatus
+ *
+ * @brief    Returns the endpoint Rx status.
+ *
+ * @param    bEpNum: Endpoint Number. 
+ *
+ * @return   Endpoint RX Status
+ */
+uint16_t GetEPRxStatus(uint8_t bEpNum)
+{
+  return(_GetEPRxStatus(bEpNum));
+}
+
+/*******************************************************************************
+ * @fn       SetEPTxValid
+ *
+ * @brief    Valid the endpoint Tx Status.
+ *
+ * @param    bEpNum: Endpoint Number.  
+ *
+ * @return   None.
+ */
+void SetEPTxValid(uint8_t bEpNum)
+{
+  _SetEPTxStatus(bEpNum, EP_TX_VALID);
+}
+
+/*******************************************************************************
+ * @fn         SetEPRxValid
+ *
+ * @brief      Valid the endpoint Rx Status.
+ *
+ * @param      bEpNum: Endpoint Number. 
+ *
+ * @return    None.
+ */
+void SetEPRxValid(uint8_t bEpNum)
+{
+  _SetEPRxStatus(bEpNum, EP_RX_VALID);
+}
+
+/*******************************************************************************
+ * @fn       SetEP_KIND
+ *
+ * @brief    Clear the EP_KIND bit.
+ *
+ * @param    bEpNum: Endpoint Number. 
+ *
+ * @return   None.
+ */
+void SetEP_KIND(uint8_t bEpNum)
+{
+  _SetEP_KIND(bEpNum);
+}
+
+/*******************************************************************************
+ * @fn       ClearEP_KIND
+ *
+ * @brief    set the  EP_KIND bit.
+ *
+ * @param    bEpNum: Endpoint Number. 
+ * 
+ * @return  None.
+ */
+void ClearEP_KIND(uint8_t bEpNum)
+{
+  _ClearEP_KIND(bEpNum);
+}
+/*******************************************************************************
+ * @fn      Clear_Status_Out
+ *
+ * @brief   Clear the Status Out of the related Endpoint
+ *
+ * @param   bEpNum: Endpoint Number. 
+ *
+ * @return  None.
+ */
+void Clear_Status_Out(uint8_t bEpNum)
+{
+  _ClearEP_KIND(bEpNum);
+}
+/*******************************************************************************
+ * @fn       Set_Status_Out
+ *
+ * @brief   Set the Status Out of the related Endpoint
+ *
+ * @param   bEpNum: Endpoint Number. 
+ *
+ * @return  None.
+ */
+void Set_Status_Out(uint8_t bEpNum)
+{
+  _SetEP_KIND(bEpNum);
+}
+/*******************************************************************************
+ * @fn       SetEPDoubleBuff
+ *
+ * @brief    Enable the double buffer feature for the endpoint. 
+ *
+ * @param    bEpNum: Endpoint Number. 
+ *
+ * @return   None.
+ */
+void SetEPDoubleBuff(uint8_t bEpNum)
+{
+  _SetEP_KIND(bEpNum);
+}
+/*******************************************************************************
+ * @fn      ClearEPDoubleBuff
+ *
+ * @brief  Disable the double buffer feature for the endpoint. 
+ *
+ * @param  bEpNum: Endpoint Number. 
+ *
+ * @return None.
+ */
+void ClearEPDoubleBuff(uint8_t bEpNum)
+{
+  _ClearEP_KIND(bEpNum);
+}
+/*******************************************************************************
+ * @fn      GetTxStallStatus
+ *
+ * @brief    Returns the Stall status of the Tx endpoint.
+ *
+ * @param   bEpNum: Endpoint Number. 
+ *
+ * @return  Tx Stall status.
+ */
+uint16_t GetTxStallStatus(uint8_t bEpNum)
+{
+  return(_GetTxStallStatus(bEpNum));
+}
+/*******************************************************************************
+ * @fn       GetRxStallStatus
+ *
+ * @brief    Returns the Stall status of the Rx endpoint. 
+ *
+ * @param   bEpNum: Endpoint Number. 
+ *
+ * @return  Rx Stall status.
+ */
+uint16_t GetRxStallStatus(uint8_t bEpNum)
+{
+  return(_GetRxStallStatus(bEpNum));
+}
+/*******************************************************************************
+ * @fn      ClearEP_CTR_RX
+ *
+ * @brief   Clear the CTR_RX bit.
+ *
+ * @param   bEpNum: Endpoint Number. 
+ *
+ * @return  None.
+ */
+void ClearEP_CTR_RX(uint8_t bEpNum)
+{
+  _ClearEP_CTR_RX(bEpNum);
+}
+/*******************************************************************************
+ * @fn         ClearEP_CTR_TX
+ *
+ * @brief      Clear the CTR_TX bit.
+ *
+ * @param      bEpNum: Endpoint Number. 
+ *
+ * @return     None.
+ */
+void ClearEP_CTR_TX(uint8_t bEpNum)
+{
+  _ClearEP_CTR_TX(bEpNum);
+}
+/*******************************************************************************
+ * @fn        ToggleDTOG_RX
+ *
+ * @brief     Toggle the DTOG_RX bit.
+ *
+ * @param     bEpNum: Endpoint Number. 
+ *
+ * @return    None.
+ */
+void ToggleDTOG_RX(uint8_t bEpNum)
+{
+  _ToggleDTOG_RX(bEpNum);
+}
+/*******************************************************************************
+ * @fn        ToggleDTOG_TX
+ *
+ * @brief     Toggle the DTOG_TX bit.
+ *
+ * @param      bEpNum: Endpoint Number. 
+ *
+ * @return   None.
+ */
+void ToggleDTOG_TX(uint8_t bEpNum)
+{
+  _ToggleDTOG_TX(bEpNum);
+}
+/*******************************************************************************
+ * @fn        ClearDTOG_RX.
+ *  
+ * @brief      Clear the DTOG_RX bit.
+ *
+ * @param      bEpNum: Endpoint Number. 
+ *
+ * @return     None.
+ */
+void ClearDTOG_RX(uint8_t bEpNum)
+{
+  _ClearDTOG_RX(bEpNum);
+}
+/*******************************************************************************
+ * @fn         ClearDTOG_TX.
+ *
+ * @brief      Clear the DTOG_TX bit.
+ *
+ * @param      bEpNum: Endpoint Number. 
+ *
+ * @return     None.
+ */
+void ClearDTOG_TX(uint8_t bEpNum)
+{
+  _ClearDTOG_TX(bEpNum);
+}
+/*******************************************************************************
+ * @fn        SetEPAddress
+ *
+ * @brief     Set the endpoint address.
+ *
+ * @param    bEpNum: Endpoint Number.
+ *                  bAddr: New endpoint address.
+ *
+ * @return     None.
+ */
+void SetEPAddress(uint8_t bEpNum, uint8_t bAddr)
+{
+  _SetEPAddress(bEpNum, bAddr);
+}
+/*******************************************************************************
+ * @fn        GetEPAddress
+ *
+ * @brief     Get the endpoint address.
+ *
+ * @param     bEpNum: Endpoint Number. 
+ *
+ * @return    Endpoint address.
+ */
+uint8_t GetEPAddress(uint8_t bEpNum)
+{
+  return(_GetEPAddress(bEpNum));
+}
+/*******************************************************************************
+ * @fn        SetEPTxAddr
+ *
+ * @brief     Set the endpoint Tx buffer address.
+ *
+ * @param      bEpNum: Endpoint Number.
+ *                  wAddr: new address. 
+ *
+ * @return   None.
+ */
+void SetEPTxAddr(uint8_t bEpNum, uint16_t wAddr)
+{
+  _SetEPTxAddr(bEpNum, wAddr);
+}
+/*******************************************************************************
+ * @fn        SetEPRxAddr
+ *
+ * @brief     Set the endpoint Rx buffer address.
+ *
+ * @param    bEpNum: Endpoint Number.
+ *                  wAddr: new address.
+ *
+ * @return  None.
+ */
+void SetEPRxAddr(uint8_t bEpNum, uint16_t wAddr)
+{
+  _SetEPRxAddr(bEpNum, wAddr);
+}
+/*******************************************************************************
+ * @fn      GetEPTxAddr
+ *
+ * @brief  Returns the endpoint Tx buffer address.
+ *
+ * @param  bEpNum: Endpoint Number. 
+ *
+ * @return Rx buffer address. 
+ */
+uint16_t GetEPTxAddr(uint8_t bEpNum)
+{
+  return(_GetEPTxAddr(bEpNum));
+}
+/*******************************************************************************
+ * @fn          GetEPRxAddr.
+ *
+ * @brief       Returns the endpoint Rx buffer address.
+ *
+ * @param       bEpNum: Endpoint Number. 
+ *
+ * @returnRx   buffer address.
+ */
+uint16_t GetEPRxAddr(uint8_t bEpNum)
+{
+  return(_GetEPRxAddr(bEpNum));
+}
+/*******************************************************************************
+ * @fn        SetEPTxCount.
+ *
+ * @brief     Set the Tx count.
+ *
+ * @param     bEpNum: Endpoint Number.
+ *                  wCount: new count value.
+ *
+ * @return    None.
+ */
+void SetEPTxCount(uint8_t bEpNum, uint16_t wCount)
+{
+  _SetEPTxCount(bEpNum, wCount);
+}
+/*******************************************************************************
+ * @fn          SetEPCountRxReg.
+ *
+ * @brief       Set the Count Rx Register value.
+ *
+ * @param       *pdwReg: point to the register.
+ *                  wCount: the new register value.
+ *
+ * @return      None.
+ */
+void SetEPCountRxReg(uint32_t *pdwReg, uint16_t wCount)
+{
+  _SetEPCountRxReg(dwReg, wCount);
+}
+/*******************************************************************************
+ * @fn        SetEPRxCount
+ *
+ * @brief     Set the Rx count.
+ *
+ * @param      bEpNum: Endpoint Number. 
+ *                    wCount: the new count value.
+ *
+ * @return    None.
+ */
+void SetEPRxCount(uint8_t bEpNum, uint16_t wCount)
+{
+  _SetEPRxCount(bEpNum, wCount);
+}
+/*******************************************************************************
+ * @fn       GetEPTxCount
+ *
+ * @brief    Get the Tx count.
+ *
+ * @param     bEpNum: Endpoint Number. 
+ *
+ * @return    Tx count value.
+ */
+uint16_t GetEPTxCount(uint8_t bEpNum)
+{
+  return(_GetEPTxCount(bEpNum));
+}
+/*******************************************************************************
+ * @fn        GetEPRxCount
+ * 
+ * @brief    Get the Rx count.
+ *
+ * @param     bEpNum: Endpoint Number. 
+ *
+ * @return    Rx count value.
+ */
+uint16_t GetEPRxCount(uint8_t bEpNum)
+{
+  return(_GetEPRxCount(bEpNum));
+}
+/*******************************************************************************
+ * @fn        SetEPDblBuffAddr
+ *
+ * @brief     Set the addresses of the buffer 0 and 1.
+ *
+ * @param      bEpNum: Endpoint Number.  
+ *                  wBuf0Addr: new address of buffer 0. 
+ *                  wBuf1Addr: new address of buffer 1.
+ *
+ * @return    None.
+ */
+void SetEPDblBuffAddr(uint8_t bEpNum, uint16_t wBuf0Addr, uint16_t wBuf1Addr)
+{
+  _SetEPDblBuffAddr(bEpNum, wBuf0Addr, wBuf1Addr);
+}
+/*******************************************************************************
+ * @fn       SetEPDblBuf0Addr
+ *
+ * @brief    Set the Buffer 1 address.
+ *
+ * @param     bEpNum: Endpoint Number
+ *                  wBuf0Addr: new address.
+ *
+ * @return    None.
+ */
+void SetEPDblBuf0Addr(uint8_t bEpNum, uint16_t wBuf0Addr)
+{
+  _SetEPDblBuf0Addr(bEpNum, wBuf0Addr);
+}
+/*******************************************************************************
+ * @fn       SetEPDblBuf1Addr
+ *
+ * @brief    Set the Buffer 1 address.
+ *
+ * @param    bEpNum: Endpoint Number
+ *                  wBuf1Addr: new address.
+ *
+ * @return   None.
+ */
+void SetEPDblBuf1Addr(uint8_t bEpNum, uint16_t wBuf1Addr)
+{
+  _SetEPDblBuf1Addr(bEpNum, wBuf1Addr);
+}
+/*******************************************************************************
+ * @fn       GetEPDblBuf0Addr
+ *
+ * @brief     Returns the address of the Buffer 0.
+ *
+ * @param     bEpNum: Endpoint Number.
+ *
+ * @return   None.
+ */
+uint16_t GetEPDblBuf0Addr(uint8_t bEpNum)
+{
+  return(_GetEPDblBuf0Addr(bEpNum));
+}
+/*******************************************************************************
+ * @fn       GetEPDblBuf1Addr
+ *
+ * @brief    Returns the address of the Buffer 1.
+ *
+ * @param    bEpNum: Endpoint Number.
+ *
+ * @return   Address of the Buffer 1.
+ */
+uint16_t GetEPDblBuf1Addr(uint8_t bEpNum)
+{
+  return(_GetEPDblBuf1Addr(bEpNum));
+}
+/*******************************************************************************
+ * @fn           SetEPDblBuffCount
+ *
+ * @brief        Set the number of bytes for a double Buffer 
+ *                  endpoint.
+ *
+ * @param       bEpNum,bDir, wCount
+ *
+ * @return     None.
+ */
+void SetEPDblBuffCount(uint8_t bEpNum, uint8_t bDir, uint16_t wCount)
+{
+  _SetEPDblBuffCount(bEpNum, bDir, wCount);
+}
+/*******************************************************************************
+ * @fn    SetEPDblBuf0Count
+ *
+ * @brief  Set the number of bytes in the buffer 0 of a double Buffer 
+ *                   endpoint.
+ *
+ * @param  bEpNum, bDir,  wCount
+ *
+ * @return  None.
+ */
+void SetEPDblBuf0Count(uint8_t bEpNum, uint8_t bDir, uint16_t wCount)
+{
+  _SetEPDblBuf0Count(bEpNum, bDir, wCount);
+}
+/*******************************************************************************
+ * @fn       SetEPDblBuf1Count
+ *
+ * @brief   Set the number of bytes in the buffer 0 of a double Buffer 
+*                  endpoint.
+ *
+ * @param    bEpNum,  bDir,  wCount
+ *
+ * @return   None.
+ */
+void SetEPDblBuf1Count(uint8_t bEpNum, uint8_t bDir, uint16_t wCount)
+{
+  _SetEPDblBuf1Count(bEpNum, bDir, wCount);
+}
+/*******************************************************************************
+ * @fn     GetEPDblBuf0Count
+ *
+ * @brief  Returns the number of byte received in the buffer 0 of a double
+ *                  Buffer endpoint.
+ *
+ * @param  bEpNum: Endpoint Number.
+ *
+ * @return Endpoint Buffer 0 count
+ */
+uint16_t GetEPDblBuf0Count(uint8_t bEpNum)
+{
+  return(_GetEPDblBuf0Count(bEpNum));
+}
+/*******************************************************************************
+ * @fn   GetEPDblBuf1Count
+ *
+ * @brief  Returns the number of data received in the buffer 1 of a double
+ *                  Buffer endpoint.
+ *
+ * @param bEpNum: Endpoint Number.
+ *
+ * @return Endpoint Buffer 1 count.
+ */
+uint16_t GetEPDblBuf1Count(uint8_t bEpNum)
+{
+  return(_GetEPDblBuf1Count(bEpNum));
+}
+/*******************************************************************************
+ * @fn       GetEPDblBufDir
+ *
+ * @brief    gets direction of the double buffered endpoint
+ *
+ * @param     bEpNum: Endpoint Number. 
+ *
+ * @return   EP_DBUF_OUT, EP_DBUF_IN,
+ *                  EP_DBUF_ERR if the endpoint counter not yet programmed.
+ */
+EP_DBUF_DIR GetEPDblBufDir(uint8_t bEpNum)
+{
+  if ((uint16_t)(*_pEPRxCount(bEpNum) & 0xFC00) != 0)
+    return(EP_DBUF_OUT);
+  else if (((uint16_t)(*_pEPTxCount(bEpNum)) & 0x03FF) != 0)
+    return(EP_DBUF_IN);
+  else
+    return(EP_DBUF_ERR);
+}
+/*******************************************************************************
+ * @fn         FreeUserBuffer
+ *
+ * @brief      free buffer used from the application realizing it to the line
+                   toggles bit SW_BUF in the double buffered endpoint register
+ *
+ * @param      bEpNum, bDir
+ *
+ * @return    None.
+ */
+void FreeUserBuffer(uint8_t bEpNum, uint8_t bDir)
+{
+  if (bDir == EP_DBUF_OUT)
+  {
+    _ToggleDTOG_TX(bEpNum);
+  }
+  else if (bDir == EP_DBUF_IN)
+  { 
+    _ToggleDTOG_RX(bEpNum);
+  }
+}
+
+/*******************************************************************************
+ * @fn        ToWord
+ *
+ * @brief     merge two byte in a word.
+ *
+ * @param      bh: byte high, bl: bytes low.
+ *
+ * @return   resulted word.
+ */
+uint16_t ToWord(uint8_t bh, uint8_t bl)
+{
+  uint16_t wRet;
+  wRet = (uint16_t)bl | ((uint16_t)bh << 8);
+	
+  return(wRet);
+}
+/*******************************************************************************
+ * @fn         ByteSwap
+ *  
+ * @brief     Swap two byte in a word.
+ *
+ * @param     wSwW: word to Swap.
+ *
+ * @return    resulted word.
+ */
+uint16_t ByteSwap(uint16_t wSwW)
+{
+  uint8_t bTemp;
+  uint16_t wRet;
+  bTemp = (uint8_t)(wSwW & 0xff);
+  wRet =  (wSwW >> 8) | ((uint16_t)bTemp << 8);
+	
+  return(wRet);
+}

--- a/Sources/source/LanaKBD/User/USBLIB/USB-Driver/src/usb_sil.c
+++ b/Sources/source/LanaKBD/User/USBLIB/USB-Driver/src/usb_sil.c
@@ -1,0 +1,77 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : usb_sil.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/08/08
+ * Description        : Simplified Interface Layer for Global Initialization and 
+ *			           Endpoint  Rea/Write operations.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/ 
+#include "usb_lib.h"
+
+
+/*******************************************************************************
+ * @fn         USB_SIL_Init
+ *
+ * @brief      Initialize the USB Device IP and the Endpoint 0.
+ *
+ * @return   Status.
+ */
+uint32_t USB_SIL_Init(void)
+{
+  _SetISTR(0);
+  wInterrupt_Mask = IMR_MSK;
+  _SetCNTR(wInterrupt_Mask);
+	
+  return 0;
+}
+
+/*******************************************************************************
+ * @fn                USB_SIL_Write
+ *
+ * @brief           Write a buffer of data to a selected endpoint.
+ *
+ * @param          bEpAddr: The address of the non control endpoint.
+ *                  pBufferPointer: The pointer to the buffer of data to be written
+ *                     to the endpoint.
+ *                  wBufferSize: Number of data to be written (in bytes).
+ *
+ * @return         Status.
+ */
+uint32_t USB_SIL_Write(uint8_t bEpAddr, uint8_t* pBufferPointer, uint32_t wBufferSize)
+{
+  UserToPMABufferCopy(pBufferPointer, GetEPTxAddr(bEpAddr & 0x7F), wBufferSize);
+  SetEPTxCount((bEpAddr & 0x7F), wBufferSize);
+  
+  return 0;
+}
+
+/*******************************************************************************
+ * @fn       USB_SIL_Read
+ *
+ * @brief     Write a buffer of data to a selected endpoint.
+ *
+ * @param    bEpAddr: The address of the non control endpoint.
+ *                  pBufferPointer: The pointer to which will be saved the 
+ *             received data buffer.
+ *
+ * @return     Number of received data (in Bytes).
+ */
+uint32_t USB_SIL_Read(uint8_t bEpAddr, uint8_t* pBufferPointer)
+{
+  uint32_t DataLength = 0;
+
+  DataLength = GetEPRxCount(bEpAddr & 0x7F); 
+  PMAToUserBufferCopy(pBufferPointer, GetEPRxAddr(bEpAddr & 0x7F), DataLength);
+
+  return DataLength;
+}
+
+
+
+
+
+

--- a/Sources/source/LanaKBD/User/ch32v20x_conf.h
+++ b/Sources/source/LanaKBD/User/ch32v20x_conf.h
@@ -1,0 +1,29 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : ch32v20x_conf.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/06/06
+ * Description        : Library configuration file.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __CH32V20x_CONF_H
+#define __CH32V20x_CONF_H
+
+#include "ch32v20x_exti.h"
+#include "ch32v20x_gpio.h"
+#include "ch32v20x_i2c.h"
+#include "ch32v20x_rcc.h"
+#include "ch32v20x_tim.h"
+#include "ch32v20x_usart.h"
+#include "ch32v20x_misc.h"
+
+
+#endif /* __CH32V20x_CONF_H */
+
+
+	
+	
+	

--- a/Sources/source/LanaKBD/User/ch32v20x_it.c
+++ b/Sources/source/LanaKBD/User/ch32v20x_it.c
@@ -1,0 +1,42 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : ch32v20x_it.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/06/06
+ * Description        : Main Interrupt Service Routines.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#include "ch32v20x_it.h"
+
+void NMI_Handler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+void HardFault_Handler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+
+/*********************************************************************
+ * @fn      NMI_Handler
+ *
+ * @brief   This function handles NMI exception.
+ *
+ * @return  none
+ */
+void NMI_Handler(void)
+{
+}
+
+/*********************************************************************
+ * @fn      HardFault_Handler
+ *
+ * @brief   This function handles Hard Fault exception.
+ *
+ * @return  none
+ */
+void HardFault_Handler(void)
+{
+  while (1)
+  {
+  }
+}
+
+

--- a/Sources/source/LanaKBD/User/ch32v20x_it.h
+++ b/Sources/source/LanaKBD/User/ch32v20x_it.h
@@ -1,0 +1,20 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : ch32v20x_it.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/06/06
+ * Description        : This file contains the headers of the interrupt handlers.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __CH32V20x_IT_H
+#define __CH32V20x_IT_H
+
+#include "debug.h"
+
+
+#endif /* __CH32V20x_IT_H */
+
+

--- a/Sources/source/LanaKBD/User/system_ch32v20x.c
+++ b/Sources/source/LanaKBD/User/system_ch32v20x.c
@@ -1,0 +1,986 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : system_ch32v20x.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/06/06
+ * Description        : CH32V20x Device Peripheral Access Layer System Source File.
+ *                      For HSE = 32Mhz (CH32V208x/CH32V203RBT6)
+ *                      For HSE = 8Mhz (other CH32V203x)
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#include "ch32v20x.h" 
+
+/* 
+* Uncomment the line corresponding to the desired System clock (SYSCLK) frequency (after 
+* reset the HSI is used as SYSCLK source).
+* If none of the define below is enabled, the HSI is used as System clock source. 
+*/
+//#define SYSCLK_FREQ_HSE    HSE_VALUE
+//#define SYSCLK_FREQ_48MHz_HSE  48000000
+//#define SYSCLK_FREQ_56MHz_HSE  56000000
+//#define SYSCLK_FREQ_72MHz_HSE  72000000
+//#define SYSCLK_FREQ_96MHz_HSE  96000000
+//#define SYSCLK_FREQ_120MHz_HSE  120000000
+//#define SYSCLK_FREQ_144MHz_HSE  144000000
+//#define SYSCLK_FREQ_HSI    HSI_VALUE
+#define SYSCLK_FREQ_48MHz_HSI  48000000
+//#define SYSCLK_FREQ_56MHz_HSI  56000000
+//#define SYSCLK_FREQ_72MHz_HSI  72000000
+//#define SYSCLK_FREQ_96MHz_HSI  96000000
+//#define SYSCLK_FREQ_120MHz_HSI  120000000
+//#define SYSCLK_FREQ_144MHz_HSI  144000000
+
+/* Clock Definitions */
+#ifdef SYSCLK_FREQ_HSE
+uint32_t SystemCoreClock         = SYSCLK_FREQ_HSE;              /* System Clock Frequency (Core Clock) */
+#elif defined SYSCLK_FREQ_48MHz_HSE
+uint32_t SystemCoreClock         = SYSCLK_FREQ_48MHz_HSE;        /* System Clock Frequency (Core Clock) */
+#elif defined SYSCLK_FREQ_56MHz_HSE
+uint32_t SystemCoreClock         = SYSCLK_FREQ_56MHz_HSE;        /* System Clock Frequency (Core Clock) */
+#elif defined SYSCLK_FREQ_72MHz_HSE
+uint32_t SystemCoreClock         = SYSCLK_FREQ_72MHz_HSE;        /* System Clock Frequency (Core Clock) */
+#elif defined SYSCLK_FREQ_96MHz_HSE
+uint32_t SystemCoreClock         = SYSCLK_FREQ_96MHz_HSE;        /* System Clock Frequency (Core Clock) */
+#elif defined SYSCLK_FREQ_120MHz_HSE
+uint32_t SystemCoreClock         = SYSCLK_FREQ_120MHz_HSE;        /* System Clock Frequency (Core Clock) */
+#elif defined SYSCLK_FREQ_144MHz_HSE
+uint32_t SystemCoreClock         = SYSCLK_FREQ_144MHz_HSE;        /* System Clock Frequency (Core Clock) */
+#elif defined SYSCLK_FREQ_48MHz_HSI
+uint32_t SystemCoreClock         = SYSCLK_FREQ_48MHz_HSI;        /* System Clock Frequency (Core Clock) */
+#elif defined SYSCLK_FREQ_56MHz_HSI
+uint32_t SystemCoreClock         = SYSCLK_FREQ_56MHz_HSI;        /* System Clock Frequency (Core Clock) */
+#elif defined SYSCLK_FREQ_72MHz_HSI
+uint32_t SystemCoreClock         = SYSCLK_FREQ_72MHz_HSI;        /* System Clock Frequency (Core Clock) */
+#elif defined SYSCLK_FREQ_96MHz_HSI
+uint32_t SystemCoreClock         = SYSCLK_FREQ_96MHz_HSI;        /* System Clock Frequency (Core Clock) */
+#elif defined SYSCLK_FREQ_120MHz_HSI
+uint32_t SystemCoreClock         = SYSCLK_FREQ_120MHz_HSI;        /* System Clock Frequency (Core Clock) */
+#elif defined SYSCLK_FREQ_144MHz_HSI
+uint32_t SystemCoreClock         = SYSCLK_FREQ_144MHz_HSI;        /* System Clock Frequency (Core Clock) */
+#else
+uint32_t SystemCoreClock         = HSI_VALUE;                    /* System Clock Frequency (Core Clock) */
+
+#endif
+
+__I uint8_t AHBPrescTable[16] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 6, 7, 8, 9};
+
+
+/* system_private_function_proto_types */
+static void SetSysClock(void);
+
+#ifdef SYSCLK_FREQ_HSE
+static void SetSysClockToHSE( void );
+#elif defined SYSCLK_FREQ_48MHz_HSE
+static void SetSysClockTo48_HSE( void );
+#elif defined SYSCLK_FREQ_56MHz_HSE
+static void SetSysClockTo56_HSE( void );
+#elif defined SYSCLK_FREQ_72MHz_HSE
+static void SetSysClockTo72_HSE( void );
+#elif defined SYSCLK_FREQ_96MHz_HSE
+static void SetSysClockTo96_HSE( void );
+#elif defined SYSCLK_FREQ_120MHz_HSE
+static void SetSysClockTo120_HSE( void );
+#elif defined SYSCLK_FREQ_144MHz_HSE
+static void SetSysClockTo144_HSE( void );
+#elif defined SYSCLK_FREQ_48MHz_HSI
+static void SetSysClockTo48_HSI( void );
+#elif defined SYSCLK_FREQ_56MHz_HSI
+static void SetSysClockTo56_HSI( void );
+#elif defined SYSCLK_FREQ_72MHz_HSI
+static void SetSysClockTo72_HSI( void );
+#elif defined SYSCLK_FREQ_96MHz_HSI
+static void SetSysClockTo96_HSI( void );
+#elif defined SYSCLK_FREQ_120MHz_HSI
+static void SetSysClockTo120_HSI( void );
+#elif defined SYSCLK_FREQ_144MHz_HSI
+static void SetSysClockTo144_HSI( void );
+
+#endif
+
+/*********************************************************************
+ * @fn      SystemInit
+ *
+ * @brief   Setup the microcontroller system Initialize the Embedded Flash Interface,
+ *        the PLL and update the SystemCoreClock variable.
+ *
+ * @return  none
+ */
+void SystemInit (void)
+{
+  RCC->CTLR |= (uint32_t)0x00000001;
+  RCC->CFGR0 &= (uint32_t)0xF8FF0000;
+  RCC->CTLR &= (uint32_t)0xFEF6FFFF;
+  RCC->CTLR &= (uint32_t)0xFFFBFFFF;
+  RCC->CFGR0 &= (uint32_t)0xFF80FFFF;
+  RCC->INTR = 0x009F0000;    
+  SetSysClock();
+}
+
+
+/*********************************************************************
+ * @fn      SystemCoreClockUpdate
+ *
+ * @brief   Update SystemCoreClock variable according to Clock Register Values.
+ *
+ * @return  none
+ */
+void SystemCoreClockUpdate (void)
+{
+  uint32_t tmp = 0, pllmull = 0, pllsource = 0, Pll_6_5 = 0;
+
+  tmp = RCC->CFGR0 & RCC_SWS;
+
+  switch (tmp)
+  {
+    case 0x00:
+      SystemCoreClock = HSI_VALUE;
+      break;
+    case 0x04:
+      SystemCoreClock = HSE_VALUE;
+      break;
+    case 0x08:
+      pllmull = RCC->CFGR0 & RCC_PLLMULL;
+      pllsource = RCC->CFGR0 & RCC_PLLSRC;
+      pllmull = ( pllmull >> 18) + 2;
+
+      if(pllmull == 17) pllmull = 18;
+
+      if (pllsource == 0x00)
+      {
+          if(EXTEN->EXTEN_CTR & EXTEN_PLL_HSI_PRE){
+              SystemCoreClock = HSI_VALUE * pllmull;
+          }
+          else{
+              SystemCoreClock = (HSI_VALUE >> 1) * pllmull;
+          }
+      }
+      else
+      {
+#if defined (CH32V20x_D8W)
+        if((RCC->CFGR0 & (3<<22)) == (3<<22))
+        {
+          SystemCoreClock = ((HSE_VALUE>>1)) * pllmull;
+        }
+        else
+#endif
+        if ((RCC->CFGR0 & RCC_PLLXTPRE) != (uint32_t)RESET)
+        {
+#if defined (CH32V20x_D8) || defined (CH32V20x_D8W)
+          SystemCoreClock = ((HSE_VALUE>>2) >> 1) * pllmull;
+#else
+          SystemCoreClock = (HSE_VALUE >> 1) * pllmull;
+#endif
+        }
+        else
+        {
+#if defined (CH32V20x_D8) || defined (CH32V20x_D8W)
+            SystemCoreClock = (HSE_VALUE>>2) * pllmull;
+#else
+          SystemCoreClock = HSE_VALUE * pllmull;
+#endif
+        }
+      }
+
+      if(Pll_6_5 == 1) SystemCoreClock = (SystemCoreClock / 2);
+
+      break;
+    default:
+      SystemCoreClock = HSI_VALUE;
+      break;
+  }
+
+  tmp = AHBPrescTable[((RCC->CFGR0 & RCC_HPRE) >> 4)];
+  SystemCoreClock >>= tmp;
+}
+
+/*********************************************************************
+ * @fn      SetSysClock
+ *
+ * @brief   Configures the System clock frequency, HCLK, PCLK2 and PCLK1 prescalers.
+ *
+ * @return  none
+ */
+static void SetSysClock(void)
+{
+#ifdef SYSCLK_FREQ_HSE
+    SetSysClockToHSE();
+#elif defined SYSCLK_FREQ_48MHz_HSE
+    SetSysClockTo48_HSE();
+#elif defined SYSCLK_FREQ_56MHz_HSE
+    SetSysClockTo56_HSE();
+#elif defined SYSCLK_FREQ_72MHz_HSE
+    SetSysClockTo72_HSE();
+#elif defined SYSCLK_FREQ_96MHz_HSE
+    SetSysClockTo96_HSE();
+#elif defined SYSCLK_FREQ_120MHz_HSE
+    SetSysClockTo120_HSE();
+#elif defined SYSCLK_FREQ_144MHz_HSE
+    SetSysClockTo144_HSE();
+#elif defined SYSCLK_FREQ_48MHz_HSI
+    SetSysClockTo48_HSI();
+#elif defined SYSCLK_FREQ_56MHz_HSI
+    SetSysClockTo56_HSI();
+#elif defined SYSCLK_FREQ_72MHz_HSI
+    SetSysClockTo72_HSI();
+#elif defined SYSCLK_FREQ_96MHz_HSI
+    SetSysClockTo96_HSI();
+#elif defined SYSCLK_FREQ_120MHz_HSI
+    SetSysClockTo120_HSI();
+#elif defined SYSCLK_FREQ_144MHz_HSI
+    SetSysClockTo144_HSI();
+
+#endif
+ 
+ /* If none of the define above is enabled, the HSI is used as System clock
+  * source (default after reset) 
+	*/ 
+}
+
+
+#ifdef SYSCLK_FREQ_HSE
+
+/*********************************************************************
+ * @fn      SetSysClockToHSE
+ *
+ * @brief   Sets HSE as System clock source and configure HCLK, PCLK2 and PCLK1 prescalers.
+ *
+ * @return  none
+ */
+static void SetSysClockToHSE(void)
+{
+  __IO uint32_t StartUpCounter = 0, HSEStatus = 0;
+  
+   
+  RCC->CTLR |= ((uint32_t)RCC_HSEON);
+ 
+  /* Wait till HSE is ready and if Time out is reached exit */
+  do
+  {
+    HSEStatus = RCC->CTLR & RCC_HSERDY;
+    StartUpCounter++;  
+  } while((HSEStatus == 0) && (StartUpCounter != HSE_STARTUP_TIMEOUT));
+
+  if ((RCC->CTLR & RCC_HSERDY) != RESET)
+  {
+    HSEStatus = (uint32_t)0x01;
+  }
+  else
+  {
+    HSEStatus = (uint32_t)0x00;
+  }  
+
+  if (HSEStatus == (uint32_t)0x01)
+  {
+    /* HCLK = SYSCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_HPRE_DIV1;      
+    /* PCLK2 = HCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_PPRE2_DIV1;
+    /* PCLK1 = HCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_PPRE1_DIV1;
+    
+    /* Select HSE as system clock source
+     *  CH32V20x_D6 (HSE=8MHZ)
+     *  CH32V20x_D8 (HSE=32MHZ)
+     *  CH32V20x_D8W (HSE=32MHZ)
+     */
+    RCC->CFGR0 &= (uint32_t)((uint32_t)~(RCC_SW));
+    RCC->CFGR0 |= (uint32_t)RCC_SW_HSE;    
+
+    /* Wait till HSE is used as system clock source */
+    while ((RCC->CFGR0 & (uint32_t)RCC_SWS) != (uint32_t)0x04)
+    {
+    }
+  }
+  else
+  { 
+		/* If HSE fails to start-up, the application will have wrong clock 
+     * configuration. User can add here some code to deal with this error 
+		 */
+  }  
+}
+
+#elif defined SYSCLK_FREQ_48MHz_HSE
+
+/*********************************************************************
+ * @fn      SetSysClockTo48_HSE
+ *
+ * @brief   Sets System clock frequency to 48MHz and configure HCLK, PCLK2 and PCLK1 prescalers.
+ *
+ * @return  none
+ */
+static void SetSysClockTo48_HSE(void)
+{
+  __IO uint32_t StartUpCounter = 0, HSEStatus = 0;
+     
+   
+  RCC->CTLR |= ((uint32_t)RCC_HSEON);
+  /* Wait till HSE is ready and if Time out is reached exit */
+  do
+  {
+    HSEStatus = RCC->CTLR & RCC_HSERDY;
+    StartUpCounter++;  
+  } while((HSEStatus == 0) && (StartUpCounter != HSE_STARTUP_TIMEOUT));
+
+  if ((RCC->CTLR & RCC_HSERDY) != RESET)
+  {
+    HSEStatus = (uint32_t)0x01;
+  }
+  else
+  {
+    HSEStatus = (uint32_t)0x00;
+  }  
+
+  if (HSEStatus == (uint32_t)0x01)
+  {
+    /* HCLK = SYSCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_HPRE_DIV1;    
+    /* PCLK2 = HCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_PPRE2_DIV1;  
+    /* PCLK1 = HCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_PPRE1_DIV2;
+
+    /*  CH32V20x_D6-PLL configuration: PLLCLK = HSE * 6 = 48 MHz (HSE=8MHZ)
+     *  CH32V20x_D8-PLL configuration: PLLCLK = HSE/4 * 6 = 48 MHz (HSE=32MHZ)
+     *  CH32V20x_D8W-PLL configuration: PLLCLK = HSE/4 * 6 = 48 MHz (HSE=32MHZ)
+     */
+    RCC->CFGR0 &= (uint32_t)((uint32_t)~(RCC_PLLSRC | RCC_PLLXTPRE | RCC_PLLMULL));
+
+     RCC->CFGR0 |= (uint32_t)(RCC_PLLSRC_HSE | RCC_PLLXTPRE_HSE | RCC_PLLMULL6);
+
+    /* Enable PLL */
+    RCC->CTLR |= RCC_PLLON;
+    /* Wait till PLL is ready */
+    while((RCC->CTLR & RCC_PLLRDY) == 0)
+    {
+    }
+    /* Select PLL as system clock source */
+    RCC->CFGR0 &= (uint32_t)((uint32_t)~(RCC_SW));
+    RCC->CFGR0 |= (uint32_t)RCC_SW_PLL;    
+    /* Wait till PLL is used as system clock source */
+    while ((RCC->CFGR0 & (uint32_t)RCC_SWS) != (uint32_t)0x08)
+    {
+    }
+  }
+  else
+  { 
+		/* 
+		 * If HSE fails to start-up, the application will have wrong clock 
+     * configuration. User can add here some code to deal with this error 
+		 */
+  } 
+}
+
+#elif defined SYSCLK_FREQ_56MHz_HSE
+
+/*********************************************************************
+ * @fn      SetSysClockTo56_HSE
+ *
+ * @brief   Sets System clock frequency to 56MHz and configure HCLK, PCLK2 and PCLK1 prescalers.
+ *
+ * @return  none
+ */
+static void SetSysClockTo56_HSE(void)
+{
+  __IO uint32_t StartUpCounter = 0, HSEStatus = 0;
+     
+  RCC->CTLR |= ((uint32_t)RCC_HSEON);
+
+  /* Wait till HSE is ready and if Time out is reached exit */
+  do
+  {
+    HSEStatus = RCC->CTLR & RCC_HSERDY;
+    StartUpCounter++;  
+  } while((HSEStatus == 0) && (StartUpCounter != HSE_STARTUP_TIMEOUT));
+
+  if ((RCC->CTLR & RCC_HSERDY) != RESET)
+  {
+    HSEStatus = (uint32_t)0x01;
+  }
+  else
+  {
+    HSEStatus = (uint32_t)0x00;
+  }  
+
+  if (HSEStatus == (uint32_t)0x01)
+  {
+    /* HCLK = SYSCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_HPRE_DIV1;   
+    /* PCLK2 = HCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_PPRE2_DIV1;
+    /* PCLK1 = HCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_PPRE1_DIV2;
+  
+    /*  CH32V20x_D6-PLL configuration: PLLCLK = HSE * 7 = 56 MHz (HSE=8MHZ)
+     *  CH32V20x_D8-PLL configuration: PLLCLK = HSE/4 * 7 = 56 MHz (HSE=32MHZ)
+     *  CH32V20x_D8W-PLL configuration: PLLCLK = HSE/4 * 7 = 56 MHz (HSE=32MHZ)
+     */
+    RCC->CFGR0 &= (uint32_t)((uint32_t)~(RCC_PLLSRC | RCC_PLLXTPRE | RCC_PLLMULL));
+
+    RCC->CFGR0 |= (uint32_t)(RCC_PLLSRC_HSE | RCC_PLLXTPRE_HSE | RCC_PLLMULL7);
+
+    /* Enable PLL */
+    RCC->CTLR |= RCC_PLLON;
+    /* Wait till PLL is ready */
+    while((RCC->CTLR & RCC_PLLRDY) == 0)
+    {
+    }
+
+    /* Select PLL as system clock source */
+    RCC->CFGR0 &= (uint32_t)((uint32_t)~(RCC_SW));
+    RCC->CFGR0 |= (uint32_t)RCC_SW_PLL;    
+    /* Wait till PLL is used as system clock source */
+    while ((RCC->CFGR0 & (uint32_t)RCC_SWS) != (uint32_t)0x08)
+    {
+    }
+  }
+  else
+  { 
+		/* 
+		 * If HSE fails to start-up, the application will have wrong clock 
+     * configuration. User can add here some code to deal with this error 
+		 */
+  } 
+}
+
+#elif defined SYSCLK_FREQ_72MHz_HSE
+
+/*********************************************************************
+ * @fn      SetSysClockTo72_HSE
+ *
+ * @brief   Sets System clock frequency to 72MHz and configure HCLK, PCLK2 and PCLK1 prescalers.
+ *
+ * @return  none
+ */
+static void SetSysClockTo72_HSE(void)
+{
+  __IO uint32_t StartUpCounter = 0, HSEStatus = 0;
+     
+  RCC->CTLR |= ((uint32_t)RCC_HSEON);
+ 
+  /* Wait till HSE is ready and if Time out is reached exit */
+  do
+  {
+    HSEStatus = RCC->CTLR & RCC_HSERDY;
+    StartUpCounter++;  
+  } while((HSEStatus == 0) && (StartUpCounter != HSE_STARTUP_TIMEOUT));
+
+  if ((RCC->CTLR & RCC_HSERDY) != RESET)
+  {
+    HSEStatus = (uint32_t)0x01;
+  }
+  else
+  {
+    HSEStatus = (uint32_t)0x00;
+  }  
+
+  if (HSEStatus == (uint32_t)0x01)
+  {
+    /* HCLK = SYSCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_HPRE_DIV1; 
+    /* PCLK2 = HCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_PPRE2_DIV1; 
+    /* PCLK1 = HCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_PPRE1_DIV2;
+ 
+    /*  CH32V20x_D6-PLL configuration: PLLCLK = HSE * 9 = 72 MHz (HSE=8MHZ)
+     *  CH32V20x_D8-PLL configuration: PLLCLK = HSE/4 * 9 = 72 MHz (HSE=32MHZ)
+     *  CH32V20x_D8W-PLL configuration: PLLCLK = HSE/4 * 9 = 72 MHz (HSE=32MHZ)
+     */
+    RCC->CFGR0 &= (uint32_t)((uint32_t)~(RCC_PLLSRC | RCC_PLLXTPRE |
+                                        RCC_PLLMULL));
+
+    RCC->CFGR0 |= (uint32_t)(RCC_PLLSRC_HSE | RCC_PLLXTPRE_HSE | RCC_PLLMULL9);
+
+    /* Enable PLL */
+    RCC->CTLR |= RCC_PLLON;
+    /* Wait till PLL is ready */
+    while((RCC->CTLR & RCC_PLLRDY) == 0)
+    {
+    }    
+    /* Select PLL as system clock source */
+    RCC->CFGR0 &= (uint32_t)((uint32_t)~(RCC_SW));
+    RCC->CFGR0 |= (uint32_t)RCC_SW_PLL;    
+    /* Wait till PLL is used as system clock source */
+    while ((RCC->CFGR0 & (uint32_t)RCC_SWS) != (uint32_t)0x08)
+    {
+    }
+  }
+  else
+  { 
+		/* 
+		 * If HSE fails to start-up, the application will have wrong clock 
+     * configuration. User can add here some code to deal with this error 
+		 */
+  }
+}
+
+
+#elif defined SYSCLK_FREQ_96MHz_HSE
+
+/*********************************************************************
+ * @fn      SetSysClockTo96_HSE
+ *
+ * @brief   Sets System clock frequency to 96MHz and configure HCLK, PCLK2 and PCLK1 prescalers.
+ *
+ * @return  none
+ */
+static void SetSysClockTo96_HSE(void)
+{
+  __IO uint32_t StartUpCounter = 0, HSEStatus = 0;
+
+  RCC->CTLR |= ((uint32_t)RCC_HSEON);
+
+  /* Wait till HSE is ready and if Time out is reached exit */
+  do
+  {
+    HSEStatus = RCC->CTLR & RCC_HSERDY;
+    StartUpCounter++;
+  } while((HSEStatus == 0) && (StartUpCounter != HSE_STARTUP_TIMEOUT));
+
+  if ((RCC->CTLR & RCC_HSERDY) != RESET)
+  {
+    HSEStatus = (uint32_t)0x01;
+  }
+  else
+  {
+    HSEStatus = (uint32_t)0x00;
+  }
+
+  if (HSEStatus == (uint32_t)0x01)
+  {
+    /* HCLK = SYSCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_HPRE_DIV1;
+    /* PCLK2 = HCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_PPRE2_DIV1;
+    /* PCLK1 = HCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_PPRE1_DIV2;
+
+    /*  CH32V20x_D6-PLL configuration: PLLCLK = HSE * 12 = 96 MHz (HSE=8MHZ)
+     *  CH32V20x_D8-PLL configuration: PLLCLK = HSE/4 * 12 = 96 MHz (HSE=32MHZ)
+     *  CH32V20x_D8W-PLL configuration: PLLCLK = HSE/4 * 12 = 96 MHz (HSE=32MHZ)
+     */
+    RCC->CFGR0 &= (uint32_t)((uint32_t)~(RCC_PLLSRC | RCC_PLLXTPRE |
+                                        RCC_PLLMULL));
+
+    RCC->CFGR0 |= (uint32_t)(RCC_PLLSRC_HSE | RCC_PLLXTPRE_HSE | RCC_PLLMULL12);
+
+    /* Enable PLL */
+    RCC->CTLR |= RCC_PLLON;
+    /* Wait till PLL is ready */
+    while((RCC->CTLR & RCC_PLLRDY) == 0)
+    {
+    }
+    /* Select PLL as system clock source */
+    RCC->CFGR0 &= (uint32_t)((uint32_t)~(RCC_SW));
+    RCC->CFGR0 |= (uint32_t)RCC_SW_PLL;
+    /* Wait till PLL is used as system clock source */
+    while ((RCC->CFGR0 & (uint32_t)RCC_SWS) != (uint32_t)0x08)
+    {
+    }
+  }
+  else
+  {
+        /*
+         * If HSE fails to start-up, the application will have wrong clock
+     * configuration. User can add here some code to deal with this error
+         */
+  }
+}
+
+
+#elif defined SYSCLK_FREQ_120MHz_HSE
+
+/*********************************************************************
+ * @fn      SetSysClockTo120_HSE
+ *
+ * @brief   Sets System clock frequency to 120MHz and configure HCLK, PCLK2 and PCLK1 prescalers.
+ *
+ * @return  none
+ */
+static void SetSysClockTo120_HSE(void)
+{
+    __IO uint32_t StartUpCounter = 0, HSEStatus = 0;
+
+    RCC->CTLR |= ((uint32_t)RCC_HSEON);
+
+    /* Wait till HSE is ready and if Time out is reached exit */
+    do
+    {
+        HSEStatus = RCC->CTLR & RCC_HSERDY;
+        StartUpCounter++;
+    } while((HSEStatus == 0) && (StartUpCounter != HSE_STARTUP_TIMEOUT));
+
+    if((RCC->CTLR & RCC_HSERDY) != RESET)
+    {
+        HSEStatus = (uint32_t)0x01;
+    }
+    else
+    {
+        HSEStatus = (uint32_t)0x00;
+    }
+
+    if(HSEStatus == (uint32_t)0x01)
+    {
+#if defined (CH32V20x_D8W)
+        RCC->CFGR0 |= (uint32_t)(3<<22);
+        /* HCLK = SYSCLK/2 */
+        RCC->CFGR0 |= (uint32_t)RCC_HPRE_DIV2;
+#else
+        /* HCLK = SYSCLK */
+        RCC->CFGR0 |= (uint32_t)RCC_HPRE_DIV1;
+#endif
+        /* PCLK2 = HCLK */
+        RCC->CFGR0 |= (uint32_t)RCC_PPRE2_DIV1;
+        /* PCLK1 = HCLK */
+        RCC->CFGR0 |= (uint32_t)RCC_PPRE1_DIV2;
+
+        /*  CH32V20x_D6-PLL configuration: PLLCLK = HSE * 15 = 120 MHz (HSE=8MHZ)
+         *  CH32V20x_D8-PLL configuration: PLLCLK = HSE/4 * 15 = 120 MHz (HSE=32MHZ)
+         *  CH32V20x_D8W-PLL configuration: PLLCLK = HSE/2 * 15 = 240 MHz (HSE=32MHZ)
+         */
+        RCC->CFGR0 &= (uint32_t)((uint32_t) ~(RCC_PLLSRC | RCC_PLLXTPRE |
+                                              RCC_PLLMULL));
+
+        RCC->CFGR0 |= (uint32_t)(RCC_PLLSRC_HSE | RCC_PLLXTPRE_HSE | RCC_PLLMULL15);
+
+        /* Enable PLL */
+        RCC->CTLR |= RCC_PLLON;
+        /* Wait till PLL is ready */
+        while((RCC->CTLR & RCC_PLLRDY) == 0)
+        {
+        }
+        /* Select PLL as system clock source */
+        RCC->CFGR0 &= (uint32_t)((uint32_t) ~(RCC_SW));
+        RCC->CFGR0 |= (uint32_t)RCC_SW_PLL;
+        /* Wait till PLL is used as system clock source */
+        while((RCC->CFGR0 & (uint32_t)RCC_SWS) != (uint32_t)0x08)
+        {
+        }
+    }
+    else
+    {
+        /*
+         * If HSE fails to start-up, the application will have wrong clock
+         * configuration. User can add here some code to deal with this error
+         */
+    }
+}
+#elif defined SYSCLK_FREQ_144MHz_HSE
+
+/*********************************************************************
+ * @fn      SetSysClockTo144_HSE
+ *
+ * @brief   Sets System clock frequency to 144MHz and configure HCLK, PCLK2 and PCLK1 prescalers.
+ *
+ * @return  none
+ */
+static void SetSysClockTo144_HSE(void)
+{
+  __IO uint32_t StartUpCounter = 0, HSEStatus = 0;
+
+  RCC->CTLR |= ((uint32_t)RCC_HSEON);
+
+  /* Wait till HSE is ready and if Time out is reached exit */
+  do
+  {
+    HSEStatus = RCC->CTLR & RCC_HSERDY;
+    StartUpCounter++;
+  } while((HSEStatus == 0) && (StartUpCounter != HSE_STARTUP_TIMEOUT));
+
+  if ((RCC->CTLR & RCC_HSERDY) != RESET)
+  {
+    HSEStatus = (uint32_t)0x01;
+  }
+  else
+  {
+    HSEStatus = (uint32_t)0x00;
+  }
+
+  if (HSEStatus == (uint32_t)0x01)
+  {
+    /* HCLK = SYSCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_HPRE_DIV1;
+    /* PCLK2 = HCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_PPRE2_DIV1;
+    /* PCLK1 = HCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_PPRE1_DIV2;
+
+    /*  CH32V20x_D6-PLL configuration: PLLCLK = HSE * 18 = 144 MHz (HSE=8MHZ)
+     *  CH32V20x_D8-PLL configuration: PLLCLK = HSE/4 * 18 = 144 MHz (HSE=32MHZ)
+     *  CH32V20x_D8W-PLL configuration: PLLCLK = HSE/4 * 18 = 144 MHz (HSE=32MHZ)
+     */
+    RCC->CFGR0 &= (uint32_t)((uint32_t)~(RCC_PLLSRC | RCC_PLLXTPRE |
+                                        RCC_PLLMULL));
+
+    RCC->CFGR0 |= (uint32_t)(RCC_PLLSRC_HSE | RCC_PLLXTPRE_HSE | RCC_PLLMULL18);
+
+    /* Enable PLL */
+    RCC->CTLR |= RCC_PLLON;
+    /* Wait till PLL is ready */
+    while((RCC->CTLR & RCC_PLLRDY) == 0)
+    {
+    }
+    /* Select PLL as system clock source */
+    RCC->CFGR0 &= (uint32_t)((uint32_t)~(RCC_SW));
+    RCC->CFGR0 |= (uint32_t)RCC_SW_PLL;
+    /* Wait till PLL is used as system clock source */
+    while ((RCC->CFGR0 & (uint32_t)RCC_SWS) != (uint32_t)0x08)
+    {
+    }
+  }
+  else
+  {
+        /*
+         * If HSE fails to start-up, the application will have wrong clock
+     * configuration. User can add here some code to deal with this error
+         */
+  }
+}
+
+#elif defined SYSCLK_FREQ_48MHz_HSI
+
+/*********************************************************************
+ * @fn      SetSysClockTo48_HSI
+ *
+ * @brief   Sets System clock frequency to 48MHz and configure HCLK, PCLK2 and PCLK1 prescalers.
+ *
+ * @return  none
+ */
+static void SetSysClockTo48_HSI(void)
+{
+    EXTEN->EXTEN_CTR |= EXTEN_PLL_HSI_PRE;
+
+    /* HCLK = SYSCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_HPRE_DIV1;
+    /* PCLK2 = HCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_PPRE2_DIV1;
+    /* PCLK1 = HCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_PPRE1_DIV2;
+
+    /*  PLL configuration: PLLCLK = HSI * 6 = 48 MHz */
+    RCC->CFGR0 &= (uint32_t)((uint32_t)~(RCC_PLLSRC | RCC_PLLXTPRE | RCC_PLLMULL));
+
+     RCC->CFGR0 |= (uint32_t)(RCC_PLLSRC_HSI_Div2 | RCC_PLLMULL6);
+
+    /* Enable PLL */
+    RCC->CTLR |= RCC_PLLON;
+    /* Wait till PLL is ready */
+    while((RCC->CTLR & RCC_PLLRDY) == 0)
+    {
+    }
+    /* Select PLL as system clock source */
+    RCC->CFGR0 &= (uint32_t)((uint32_t)~(RCC_SW));
+    RCC->CFGR0 |= (uint32_t)RCC_SW_PLL;
+    /* Wait till PLL is used as system clock source */
+    while ((RCC->CFGR0 & (uint32_t)RCC_SWS) != (uint32_t)0x08)
+    {
+    }
+}
+
+#elif defined SYSCLK_FREQ_56MHz_HSI
+
+/*********************************************************************
+ * @fn      SetSysClockTo56_HSI
+ *
+ * @brief   Sets System clock frequency to 56MHz and configure HCLK, PCLK2 and PCLK1 prescalers.
+ *
+ * @return  none
+ */
+static void SetSysClockTo56_HSI(void)
+{
+    EXTEN->EXTEN_CTR |= EXTEN_PLL_HSI_PRE;
+
+    /* HCLK = SYSCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_HPRE_DIV1;
+    /* PCLK2 = HCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_PPRE2_DIV1;
+    /* PCLK1 = HCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_PPRE1_DIV2;
+
+    /*  PLL configuration: PLLCLK = HSI * 7 = 48 MHz */
+    RCC->CFGR0 &= (uint32_t)((uint32_t)~(RCC_PLLSRC | RCC_PLLXTPRE | RCC_PLLMULL));
+
+     RCC->CFGR0 |= (uint32_t)(RCC_PLLSRC_HSI_Div2 | RCC_PLLMULL7);
+
+    /* Enable PLL */
+    RCC->CTLR |= RCC_PLLON;
+    /* Wait till PLL is ready */
+    while((RCC->CTLR & RCC_PLLRDY) == 0)
+    {
+    }
+    /* Select PLL as system clock source */
+    RCC->CFGR0 &= (uint32_t)((uint32_t)~(RCC_SW));
+    RCC->CFGR0 |= (uint32_t)RCC_SW_PLL;
+    /* Wait till PLL is used as system clock source */
+    while ((RCC->CFGR0 & (uint32_t)RCC_SWS) != (uint32_t)0x08)
+    {
+    }
+}
+
+#elif defined SYSCLK_FREQ_72MHz_HSI
+
+/*********************************************************************
+ * @fn      SetSysClockTo72_HSI
+ *
+ * @brief   Sets System clock frequency to 72MHz and configure HCLK, PCLK2 and PCLK1 prescalers.
+ *
+ * @return  none
+ */
+static void SetSysClockTo72_HSI(void)
+{
+    EXTEN->EXTEN_CTR |= EXTEN_PLL_HSI_PRE;
+
+    /* HCLK = SYSCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_HPRE_DIV1;
+    /* PCLK2 = HCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_PPRE2_DIV1;
+    /* PCLK1 = HCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_PPRE1_DIV2;
+
+    /*  PLL configuration: PLLCLK = HSI * 9 = 72 MHz */
+    RCC->CFGR0 &= (uint32_t)((uint32_t)~(RCC_PLLSRC | RCC_PLLXTPRE | RCC_PLLMULL));
+
+     RCC->CFGR0 |= (uint32_t)(RCC_PLLSRC_HSI_Div2 | RCC_PLLMULL9);
+
+    /* Enable PLL */
+    RCC->CTLR |= RCC_PLLON;
+    /* Wait till PLL is ready */
+    while((RCC->CTLR & RCC_PLLRDY) == 0)
+    {
+    }
+    /* Select PLL as system clock source */
+    RCC->CFGR0 &= (uint32_t)((uint32_t)~(RCC_SW));
+    RCC->CFGR0 |= (uint32_t)RCC_SW_PLL;
+    /* Wait till PLL is used as system clock source */
+    while ((RCC->CFGR0 & (uint32_t)RCC_SWS) != (uint32_t)0x08)
+    {
+    }
+}
+
+
+#elif defined SYSCLK_FREQ_96MHz_HSI
+
+/*********************************************************************
+ * @fn      SetSysClockTo96_HSI
+ *
+ * @brief   Sets System clock frequency to 96MHz and configure HCLK, PCLK2 and PCLK1 prescalers.
+ *
+ * @return  none
+ */
+static void SetSysClockTo96_HSI(void)
+{
+    EXTEN->EXTEN_CTR |= EXTEN_PLL_HSI_PRE;
+
+    /* HCLK = SYSCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_HPRE_DIV1;
+    /* PCLK2 = HCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_PPRE2_DIV1;
+    /* PCLK1 = HCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_PPRE1_DIV2;
+
+    /*  PLL configuration: PLLCLK = HSI * 12 = 96 MHz */
+    RCC->CFGR0 &= (uint32_t)((uint32_t)~(RCC_PLLSRC | RCC_PLLXTPRE | RCC_PLLMULL));
+
+     RCC->CFGR0 |= (uint32_t)(RCC_PLLSRC_HSI_Div2 | RCC_PLLMULL12);
+
+    /* Enable PLL */
+    RCC->CTLR |= RCC_PLLON;
+    /* Wait till PLL is ready */
+    while((RCC->CTLR & RCC_PLLRDY) == 0)
+    {
+    }
+    /* Select PLL as system clock source */
+    RCC->CFGR0 &= (uint32_t)((uint32_t)~(RCC_SW));
+    RCC->CFGR0 |= (uint32_t)RCC_SW_PLL;
+    /* Wait till PLL is used as system clock source */
+    while ((RCC->CFGR0 & (uint32_t)RCC_SWS) != (uint32_t)0x08)
+    {
+    }
+}
+
+
+#elif defined SYSCLK_FREQ_120MHz_HSI
+
+/*********************************************************************
+ * @fn      SetSysClockTo120_HSI
+ *
+ * @brief   Sets System clock frequency to 120MHz and configure HCLK, PCLK2 and PCLK1 prescalers.
+ *
+ * @return  none
+ */
+static void SetSysClockTo120_HSI(void)
+{
+    EXTEN->EXTEN_CTR |= EXTEN_PLL_HSI_PRE;
+
+    /* HCLK = SYSCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_HPRE_DIV1;
+    /* PCLK2 = HCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_PPRE2_DIV1;
+    /* PCLK1 = HCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_PPRE1_DIV2;
+
+    /*  PLL configuration: PLLCLK = HSI * 15 = 120 MHz */
+    RCC->CFGR0 &= (uint32_t)((uint32_t) ~(RCC_PLLSRC | RCC_PLLXTPRE |
+                                          RCC_PLLMULL));
+
+    RCC->CFGR0 |= (uint32_t)(RCC_PLLSRC_HSI_Div2 | RCC_PLLMULL15);
+
+    /* Enable PLL */
+    RCC->CTLR |= RCC_PLLON;
+    /* Wait till PLL is ready */
+    while((RCC->CTLR & RCC_PLLRDY) == 0)
+    {
+    }
+    /* Select PLL as system clock source */
+    RCC->CFGR0 &= (uint32_t)((uint32_t) ~(RCC_SW));
+    RCC->CFGR0 |= (uint32_t)RCC_SW_PLL;
+    /* Wait till PLL is used as system clock source */
+    while((RCC->CFGR0 & (uint32_t)RCC_SWS) != (uint32_t)0x08)
+    {
+    }
+}
+#elif defined SYSCLK_FREQ_144MHz_HSI
+
+/*********************************************************************
+ * @fn      SetSysClockTo144_HSI
+ *
+ * @brief   Sets System clock frequency to 144MHz and configure HCLK, PCLK2 and PCLK1 prescalers.
+ *
+ * @return  none
+ */
+static void SetSysClockTo144_HSI(void)
+{
+    EXTEN->EXTEN_CTR |= EXTEN_PLL_HSI_PRE;
+
+    /* HCLK = SYSCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_HPRE_DIV1;
+    /* PCLK2 = HCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_PPRE2_DIV1;
+    /* PCLK1 = HCLK */
+    RCC->CFGR0 |= (uint32_t)RCC_PPRE1_DIV2;
+
+    /*  PLL configuration: PLLCLK = HSI * 18 = 144 MHz */
+    RCC->CFGR0 &= (uint32_t)((uint32_t)~(RCC_PLLSRC | RCC_PLLXTPRE | RCC_PLLMULL));
+
+     RCC->CFGR0 |= (uint32_t)(RCC_PLLSRC_HSI_Div2 | RCC_PLLMULL18);
+
+    /* Enable PLL */
+    RCC->CTLR |= RCC_PLLON;
+    /* Wait till PLL is ready */
+    while((RCC->CTLR & RCC_PLLRDY) == 0)
+    {
+    }
+    /* Select PLL as system clock source */
+    RCC->CFGR0 &= (uint32_t)((uint32_t)~(RCC_SW));
+    RCC->CFGR0 |= (uint32_t)RCC_SW_PLL;
+    /* Wait till PLL is used as system clock source */
+    while ((RCC->CFGR0 & (uint32_t)RCC_SWS) != (uint32_t)0x08)
+    {
+    }
+}
+
+
+#endif

--- a/Sources/source/LanaKBD/User/system_ch32v20x.h
+++ b/Sources/source/LanaKBD/User/system_ch32v20x.h
@@ -1,0 +1,32 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : system_ch32v20x.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/06/06
+ * Description        : CH32V20x Device Peripheral Access Layer System Header File.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __SYSTEM_ch32v20x_H 
+#define __SYSTEM_ch32v20x_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif 
+
+extern uint32_t SystemCoreClock;          /* System Clock Frequency (Core Clock) */
+
+/* System_Exported_Functions */  
+extern void SystemInit(void);
+extern void SystemCoreClockUpdate(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*__CH32V20x_SYSTEM_H */
+
+
+

--- a/Sources/source/LanaKBD/User/usbd_composite_km.h
+++ b/Sources/source/LanaKBD/User/usbd_composite_km.h
@@ -1,0 +1,143 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : usbd_composite_km.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2022/07/04
+ * Description        :
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+
+
+#ifndef __USBD_COMPOSITE_KM_H
+#define __USBD_COMPOSITE_KM_H
+
+/*******************************************************************************/
+/* Included Header Files */
+#include "debug.h"
+#include "string.h"
+#include "usb_lib.h"
+#include "usb_desc.h"
+#include "usb_prop.h"
+#include "usb_pwr.h"
+/*******************************************************************************/
+
+/**
+ * Modifier masks - used for the first byte in the HID report.
+ * NOTE: The second byte in the report is reserved, 0x00
+ */
+#define KEY_MOD_LCTRL  0x01
+#define KEY_MOD_LSHIFT 0x02
+#define KEY_MOD_LALT   0x04
+#define KEY_MOD_LMETA  0x08
+#define KEY_MOD_RCTRL  0x10
+#define KEY_MOD_RSHIFT 0x20
+#define KEY_MOD_RALT   0x40
+#define KEY_MOD_RMETA  0x80
+
+#define KEY_NONE 0x00 // No key pressed
+
+/* Keyboard Key Value Macro Definition */
+#define KEY_A 0x04 // Keyboard a and A
+#define KEY_B 0x05 // Keyboard b and B
+#define KEY_C 0x06 // Keyboard c and C
+#define KEY_D 0x07 // Keyboard d and D
+#define KEY_E 0x08 // Keyboard e and E
+#define KEY_F 0x09 // Keyboard f and F
+#define KEY_G 0x0a // Keyboard g and G
+#define KEY_H 0x0b // Keyboard h and H
+#define KEY_I 0x0c // Keyboard i and I
+#define KEY_J 0x0d // Keyboard j and J
+#define KEY_K 0x0e // Keyboard k and K
+#define KEY_L 0x0f // Keyboard l and L
+#define KEY_M 0x10 // Keyboard m and M
+#define KEY_N 0x11 // Keyboard n and N
+#define KEY_O 0x12 // Keyboard o and O
+#define KEY_P 0x13 // Keyboard p and P
+#define KEY_Q 0x14 // Keyboard q and Q
+#define KEY_R 0x15 // Keyboard r and R
+#define KEY_S 0x16 // Keyboard s and S
+#define KEY_T 0x17 // Keyboard t and T
+#define KEY_U 0x18 // Keyboard u and U
+#define KEY_V 0x19 // Keyboard v and V
+#define KEY_W 0x1a // Keyboard w and W
+#define KEY_X 0x1b // Keyboard x and X
+#define KEY_Y 0x1c // Keyboard y and Y
+#define KEY_Z 0x1d // Keyboard z and Z
+
+#define KEY_1 0x1e // Keyboard 1 and !
+#define KEY_2 0x1f // Keyboard 2 and @
+#define KEY_3 0x20 // Keyboard 3 and #
+#define KEY_4 0x21 // Keyboard 4 and $
+#define KEY_5 0x22 // Keyboard 5 and %
+#define KEY_6 0x23 // Keyboard 6 and ^
+#define KEY_7 0x24 // Keyboard 7 and &
+#define KEY_8 0x25 // Keyboard 8 and *
+#define KEY_9 0x26 // Keyboard 9 and (
+#define KEY_0 0x27 // Keyboard 0 and )
+
+#define KEY_ENTER 0x28 // Keyboard Return (ENTER)
+#define KEY_ESC 0x29 // Keyboard ESCAPE
+#define KEY_BACKSPACE 0x2a // Keyboard DELETE (Backspace)
+#define KEY_TAB 0x2b // Keyboard Tab
+#define KEY_SPACE 0x2c // Keyboard Spacebar
+#define KEY_MINUS 0x2d // Keyboard - and _
+#define KEY_EQUAL 0x2e // Keyboard = and +
+#define KEY_LEFTBRACE 0x2f // Keyboard [ and {
+#define KEY_RIGHTBRACE 0x30 // Keyboard ] and }
+#define KEY_BACKSLASH 0x31 // Keyboard \ and |
+#define KEY_HASHTILDE 0x32 // Keyboard Non-US # and ~
+#define KEY_SEMICOLON 0x33 // Keyboard ; and :
+#define KEY_APOSTROPHE 0x34 // Keyboard ' and "
+#define KEY_GRAVE 0x35 // Keyboard ` and ~
+#define KEY_COMMA 0x36 // Keyboard , and <
+#define KEY_DOT 0x37 // Keyboard . and >
+#define KEY_SLASH 0x38 // Keyboard / and ?
+#define KEY_CAPSLOCK 0x39 // Keyboard Caps Lock
+
+#define KEY_F1 0x3a // Keyboard F1
+#define KEY_F2 0x3b // Keyboard F2
+#define KEY_F3 0x3c // Keyboard F3
+#define KEY_F4 0x3d // Keyboard F4
+#define KEY_F5 0x3e // Keyboard F5
+#define KEY_F6 0x3f // Keyboard F6
+#define KEY_F7 0x40 // Keyboard F7
+#define KEY_F8 0x41 // Keyboard F8
+#define KEY_F9 0x42 // Keyboard F9
+#define KEY_F10 0x43 // Keyboard F10
+#define KEY_F11 0x44 // Keyboard F11
+#define KEY_F12 0x45 // Keyboard F12
+
+#define KEY_SYSRQ 0x46 // Keyboard Print Screen
+#define KEY_SCROLLLOCK 0x47 // Keyboard Scroll Lock
+#define KEY_PAUSE 0x48 // Keyboard Pause
+#define KEY_INSERT 0x49 // Keyboard Insert
+#define KEY_HOME 0x4a // Keyboard Home
+#define KEY_PAGEUP 0x4b // Keyboard Page Up
+#define KEY_DELETE 0x4c // Keyboard Delete Forward
+#define KEY_END 0x4d // Keyboard End
+#define KEY_PAGEDOWN 0x4e // Keyboard Page Down
+#define KEY_RIGHT 0x4f // Keyboard Right Arrow
+#define KEY_LEFT 0x50 // Keyboard Left Arrow
+#define KEY_DOWN 0x51 // Keyboard Down Arrow
+#define KEY_UP 0x52 // Keyboard Up Arrow
+
+#define KEY_LEFTMETA 0xe3 // Keyboard Left GUI
+
+/*******************************************************************************/
+/* Global Variable Declaration */
+extern volatile uint8_t  KB_LED_Cur_Status;
+/*******************************************************************************/
+/* Function Declaration */
+extern void TIM3_Init( uint16_t arr, uint16_t psc );
+extern void USART_Badge_Init(uint32_t baudrate);
+extern void IIC_Init(uint32_t bound, uint16_t address);
+extern void LED_Init_Neopixel(void);
+extern void KB_Scan_Init( void );
+extern void KB_Sleep_Wakeup_Cfg( void );
+extern void KB_Scan( void );
+extern void KB_Scan_Handle( void );
+extern void MCU_Sleep_Wakeup_Operate( void );
+#endif

--- a/Sources/source/LanaKBD/User/usbd_compostie_km.c
+++ b/Sources/source/LanaKBD/User/usbd_compostie_km.c
@@ -1,0 +1,855 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : usbd_composite_km.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2022/08/20
+ * Description        : USB keyboard and mouse processing.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+
+
+/*******************************************************************************/
+/* Header Files */
+#include "usbd_composite_km.h"
+#include "usb_pwr.h"
+
+#define I2COUTPUT (1)
+#define UARTOUTPUT (0)
+
+uint8_t USBD_ENDPx_DataUp( uint8_t endp, uint8_t *pbuf, uint16_t len );
+
+/*******************************************************************************/
+/* Variable Definition */
+
+#define N_COLS (9)
+#define N_ROWS (8)
+#define N_LEDS (12)
+
+#define LED_LANA_OFFSET (0)
+#define LED_LANA_LEN (3)
+#define LED_BACKLIGHT_OFFSET (3)
+#define LED_BACKLIGHT_LEN (8)
+#define LED_RED_OFFSET (11)
+#define LED_RED_LEN (1)
+
+/* Keyboard */
+volatile uint8_t  KB_Scan_Done = 0x00;                                          // Keyboard Keys Scan Done
+uint8_t KB_Scan_Result[N_COLS] = {                                              // Keyboard Keys Current Scan Result
+    0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF
+};
+uint8_t KB_Scan_Last_Result[N_COLS] = {                                         // Keyboard Keys Last Scan Result
+    0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF
+};
+uint8_t  KB_Data_Pack[ DEF_ENDP_SIZE_KB ] = { 0x00 };                           // Keyboard IN Data Packet
+volatile uint8_t  KB_LED_Cur_Status = 0x00;                                     // Keyboard LED Current Result
+
+static uint8_t keycodes[N_COLS][N_ROWS] = {
+    { KEY_ESC, KEY_1, KEY_0, KEY_Y, KEY_S, KEY_APOSTROPHE, KEY_M, KEY_BACKSLASH, },
+    { KEY_F1, KEY_2, KEY_MINUS, KEY_U, KEY_D, KEY_ENTER, KEY_COMMA, KEY_SPACE, },
+    { KEY_F2, KEY_3, KEY_EQUAL, KEY_I, KEY_F, KEY_NONE, KEY_DOT, KEY_SPACE, },
+    { KEY_F3, KEY_4, KEY_TAB, KEY_O, KEY_G, KEY_Z, KEY_SLASH, KEY_SPACE, },
+    { KEY_F4, KEY_5, KEY_Q, KEY_P, KEY_H, KEY_X, KEY_UP, KEY_NONE, },
+    { KEY_F5, KEY_6, KEY_W, KEY_LEFTBRACE, KEY_J, KEY_C, KEY_NONE, KEY_LEFT, },
+    { KEY_F6, KEY_7, KEY_E, KEY_RIGHTBRACE, KEY_K, KEY_V, KEY_NONE, KEY_DOWN, },
+    { KEY_BACKSPACE, KEY_8, KEY_R, KEY_NONE, KEY_L, KEY_B, KEY_LEFTMETA, KEY_RIGHT, },
+    { KEY_GRAVE, KEY_9, KEY_T, KEY_A, KEY_SEMICOLON, KEY_N, KEY_NONE, KEY_NONE, },
+};
+
+static uint8_t modifiers[N_COLS][N_ROWS] = {
+    { KEY_NONE, KEY_NONE, KEY_NONE, KEY_NONE, KEY_NONE, KEY_NONE, KEY_NONE, KEY_NONE, },
+    { KEY_NONE, KEY_NONE, KEY_NONE, KEY_NONE, KEY_NONE, KEY_NONE, KEY_NONE, KEY_NONE, },
+    { KEY_NONE, KEY_NONE, KEY_NONE, KEY_NONE, KEY_NONE, KEY_MOD_LSHIFT, KEY_NONE, KEY_NONE, },
+    { KEY_NONE, KEY_NONE, KEY_NONE, KEY_NONE, KEY_NONE, KEY_NONE, KEY_NONE, KEY_NONE, },
+    { KEY_NONE, KEY_NONE, KEY_NONE, KEY_NONE, KEY_NONE, KEY_NONE, KEY_NONE, KEY_MOD_RALT, },
+    { KEY_NONE, KEY_NONE, KEY_NONE, KEY_NONE, KEY_NONE, KEY_NONE, KEY_MOD_RSHIFT, KEY_NONE, },
+    { KEY_NONE, KEY_NONE, KEY_NONE, KEY_NONE, KEY_NONE, KEY_NONE, KEY_MOD_LCTRL, KEY_NONE, },
+    { KEY_NONE, KEY_NONE, KEY_NONE, KEY_MOD_RMETA, KEY_NONE, KEY_NONE, KEY_NONE, KEY_NONE, },
+    { KEY_NONE, KEY_NONE, KEY_NONE, KEY_NONE, KEY_NONE, KEY_NONE, KEY_MOD_LALT, KEY_NONE, },
+};
+
+static uint8_t leds[N_LEDS];
+
+/*******************************************************************************/
+/* Interrupt Function Declaration */
+void TIM3_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+
+/*********************************************************************
+ * @fn      TIM3_Init
+ *
+ * @brief   Initialize timer3 for keyboard and mouse scan.
+ *
+ * @param   arr - The specific period value
+ *          psc - The specifies prescaler value
+ *
+ * @return  none
+ */
+void TIM3_Init( uint16_t arr, uint16_t psc )
+{
+    TIM_TimeBaseInitTypeDef TIM_TimeBaseStructure = { 0 };
+    NVIC_InitTypeDef NVIC_InitStructure = { 0 };
+
+    /* Enable Timer3 Clock */
+    RCC_APB1PeriphClockCmd( RCC_APB1Periph_TIM3, ENABLE );
+
+    /* Initialize Timer3 */
+    TIM_TimeBaseStructure.TIM_Period = arr;
+    TIM_TimeBaseStructure.TIM_Prescaler = psc;
+    TIM_TimeBaseStructure.TIM_ClockDivision = TIM_CKD_DIV1;
+    TIM_TimeBaseStructure.TIM_CounterMode = TIM_CounterMode_Up;
+    TIM_TimeBaseInit( TIM3, &TIM_TimeBaseStructure );
+
+    TIM_ITConfig( TIM3, TIM_IT_Update, ENABLE );
+
+    NVIC_InitStructure.NVIC_IRQChannel = TIM3_IRQn;
+    NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 1;
+    NVIC_InitStructure.NVIC_IRQChannelSubPriority = 2;
+    NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
+    NVIC_Init( &NVIC_InitStructure );
+
+    /* Enable Timer3 */
+    TIM_Cmd( TIM3, ENABLE );
+}
+
+/*********************************************************************
+ * @fn      TIM3_IRQHandler
+ *
+ * @brief   This function handles TIM3 global interrupt request.
+ *
+ * @return  none
+ */
+void TIM3_IRQHandler( void )
+{
+    if( TIM_GetITStatus( TIM3, TIM_IT_Update ) != RESET )
+    {
+        /* Clear interrupt flag */
+        TIM_ClearITPendingBit( TIM3, TIM_IT_Update );
+
+        /* Handle keyboard scan */
+        KB_Scan( );
+    }
+}
+
+static void KB_Set_Col(uint8_t colIdx)
+{
+    if (colIdx == 0) {
+        GPIO_Write(GPIOA, 0);
+        GPIO_Write(GPIOB, GPIO_Pin_4);
+    } else if (colIdx == 1) {
+        GPIO_Write(GPIOA, 0);
+        GPIO_Write(GPIOB, GPIO_Pin_3);
+    } else if (colIdx == 2) {
+        GPIO_Write(GPIOA, GPIO_Pin_0);
+        GPIO_Write(GPIOB, 0);
+    } else if (colIdx == 3) {
+        GPIO_Write(GPIOA, GPIO_Pin_15);
+        GPIO_Write(GPIOB, 0);
+    } else if (colIdx == 4) {
+        GPIO_Write(GPIOA, GPIO_Pin_1);
+        GPIO_Write(GPIOB, 0);
+    } else if (colIdx == 5) {
+        GPIO_Write(GPIOA, GPIO_Pin_14);
+        GPIO_Write(GPIOB, 0);
+    } else if (colIdx == 6) {
+        GPIO_Write(GPIOA, 0);
+        GPIO_Write(GPIOB, GPIO_Pin_0);
+    } else if (colIdx == 7) {
+        GPIO_Write(GPIOA, GPIO_Pin_13);
+        GPIO_Write(GPIOB, 0);
+    } else if (colIdx == 8) {
+        GPIO_Write(GPIOA, 0);
+        GPIO_Write(GPIOB, GPIO_Pin_1);
+    }
+}
+
+/*********************************************************************
+ * @fn      USART_Printf_Init
+ *
+ * @brief   Initializes the USARTx peripheral.
+ *
+ * @param   baudrate - USART communication baud rate.
+ *
+ * @return  None
+ */
+void USART_Badge_Init(uint32_t baudrate)
+{
+    GPIO_InitTypeDef  GPIO_InitStructure;
+    USART_InitTypeDef USART_InitStructure;
+
+    RCC_APB1PeriphClockCmd(RCC_APB1Periph_USART2, ENABLE);
+    RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOA, ENABLE);
+
+    GPIO_InitStructure.GPIO_Pin = GPIO_Pin_2;
+    GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
+    GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF_PP;
+    GPIO_Init(GPIOA, &GPIO_InitStructure);
+
+    USART_InitStructure.USART_BaudRate = baudrate;
+    USART_InitStructure.USART_WordLength = USART_WordLength_8b;
+    USART_InitStructure.USART_StopBits = USART_StopBits_1;
+    USART_InitStructure.USART_Parity = USART_Parity_No;
+    USART_InitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
+    USART_InitStructure.USART_Mode = USART_Mode_Tx;
+
+    USART_Init(USART2, &USART_InitStructure);
+    USART_Cmd(USART2, ENABLE);
+}
+
+/*********************************************************************
+ * @fn      IIC_Init
+ *
+ * @brief   Initializes the IIC peripheral.
+ *
+ * @return  none
+ */
+void IIC_Init(uint32_t bound, uint16_t address)
+{
+    GPIO_InitTypeDef GPIO_InitStructure={0};
+    I2C_InitTypeDef I2C_InitTSturcture={0};
+
+    RCC_APB2PeriphClockCmd( RCC_APB2Periph_GPIOB | RCC_APB2Periph_AFIO, ENABLE );
+    RCC_APB1PeriphClockCmd( RCC_APB1Periph_I2C1, ENABLE );
+
+    GPIO_InitStructure.GPIO_Pin = GPIO_Pin_6;
+    GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF_OD;
+    GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
+    GPIO_Init( GPIOB, &GPIO_InitStructure );
+
+    GPIO_InitStructure.GPIO_Pin = GPIO_Pin_7;
+    GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF_OD;
+    GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
+    GPIO_Init( GPIOB, &GPIO_InitStructure );
+
+    I2C_InitTSturcture.I2C_ClockSpeed = bound;
+    I2C_InitTSturcture.I2C_Mode = I2C_Mode_I2C;
+    I2C_InitTSturcture.I2C_DutyCycle = I2C_DutyCycle_16_9;
+    I2C_InitTSturcture.I2C_OwnAddress1 = address << 1;
+    I2C_InitTSturcture.I2C_Ack = I2C_Ack_Enable;
+    I2C_InitTSturcture.I2C_AcknowledgedAddress = I2C_AcknowledgedAddress_7bit;
+    I2C_Init( I2C1, &I2C_InitTSturcture );
+
+    I2C_Cmd( I2C1, ENABLE );
+}
+
+void LED_Init_Neopixel(void)
+{
+    RCC_APB2PeriphClockCmd(RCC_APB2Periph_AFIO, ENABLE);
+    RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOD, ENABLE);
+    GPIO_PinRemapConfig(AFIO_PCFR1_PD01_REMAP, ENABLE);
+
+    GPIO_InitTypeDef GPIO_InitStructure = {0};
+    GPIO_InitStructure.GPIO_Pin = GPIO_Pin_0;
+    GPIO_InitStructure.GPIO_Mode = GPIO_Mode_Out_PP;
+    GPIO_InitStructure.GPIO_Speed = GPIO_Speed_2MHz;
+    GPIO_Init(GPIOD, &GPIO_InitStructure);
+
+    memset(leds, 0, N_LEDS);
+}
+
+static void WS2812BSimpleSend( GPIO_TypeDef * port, uint16_t GPIO_Pin, uint8_t * data, int len_in_bytes )
+{
+    port->BCR = GPIO_Pin;
+
+    uint8_t * end = data + len_in_bytes;
+    while( data != end )
+    {
+        uint8_t byte = *data;
+
+        int i;
+        for( i = 0; i < 8; i++ ) {
+            if( byte & 0x80 )
+            {
+                // WS2812B's need AT LEAST 625ns for a logical "1"
+                port->BSHR = GPIO_Pin;
+                __asm__("nop");__asm__("nop");__asm__("nop");__asm__("nop");
+                __asm__("nop");__asm__("nop");__asm__("nop");__asm__("nop");
+                __asm__("nop");__asm__("nop");__asm__("nop");__asm__("nop");
+                __asm__("nop");__asm__("nop");__asm__("nop");__asm__("nop");
+                __asm__("nop");__asm__("nop");__asm__("nop");__asm__("nop");
+                __asm__("nop");__asm__("nop");__asm__("nop");__asm__("nop");
+                __asm__("nop");__asm__("nop");__asm__("nop");__asm__("nop");
+                __asm__("nop");__asm__("nop");__asm__("nop");__asm__("nop");
+                port->BCR = GPIO_Pin;
+            }
+            else
+            {
+                // WS2812B's need BETWEEN 62.5 to about 500 ns for a logical "0"
+                port->BSHR = GPIO_Pin;
+                __asm__("nop");__asm__("nop");__asm__("nop");__asm__("nop");
+                __asm__("nop");__asm__("nop");__asm__("nop");__asm__("nop");
+                __asm__("nop");__asm__("nop");__asm__("nop");__asm__("nop");
+                port->BCR = GPIO_Pin;
+                __asm__("nop");__asm__("nop");__asm__("nop");__asm__("nop");
+                __asm__("nop");__asm__("nop");__asm__("nop");__asm__("nop");
+                __asm__("nop");__asm__("nop");__asm__("nop");__asm__("nop");
+                __asm__("nop");__asm__("nop");__asm__("nop");__asm__("nop");
+            }
+            byte <<= 1;
+        }
+        data++;
+    }
+
+    port->BCR = GPIO_Pin;
+}
+
+static void LED_Lana_SetColour(uint8_t red, uint8_t green, uint8_t blue)
+{
+    leds[LED_LANA_OFFSET+0] = green;
+    leds[LED_LANA_OFFSET+1] = red;
+    leds[LED_LANA_OFFSET+2] = blue;
+    WS2812BSimpleSend(GPIOD, GPIO_Pin_0, leds, N_LEDS);
+}
+
+static void LED_Backlight_SetBrightness(uint8_t brightness)
+{
+    memset(&leds[LED_BACKLIGHT_OFFSET], brightness, LED_BACKLIGHT_LEN);
+    WS2812BSimpleSend(GPIOD, GPIO_Pin_0, leds, N_LEDS);
+}
+
+static void LED_Red_Toggle(void)
+{
+    if (leds[LED_RED_OFFSET] < 0x0f) {
+        memset(&leds[LED_RED_OFFSET], 0xff, LED_RED_LEN);
+    }
+    else {
+        memset(&leds[LED_RED_OFFSET], 0x00, LED_RED_LEN);
+    }
+    WS2812BSimpleSend(GPIOD, GPIO_Pin_0, leds, N_LEDS);
+}
+
+/*********************************************************************
+ * @fn      KB_Scan_Init
+ *
+ * @brief   Initialize IO for keyboard scan.
+ *
+ * @return  none
+ */
+void KB_Scan_Init( void )
+{
+    GPIO_InitTypeDef GPIO_InitStructure = { 0 };
+
+    /* Enable GPIOA B and D clock */
+    RCC_APB2PeriphClockCmd(RCC_APB2Periph_AFIO | RCC_APB2Periph_GPIOA | RCC_APB2Periph_GPIOB | RCC_APB2Periph_GPIOD, ENABLE);
+
+    /* remap SWD pins */
+    GPIO_PinRemapConfig(GPIO_Remap_SWJ_Disable, ENABLE);
+
+    /* remap PD1 */
+    GPIO_PinRemapConfig(AFIO_PCFR1_PD01_REMAP, ENABLE);
+
+    /* Initialize GPIOD (row0) as input */
+    GPIO_InitStructure.GPIO_Pin = GPIO_Pin_1;
+    GPIO_InitStructure.GPIO_Mode = GPIO_Mode_IPD;
+    GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
+    GPIO_Init( GPIOD, &GPIO_InitStructure );
+
+    /* Initialize GPIOA (row1-row6) as input */
+    GPIO_InitStructure.GPIO_Pin = GPIO_Pin_3 | GPIO_Pin_4 | GPIO_Pin_5 | GPIO_Pin_6 | GPIO_Pin_7 | GPIO_Pin_9;
+    GPIO_InitStructure.GPIO_Mode = GPIO_Mode_IPD;
+    GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
+    GPIO_Init( GPIOA, &GPIO_InitStructure );
+
+    /* Initialize GPIOB (row7) as input */
+    GPIO_InitStructure.GPIO_Pin = GPIO_Pin_5;
+    GPIO_InitStructure.GPIO_Mode = GPIO_Mode_IPD;
+    GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
+    GPIO_Init( GPIOB, &GPIO_InitStructure );
+
+    /* Initialize GPIOA (col2-col5, col7) as outputs */
+    GPIO_InitStructure.GPIO_Pin = GPIO_Pin_0 | GPIO_Pin_1 | GPIO_Pin_13 | GPIO_Pin_14 | GPIO_Pin_15;
+    GPIO_InitStructure.GPIO_Mode = GPIO_Mode_Out_PP;
+    GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
+    GPIO_Init( GPIOA, &GPIO_InitStructure );
+
+    /* Initialize GPIOB (col0, col1, col6, col8) as outputs */
+    GPIO_InitStructure.GPIO_Pin = GPIO_Pin_0 | GPIO_Pin_1 | GPIO_Pin_3 | GPIO_Pin_4;
+    GPIO_InitStructure.GPIO_Mode = GPIO_Mode_Out_PP;
+    GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
+    GPIO_Init( GPIOB, &GPIO_InitStructure );
+
+    /* put col0 to high */
+    KB_Set_Col(0);
+
+    /* put all outputs high*/
+
+    /*
+    output: 
+    col0: PB4
+    col1: PB3
+    col2: PA0
+    col3: PA15
+    col4: PA1
+    col5: PA14 / SWC
+    col6: PB0
+    col7: PA13 / SWD
+    col8: PB1
+    
+    input: 
+    row0: PD1
+    row1: PA3
+    row2: PA5
+    row3: PA4
+    row4: PA6
+    row5: PA9
+    row6: PA7
+    row7: PB5
+    */
+}
+
+/*********************************************************************
+ * @fn      KB_Sleep_Wakeup_Cfg
+ *
+ * @brief   Configure keyboard wake up mode.
+ *
+ * @return  none
+ */
+void KB_Sleep_Wakeup_Cfg( void )
+{
+    EXTI_InitTypeDef EXTI_InitStructure = { 0 };
+
+    /* Enable GPIOB clock */
+    RCC_APB2PeriphClockCmd( RCC_APB2Periph_AFIO, ENABLE );
+
+    GPIO_EXTILineConfig( GPIO_PortSourceGPIOD, GPIO_PinSource1 );
+    EXTI_InitStructure.EXTI_Line = EXTI_Line1;
+    EXTI_InitStructure.EXTI_Mode = EXTI_Mode_Event;
+    EXTI_InitStructure.EXTI_Trigger = EXTI_Trigger_Rising;
+    EXTI_InitStructure.EXTI_LineCmd = ENABLE;
+    EXTI_Init( &EXTI_InitStructure );
+
+    GPIO_EXTILineConfig( GPIO_PortSourceGPIOA, GPIO_PinSource3 );
+    EXTI_InitStructure.EXTI_Line = EXTI_Line3;
+    EXTI_InitStructure.EXTI_Mode = EXTI_Mode_Event;
+    EXTI_InitStructure.EXTI_Trigger = EXTI_Trigger_Rising;
+    EXTI_InitStructure.EXTI_LineCmd = ENABLE;
+    EXTI_Init( &EXTI_InitStructure );
+
+    GPIO_EXTILineConfig( GPIO_PortSourceGPIOA, GPIO_PinSource4 );
+    EXTI_InitStructure.EXTI_Line = EXTI_Line4;
+    EXTI_InitStructure.EXTI_Mode = EXTI_Mode_Event;
+    EXTI_InitStructure.EXTI_Trigger = EXTI_Trigger_Rising;
+    EXTI_InitStructure.EXTI_LineCmd = ENABLE;
+    EXTI_Init( &EXTI_InitStructure );
+
+    GPIO_EXTILineConfig( GPIO_PortSourceGPIOB, GPIO_PinSource5 );
+    GPIO_EXTILineConfig( GPIO_PortSourceGPIOA, GPIO_PinSource5 );
+    EXTI_InitStructure.EXTI_Line = EXTI_Line5;
+    EXTI_InitStructure.EXTI_Mode = EXTI_Mode_Event;
+    EXTI_InitStructure.EXTI_Trigger = EXTI_Trigger_Rising;
+    EXTI_InitStructure.EXTI_LineCmd = ENABLE;
+    EXTI_Init( &EXTI_InitStructure );
+
+    GPIO_EXTILineConfig( GPIO_PortSourceGPIOA, GPIO_PinSource6 );
+    EXTI_InitStructure.EXTI_Line = EXTI_Line6;
+    EXTI_InitStructure.EXTI_Mode = EXTI_Mode_Event;
+    EXTI_InitStructure.EXTI_Trigger = EXTI_Trigger_Rising;
+    EXTI_InitStructure.EXTI_LineCmd = ENABLE;
+    EXTI_Init( &EXTI_InitStructure );
+
+    GPIO_EXTILineConfig( GPIO_PortSourceGPIOA, GPIO_PinSource7 );
+    EXTI_InitStructure.EXTI_Line = EXTI_Line7;
+    EXTI_InitStructure.EXTI_Mode = EXTI_Mode_Event;
+    EXTI_InitStructure.EXTI_Trigger = EXTI_Trigger_Rising;
+    EXTI_InitStructure.EXTI_LineCmd = ENABLE;
+    EXTI_Init( &EXTI_InitStructure );
+
+    GPIO_EXTILineConfig( GPIO_PortSourceGPIOA, GPIO_PinSource9 );
+    EXTI_InitStructure.EXTI_Line = EXTI_Line9;
+    EXTI_InitStructure.EXTI_Mode = EXTI_Mode_Event;
+    EXTI_InitStructure.EXTI_Trigger = EXTI_Trigger_Rising;
+    EXTI_InitStructure.EXTI_LineCmd = ENABLE;
+    EXTI_Init( &EXTI_InitStructure );
+
+    EXTI->INTENR |= EXTI_INTENR_MR1 | EXTI_INTENR_MR3 | EXTI_INTENR_MR4 | EXTI_INTENR_MR5 | EXTI_INTENR_MR6 | EXTI_INTENR_MR7 | EXTI_INTENR_MR9;
+}
+
+static uint8_t io_to_scan_result(uint16_t a, uint16_t b, uint16_t d)
+{
+    uint8_t out = 0;
+
+    // row7: PB5
+    if (b & (GPIO_Pin_5)) {
+        out |= 1;
+    }
+    out <<= 1;
+
+    // row6: PA7
+    if (a & (GPIO_Pin_7)) {
+        out |= 1;
+    }
+    out <<= 1;
+
+    // row5: PA9
+    if (a & (GPIO_Pin_9)) {
+        out |= 1;
+    }
+    out <<= 1;
+
+    // row4: PA6
+    if (a & (GPIO_Pin_6)) {
+        out |= 1;
+    }
+    out <<= 1;
+
+    // row3: PA4
+    if (a & (GPIO_Pin_4)) {
+        out |= 1;
+    }
+    out <<= 1;
+
+    // row2: PA5
+    if (a & (GPIO_Pin_5)) {
+        out |= 1;
+    }
+    out <<= 1;
+
+    // row1: PA3
+    if (a & (GPIO_Pin_3)) {
+        out |= 1;
+    }
+    out <<= 1;
+
+    // row0: PD1
+    if (d & (GPIO_Pin_1)) {
+        out |= 1;
+    }
+    return out;
+}
+
+/*********************************************************************
+ * @fn      KB_Scan
+ *
+ * @brief   Perform keyboard scan.
+ *
+ * @return  none
+ */
+void KB_Scan( void )
+{
+    static uint16_t scan_cnt = 0;
+    static uint8_t scan_col = 0;
+    static uint8_t scan_result[N_COLS] = { 0x00 };
+    static uint8_t scan = 0;
+
+    scan_cnt++;
+    if( ( scan_cnt % 10 ) == 0 )
+    {
+        scan_cnt = 0;
+
+        /* Determine whether the two scan results are consistent */
+        if( scan == io_to_scan_result(GPIO_ReadInputData(GPIOA), GPIO_ReadInputData(GPIOB), GPIO_ReadInputData(GPIOD)))
+        {
+            scan_result[scan_col] = scan;
+        }
+        scan_col = (scan_col + 1) % N_COLS;
+        KB_Set_Col(scan_col);
+        if (scan_col == 0) {
+            memcpy(KB_Scan_Result, scan_result, N_COLS);
+            KB_Scan_Done = 1;
+        }
+    }
+    else if( ( scan_cnt % 5 ) == 0 )
+    {
+        /* Save the first scan result */
+        scan = io_to_scan_result(GPIO_ReadInputData(GPIOA), GPIO_ReadInputData(GPIOB), GPIO_ReadInputData(GPIOD));
+    }
+}
+
+static uint8_t get_keycode(uint8_t col, uint8_t row, uint8_t *keycode)
+{
+    *keycode = modifiers[col][row];
+
+    if (*keycode != KEY_NONE) {
+        return 1;
+    }
+
+    *keycode = keycodes[col][row];
+    if (*keycode != KEY_NONE) {
+        return 0;
+    }
+
+    return 2;
+}
+
+static void determine_hid_report(uint8_t keycode, uint8_t is_modifier, uint8_t value, uint8_t *out)
+{
+    uint8_t j;
+    static uint8_t key_cnt = 0x00;
+
+    if (is_modifier) {
+        if (value) {
+            out[0] |= keycode;
+         } else {
+            out[0] &= (~keycode);
+        }
+        return;
+    }
+
+    if (value) { // key press
+        out[ 2 + key_cnt ] = keycode;
+        if (key_cnt < 6) {
+            key_cnt++;
+        }
+    }
+    else { // key release
+        for( j = 2; j < 8; j++ ) {
+            if( out[ j ] == keycode ) {
+                break;
+            }
+        }
+        if( j == 8 ) {
+            out[ 5 ] = 0;
+        }
+        else {
+            memcpy( &out[ j ], &out[ j + 1 ], ( 8 - j - 1 ) );
+            out[ 7 ] = 0;
+        }
+        if (key_cnt > 0) {
+            key_cnt--;
+        }
+    }
+}
+
+static void toggle_backlight(void)
+{
+    static uint8_t on = 0;
+    if (on) {
+        LED_Backlight_SetBrightness(0x00);
+        on = 0;
+    }
+    else {
+        LED_Backlight_SetBrightness(0xff);
+        on = 1;
+    }
+}
+
+static void handle_fn(uint8_t *in, uint8_t *out)
+{
+    uint8_t j;
+
+    if ((in[0] & (KEY_MOD_RMETA | KEY_MOD_RSHIFT)) == (KEY_MOD_RMETA | KEY_MOD_RSHIFT)) {
+        determine_hid_report(KEY_CAPSLOCK, 0, 1, in);
+        LED_Red_Toggle();
+    }
+    else {
+        determine_hid_report(KEY_CAPSLOCK, 0, 0, in);
+    }
+
+    /* take a copy of the report */
+    memcpy(out, in, DEF_ENDP_SIZE_KB);
+
+    /*
+      if the FN key is pressed, modify the output,
+      and trigger special functions
+    */
+    if (out[0] & KEY_MOD_RMETA) {
+
+        /* replace keys and/or trigger special functions */
+        for (j = 2; j < DEF_ENDP_SIZE_KB; j++) {
+            switch (out[j]) {
+            case KEY_LEFTMETA:
+                LED_Lana_SetColour(0x00, 0x00, 0x00);
+                memcpy(&out[j], &out[j+1], (DEF_ENDP_SIZE_KB - j - 1));
+                out[7] = 0;
+                break;
+            case KEY_F1:
+                LED_Lana_SetColour(0xff, 0x00, 0x00);
+                memcpy(&out[j], &out[j+1], (DEF_ENDP_SIZE_KB - j - 1));
+                out[7] = 0;
+                break;
+            case KEY_F2:
+                LED_Lana_SetColour(0xff, 44, 0x00);
+                memcpy(&out[j], &out[j+1], (DEF_ENDP_SIZE_KB - j - 1));
+                out[7] = 0;
+                break;
+            case KEY_F3:
+                LED_Lana_SetColour(0xff, 0xff, 0x00);
+                memcpy(&out[j], &out[j+1], (DEF_ENDP_SIZE_KB - j - 1));
+                out[7] = 0;
+                break;
+            case KEY_F4:
+                LED_Lana_SetColour(0x00, 0xff, 0x00);
+                memcpy(&out[j], &out[j+1], (DEF_ENDP_SIZE_KB - j - 1));
+                out[7] = 0;
+                break;
+            case KEY_F5:
+                LED_Lana_SetColour(0x00, 0x00, 0xff);
+                memcpy(&out[j], &out[j+1], (DEF_ENDP_SIZE_KB - j - 1));
+                out[7] = 0;
+                break;
+            case KEY_F6:
+                LED_Lana_SetColour(0x80, 0x00, 0x80);
+                memcpy(&out[j], &out[j+1], (DEF_ENDP_SIZE_KB - j - 1));
+                out[7] = 0;
+                break;
+            case KEY_SPACE:
+                toggle_backlight();
+                memcpy(&out[j], &out[j+1], (DEF_ENDP_SIZE_KB - j - 1));
+                out[7] = 0;
+                break;
+            case KEY_BACKSPACE:
+                out[j] = KEY_DELETE;
+                break;
+            case KEY_LEFT:
+                out[j] = KEY_HOME;
+                break;
+            case KEY_RIGHT:
+                out[j] = KEY_END;
+                break;
+            case KEY_UP:
+                out[j] = KEY_PAGEUP;
+                break;
+            case KEY_DOWN:
+                out[j] = KEY_PAGEDOWN;
+                break;
+            default:
+                break;
+            }
+        }
+
+        /* clear the FN key in the reporting */
+        out[0] &= (~KEY_MOD_RMETA);
+    }
+}
+
+static uint8_t wait_for_event(uint32_t I2C_EVENT)
+{
+    uint8_t tries = 10;
+    while (tries > 0) {
+        if (!I2C_CheckEvent(I2C1, I2C_EVENT )) {
+            Delay_Ms(20);
+        } else {
+            return 1;
+        }
+        tries--;
+    }
+    return 0;
+}
+
+static uint8_t wait_for_flag(uint32_t I2C_FLAG)
+{
+    uint8_t tries = 10;
+    while (tries > 0) {
+        if (I2C_GetFlagStatus(I2C1, I2C_FLAG) == RESET) {
+            Delay_Ms(20);
+        } else {
+            return 1;
+        }
+        tries--;
+    }
+    return 0;
+}
+
+/*********************************************************************
+ * @fn      KB_Scan_Handle
+ *
+ * @brief   Handle keyboard scan data.
+ *
+ * @return  none
+ */
+void KB_Scan_Handle( void )
+{
+    uint8_t c, i, keycode, is_modifier;
+    static uint8_t flag = 0x00;
+    static uint8_t reported[DEF_ENDP_SIZE_KB];
+
+    if( KB_Scan_Done )
+    {
+        KB_Scan_Done = 0;
+
+        if( memcmp(KB_Scan_Result, KB_Scan_Last_Result, N_COLS) != 0 )
+        {
+            for( c = 0; c < N_COLS; c++ )
+            {
+                if (KB_Scan_Result[c] != KB_Scan_Last_Result[c]) {
+                    for( i = 0; i < N_ROWS; i++ )
+                    {
+                        /* Determine that there is at least one key is pressed or released */
+                        if( ( KB_Scan_Result[c] & ( 1 << i ) ) != ( KB_Scan_Last_Result[c] & ( 1 << i ) ) )
+                        {
+                            is_modifier = get_keycode(c, i, &keycode);
+                            if (is_modifier != 2) {
+                                determine_hid_report(keycode, is_modifier, ( KB_Scan_Result[c] & ( 1 << i ) ), KB_Data_Pack);
+                            }
+                        }
+                    }
+                }
+            }
+
+            /* Copy the keyboard data to the buffer of endpoint 1 and set the data uploading flag */
+            memcpy(KB_Scan_Last_Result, KB_Scan_Result, N_COLS);
+            /* handle special FN triggers */
+            handle_fn(KB_Data_Pack, reported);
+            flag = 1;
+        }
+    }
+
+    if( flag )
+    {
+#ifdef UARTOUTPUT
+        /* send it to uart2 */
+        for(i = 0; i < DEF_ENDP_SIZE_KB; i++){
+            while(USART_GetFlagStatus(USART2, USART_FLAG_TC) == RESET);
+            USART_SendData(USART2, reported[i]);
+        }
+#endif
+
+        /* Load keyboard data to endpoint 1 */
+        if( bDeviceState == CONFIGURED )
+        {
+            USBD_ENDPx_DataUp(ENDP1, reported, DEF_ENDP_SIZE_KB);
+        }
+
+        /* Clear flag always */
+        flag = 0;
+    }
+
+#ifdef I2COUTPUT
+    /* send it on i2c if requested by the master */
+    if (I2C_CheckEvent( I2C1, I2C_EVENT_SLAVE_RECEIVER_ADDRESS_MATCHED )) {
+        for (i = 0; i < DEF_ENDP_SIZE_KB; i++) {
+            // send the byte to master
+            if (wait_for_flag(I2C_FLAG_TXE) == 0) {
+                break;
+            }
+            I2C_SendData(I2C1, reported[i]);
+            if (i < (DEF_ENDP_SIZE_KB-1)) {
+                // wait for the master to ack
+                if (wait_for_event(I2C_EVENT_SLAVE_BYTE_TRANSMITTED) == 0) {
+                    break;
+                }
+            } else {
+                // wait for master to end the receiving
+                if (wait_for_event(I2C_EVENT_SLAVE_ACK_FAILURE) == 0) {
+                    break;
+                }
+            }
+        }
+        I2C1->CTLR1 &= I2C1->CTLR1;
+    }
+#endif
+}
+
+/*********************************************************************
+ * @fn      MCU_Sleep_Wakeup_Operate
+ *
+ * @brief   Perform sleep operation
+ *
+ * @return  none
+ */
+void MCU_Sleep_Wakeup_Operate( void )
+{
+    EXTI_ClearFlag( EXTI_Line1 | EXTI_Line3 | EXTI_Line4 | EXTI_Line5 | EXTI_Line6 | EXTI_Line7 | EXTI_Line9 );
+
+    __WFE( );
+
+    if( EXTI_GetFlagStatus( EXTI_Line1 | EXTI_Line3 | EXTI_Line4 | EXTI_Line5 | EXTI_Line6 | EXTI_Line7 | EXTI_Line9 ) != RESET  )
+    {
+        EXTI_ClearFlag( EXTI_Line1 | EXTI_Line3 | EXTI_Line4 | EXTI_Line5 | EXTI_Line6 | EXTI_Line7 | EXTI_Line9 );
+        Resume(RESUME_INTERNAL);
+    }
+}
+
+
+

--- a/Sources/source/Peripheral/inc/ch32v20x.h
+++ b/Sources/source/Peripheral/inc/ch32v20x.h
@@ -1,0 +1,4819 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32v20x.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/06/06
+ * Description        : CH32V20x Device Peripheral Access Layer Header File.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __CH32V20x_H
+#define __CH32V20x_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if !defined(CH32V20x_D8W) && !defined(CH32V20x_D8) && !defined(CH32V20x_D6)
+#define CH32V20x_D6              /* CH32V203F6-CH32V203F8-CH32V203G6-CH32V203G8-CH32V203K6-CH32V203K8-CH32V203C6-CH32V203C8 */
+//#define CH32V20x_D8              /* CH32V203RBT6 */
+//#define CH32V20x_D8W             /* CH32V208 */
+
+#endif
+
+#define __MPU_PRESENT             0                   /* Other CH32 devices does not provide an MPU */
+#define __Vendor_SysTickConfig    0                   /* Set to 1 if different SysTick Config is used */
+
+#if defined(CH32V20x_D8) || defined(CH32V20x_D8W)
+  #define HSE_VALUE    ((uint32_t)32000000) /* Value of the External oscillator in Hz */
+#else
+  #define HSE_VALUE    ((uint32_t)8000000) /* Value of the External oscillator in Hz */
+#endif
+
+/* In the following line adjust the External High Speed oscillator (HSE) Startup Timeout value */
+#define HSE_STARTUP_TIMEOUT    ((uint16_t)0x1000) /* Time out for HSE start up */
+
+#define HSI_VALUE              ((uint32_t)8000000) /* Value of the Internal oscillator in Hz */
+
+/* Interrupt Number Definition, according to the selected device */
+typedef enum IRQn
+{
+    /******  RISC-V Processor Exceptions Numbers *******************************************************/
+    NonMaskableInt_IRQn = 2, /* 2 Non Maskable Interrupt                             */
+    EXC_IRQn = 3,            /* 3 Exception Interrupt                                */
+    Ecall_M_Mode_IRQn = 5,   /* 5 Ecall M Mode Interrupt                             */
+    Ecall_U_Mode_IRQn = 8,   /* 8 Ecall U Mode Interrupt                             */
+    Break_Point_IRQn = 9,    /* 9 Break Point Interrupt                              */
+    SysTicK_IRQn = 12,       /* 12 System timer Interrupt                            */
+    Software_IRQn = 14,      /* 14 software Interrupt                                */
+
+    /******  RISC-V specific Interrupt Numbers *********************************************************/
+    WWDG_IRQn = 16,            /* Window WatchDog Interrupt                            */
+    PVD_IRQn = 17,             /* PVD through EXTI Line detection Interrupt            */
+    TAMPER_IRQn = 18,          /* Tamper Interrupt                                     */
+    RTC_IRQn = 19,             /* RTC global Interrupt                                 */
+    FLASH_IRQn = 20,           /* FLASH global Interrupt                               */
+    RCC_IRQn = 21,             /* RCC global Interrupt                                 */
+    EXTI0_IRQn = 22,           /* EXTI Line0 Interrupt                                 */
+    EXTI1_IRQn = 23,           /* EXTI Line1 Interrupt                                 */
+    EXTI2_IRQn = 24,           /* EXTI Line2 Interrupt                                 */
+    EXTI3_IRQn = 25,           /* EXTI Line3 Interrupt                                 */
+    EXTI4_IRQn = 26,           /* EXTI Line4 Interrupt                                 */
+    DMA1_Channel1_IRQn = 27,   /* DMA1 Channel 1 global Interrupt                      */
+    DMA1_Channel2_IRQn = 28,   /* DMA1 Channel 2 global Interrupt                      */
+    DMA1_Channel3_IRQn = 29,   /* DMA1 Channel 3 global Interrupt                      */
+    DMA1_Channel4_IRQn = 30,   /* DMA1 Channel 4 global Interrupt                      */
+    DMA1_Channel5_IRQn = 31,   /* DMA1 Channel 5 global Interrupt                      */
+    DMA1_Channel6_IRQn = 32,   /* DMA1 Channel 6 global Interrupt                      */
+    DMA1_Channel7_IRQn = 33,   /* DMA1 Channel 7 global Interrupt                      */
+    ADC_IRQn = 34,             /* ADC1 and ADC2 global Interrupt                       */
+    USB_HP_CAN1_TX_IRQn = 35,  /* USB Device High Priority or CAN1 TX Interrupts       */
+    USB_LP_CAN1_RX0_IRQn = 36, /* USB Device Low Priority or CAN1 RX0 Interrupts       */
+    CAN1_RX1_IRQn = 37,        /* CAN1 RX1 Interrupt                                   */
+    CAN1_SCE_IRQn = 38,        /* CAN1 SCE Interrupt                                   */
+    EXTI9_5_IRQn = 39,         /* External Line[9:5] Interrupts                        */
+    TIM1_BRK_IRQn = 40,        /* TIM1 Break Interrupt                                 */
+    TIM1_UP_IRQn = 41,         /* TIM1 Update Interrupt                                */
+    TIM1_TRG_COM_IRQn = 42,    /* TIM1 Trigger and Commutation Interrupt               */
+    TIM1_CC_IRQn = 43,         /* TIM1 Capture Compare Interrupt                       */
+    TIM2_IRQn = 44,            /* TIM2 global Interrupt                                */
+    TIM3_IRQn = 45,            /* TIM3 global Interrupt                                */
+    TIM4_IRQn = 46,            /* TIM4 global Interrupt                                */
+    I2C1_EV_IRQn = 47,         /* I2C1 Event Interrupt                                 */
+    I2C1_ER_IRQn = 48,         /* I2C1 Error Interrupt                                 */
+    I2C2_EV_IRQn = 49,         /* I2C2 Event Interrupt                                 */
+    I2C2_ER_IRQn = 50,         /* I2C2 Error Interrupt                                 */
+    SPI1_IRQn = 51,            /* SPI1 global Interrupt                                */
+    SPI2_IRQn = 52,            /* SPI2 global Interrupt                                */
+    USART1_IRQn = 53,          /* USART1 global Interrupt                              */
+    USART2_IRQn = 54,          /* USART2 global Interrupt                              */
+    USART3_IRQn = 55,          /* USART3 global Interrupt                              */
+    EXTI15_10_IRQn = 56,       /* External Line[15:10] Interrupts                      */
+    RTCAlarm_IRQn = 57,        /* RTC Alarm through EXTI Line Interrupt                */
+    USBWakeUp_IRQn = 58,       /* USB Device WakeUp from suspend through EXTI Line Interrupt 	*/
+    USBHD_IRQn = 59,           /* USBHD global Interrupt                               */
+    USBHDWakeUp_IRQn = 60,     /* USB Host/Device WakeUp Interrupt                     */
+
+#ifdef CH32V20x_D6
+    UART4_IRQn = 61,         /* UART4 global Interrupt                               */
+    DMA1_Channel8_IRQn = 62, /* DMA1 Channel 8 global Interrupt                      */
+
+#elif defined(CH32V20x_D8)
+    ETH_IRQn = 61,           /* ETH global Interrupt               	                 */
+    ETHWakeUp_IRQn = 62,     /* ETH WakeUp Interrupt                       			 */
+    TIM5_IRQn = 65,          /* TIM5 global Interrupt                                */
+    UART4_IRQn = 66,         /* UART4 global Interrupt                               */
+    DMA1_Channel8_IRQn = 67, /* DMA1 Channel 8 global Interrupt                      */
+    OSC32KCal_IRQn = 68,     /* OSC32K global Interrupt                              */
+    OSCWakeUp_IRQn = 69,     /* OSC32K WakeUp Interrupt                              */
+
+#elif defined(CH32V20x_D8W)
+    ETH_IRQn = 61,           /* ETH global Interrupt               	                 */
+    ETHWakeUp_IRQn = 62,     /* ETH WakeUp Interrupt                       			 */
+    BB_IRQn = 63,            /* BLE BB global Interrupt                              */
+    LLE_IRQn = 64,           /* BLE LLE global Interrupt                             */
+    TIM5_IRQn = 65,          /* TIM5 global Interrupt                                */
+    UART4_IRQn = 66,         /* UART4 global Interrupt                               */
+    DMA1_Channel8_IRQn = 67, /* DMA1 Channel 8 global Interrupt                      */
+    OSC32KCal_IRQn = 68,     /* OSC32K global Interrupt                              */
+    OSCWakeUp_IRQn = 69,     /* OSC32K WakeUp Interrupt                              */
+#endif
+
+} IRQn_Type;
+
+#define HardFault_IRQn    EXC_IRQn
+#define ADC1_2_IRQn       ADC_IRQn
+
+#include <stdint.h>
+#include "core_riscv.h"
+#include "system_ch32v20x.h"
+
+/* Standard Peripheral Library old definitions (maintained for legacy purpose) */
+#define HSI_Value             HSI_VALUE
+#define HSE_Value             HSE_VALUE
+#define HSEStartUp_TimeOut    HSE_STARTUP_TIMEOUT
+
+/* Analog to Digital Converter */
+typedef struct
+{
+    __IO uint32_t STATR;
+    __IO uint32_t CTLR1;
+    __IO uint32_t CTLR2;
+    __IO uint32_t SAMPTR1;
+    __IO uint32_t SAMPTR2;
+    __IO uint32_t IOFR1;
+    __IO uint32_t IOFR2;
+    __IO uint32_t IOFR3;
+    __IO uint32_t IOFR4;
+    __IO uint32_t WDHTR;
+    __IO uint32_t WDLTR;
+    __IO uint32_t RSQR1;
+    __IO uint32_t RSQR2;
+    __IO uint32_t RSQR3;
+    __IO uint32_t ISQR;
+    __IO uint32_t IDATAR1;
+    __IO uint32_t IDATAR2;
+    __IO uint32_t IDATAR3;
+    __IO uint32_t IDATAR4;
+    __IO uint32_t RDATAR;
+} ADC_TypeDef;
+
+/* Backup Registers */
+typedef struct
+{
+    uint32_t      RESERVED0;
+    __IO uint16_t DATAR1;
+    uint16_t      RESERVED1;
+    __IO uint16_t DATAR2;
+    uint16_t      RESERVED2;
+    __IO uint16_t DATAR3;
+    uint16_t      RESERVED3;
+    __IO uint16_t DATAR4;
+    uint16_t      RESERVED4;
+    __IO uint16_t DATAR5;
+    uint16_t      RESERVED5;
+    __IO uint16_t DATAR6;
+    uint16_t      RESERVED6;
+    __IO uint16_t DATAR7;
+    uint16_t      RESERVED7;
+    __IO uint16_t DATAR8;
+    uint16_t      RESERVED8;
+    __IO uint16_t DATAR9;
+    uint16_t      RESERVED9;
+    __IO uint16_t DATAR10;
+    uint16_t      RESERVED10;
+    __IO uint16_t OCTLR;
+    uint16_t      RESERVED11;
+    __IO uint16_t TPCTLR;
+    uint16_t      RESERVED12;
+    __IO uint16_t TPCSR;
+    uint16_t      RESERVED13[5];
+    __IO uint16_t DATAR11;
+    uint16_t      RESERVED14;
+    __IO uint16_t DATAR12;
+    uint16_t      RESERVED15;
+    __IO uint16_t DATAR13;
+    uint16_t      RESERVED16;
+    __IO uint16_t DATAR14;
+    uint16_t      RESERVED17;
+    __IO uint16_t DATAR15;
+    uint16_t      RESERVED18;
+    __IO uint16_t DATAR16;
+    uint16_t      RESERVED19;
+    __IO uint16_t DATAR17;
+    uint16_t      RESERVED20;
+    __IO uint16_t DATAR18;
+    uint16_t      RESERVED21;
+    __IO uint16_t DATAR19;
+    uint16_t      RESERVED22;
+    __IO uint16_t DATAR20;
+    uint16_t      RESERVED23;
+    __IO uint16_t DATAR21;
+    uint16_t      RESERVED24;
+    __IO uint16_t DATAR22;
+    uint16_t      RESERVED25;
+    __IO uint16_t DATAR23;
+    uint16_t      RESERVED26;
+    __IO uint16_t DATAR24;
+    uint16_t      RESERVED27;
+    __IO uint16_t DATAR25;
+    uint16_t      RESERVED28;
+    __IO uint16_t DATAR26;
+    uint16_t      RESERVED29;
+    __IO uint16_t DATAR27;
+    uint16_t      RESERVED30;
+    __IO uint16_t DATAR28;
+    uint16_t      RESERVED31;
+    __IO uint16_t DATAR29;
+    uint16_t      RESERVED32;
+    __IO uint16_t DATAR30;
+    uint16_t      RESERVED33;
+    __IO uint16_t DATAR31;
+    uint16_t      RESERVED34;
+    __IO uint16_t DATAR32;
+    uint16_t      RESERVED35;
+    __IO uint16_t DATAR33;
+    uint16_t      RESERVED36;
+    __IO uint16_t DATAR34;
+    uint16_t      RESERVED37;
+    __IO uint16_t DATAR35;
+    uint16_t      RESERVED38;
+    __IO uint16_t DATAR36;
+    uint16_t      RESERVED39;
+    __IO uint16_t DATAR37;
+    uint16_t      RESERVED40;
+    __IO uint16_t DATAR38;
+    uint16_t      RESERVED41;
+    __IO uint16_t DATAR39;
+    uint16_t      RESERVED42;
+    __IO uint16_t DATAR40;
+    uint16_t      RESERVED43;
+    __IO uint16_t DATAR41;
+    uint16_t      RESERVED44;
+    __IO uint16_t DATAR42;
+    uint16_t      RESERVED45;
+} BKP_TypeDef;
+
+/* Controller Area Network TxMailBox */
+typedef struct
+{
+    __IO uint32_t TXMIR;
+    __IO uint32_t TXMDTR;
+    __IO uint32_t TXMDLR;
+    __IO uint32_t TXMDHR;
+} CAN_TxMailBox_TypeDef;
+
+/* Controller Area Network FIFOMailBox */
+typedef struct
+{
+    __IO uint32_t RXMIR;
+    __IO uint32_t RXMDTR;
+    __IO uint32_t RXMDLR;
+    __IO uint32_t RXMDHR;
+} CAN_FIFOMailBox_TypeDef;
+
+/* Controller Area Network FilterRegister */
+typedef struct
+{
+    __IO uint32_t FR1;
+    __IO uint32_t FR2;
+} CAN_FilterRegister_TypeDef;
+
+/* Controller Area Network */
+typedef struct
+{
+    __IO uint32_t              CTLR;
+    __IO uint32_t              STATR;
+    __IO uint32_t              TSTATR;
+    __IO uint32_t              RFIFO0;
+    __IO uint32_t              RFIFO1;
+    __IO uint32_t              INTENR;
+    __IO uint32_t              ERRSR;
+    __IO uint32_t              BTIMR;
+    uint32_t                   RESERVED0[88];
+    CAN_TxMailBox_TypeDef      sTxMailBox[3];
+    CAN_FIFOMailBox_TypeDef    sFIFOMailBox[2];
+    uint32_t                   RESERVED1[12];
+    __IO uint32_t              FCTLR;
+    __IO uint32_t              FMCFGR;
+    uint32_t                   RESERVED2;
+    __IO uint32_t              FSCFGR;
+    uint32_t                   RESERVED3;
+    __IO uint32_t              FAFIFOR;
+    uint32_t                   RESERVED4;
+    __IO uint32_t              FWR;
+    uint32_t                   RESERVED5[8];
+    CAN_FilterRegister_TypeDef sFilterRegister[28];
+} CAN_TypeDef;
+
+/* CRC Calculation Unit */
+typedef struct
+{
+    __IO uint32_t DATAR;
+    __IO uint8_t  IDATAR;
+    uint8_t       RESERVED0;
+    uint16_t      RESERVED1;
+    __IO uint32_t CTLR;
+} CRC_TypeDef;
+
+/* DMA Channel Controller */
+typedef struct
+{
+    __IO uint32_t CFGR;
+    __IO uint32_t CNTR;
+    __IO uint32_t PADDR;
+    __IO uint32_t MADDR;
+} DMA_Channel_TypeDef;
+
+/* DMA Controller */
+typedef struct
+{
+    __IO uint32_t INTFR;
+    __IO uint32_t INTFCR;
+} DMA_TypeDef;
+
+/* External Interrupt/Event Controller */
+typedef struct
+{
+    __IO uint32_t INTENR;
+    __IO uint32_t EVENR;
+    __IO uint32_t RTENR;
+    __IO uint32_t FTENR;
+    __IO uint32_t SWIEVR;
+    __IO uint32_t INTFR;
+} EXTI_TypeDef;
+
+/* FLASH Registers */
+typedef struct
+{
+    __IO uint32_t ACTLR;
+    __IO uint32_t KEYR;
+    __IO uint32_t OBKEYR;
+    __IO uint32_t STATR;
+    __IO uint32_t CTLR;
+    __IO uint32_t ADDR;
+    __IO uint32_t RESERVED;
+    __IO uint32_t OBR;
+    __IO uint32_t WPR;
+    __IO uint32_t MODEKEYR;
+} FLASH_TypeDef;
+
+/* Option Bytes Registers */
+typedef struct
+{
+    __IO uint16_t RDPR;
+    __IO uint16_t USER;
+    __IO uint16_t Data0;
+    __IO uint16_t Data1;
+    __IO uint16_t WRPR0;
+    __IO uint16_t WRPR1;
+    __IO uint16_t WRPR2;
+    __IO uint16_t WRPR3;
+} OB_TypeDef;
+
+/* General Purpose I/O */
+typedef struct
+{
+    __IO uint32_t CFGLR;
+    __IO uint32_t CFGHR;
+    __IO uint32_t INDR;
+    __IO uint32_t OUTDR;
+    __IO uint32_t BSHR;
+    __IO uint32_t BCR;
+    __IO uint32_t LCKR;
+} GPIO_TypeDef;
+
+/* Alternate Function I/O */
+typedef struct
+{
+    __IO uint32_t ECR;
+    __IO uint32_t PCFR1;
+    __IO uint32_t EXTICR[4];
+    uint32_t      RESERVED0;
+    __IO uint32_t PCFR2;
+} AFIO_TypeDef;
+
+/* Inter Integrated Circuit Interface */
+typedef struct
+{
+    __IO uint16_t CTLR1;
+    uint16_t      RESERVED0;
+    __IO uint16_t CTLR2;
+    uint16_t      RESERVED1;
+    __IO uint16_t OADDR1;
+    uint16_t      RESERVED2;
+    __IO uint16_t OADDR2;
+    uint16_t      RESERVED3;
+    __IO uint16_t DATAR;
+    uint16_t      RESERVED4;
+    __IO uint16_t STAR1;
+    uint16_t      RESERVED5;
+    __IO uint16_t STAR2;
+    uint16_t      RESERVED6;
+    __IO uint16_t CKCFGR;
+    uint16_t      RESERVED7;
+    __IO uint16_t RTR;
+    uint16_t      RESERVED8;
+} I2C_TypeDef;
+
+/* Independent WatchDog */
+typedef struct
+{
+    __IO uint32_t CTLR;
+    __IO uint32_t PSCR;
+    __IO uint32_t RLDR;
+    __IO uint32_t STATR;
+} IWDG_TypeDef;
+
+/* Power Control */
+typedef struct
+{
+    __IO uint32_t CTLR;
+    __IO uint32_t CSR;
+} PWR_TypeDef;
+
+/* Reset and Clock Control */
+typedef struct
+{
+    __IO uint32_t CTLR;
+    __IO uint32_t CFGR0;
+    __IO uint32_t INTR;
+    __IO uint32_t APB2PRSTR;
+    __IO uint32_t APB1PRSTR;
+    __IO uint32_t AHBPCENR;
+    __IO uint32_t APB2PCENR;
+    __IO uint32_t APB1PCENR;
+    __IO uint32_t BDCTLR;
+    __IO uint32_t RSTSCKR;
+
+    __IO uint32_t AHBRSTR;
+    __IO uint32_t CFGR2;
+} RCC_TypeDef;
+
+/* Real-Time Clock */
+typedef struct
+{
+    __IO uint16_t CTLRH;
+    uint16_t      RESERVED0;
+    __IO uint16_t CTLRL;
+    uint16_t      RESERVED1;
+    __IO uint16_t PSCRH;
+    uint16_t      RESERVED2;
+    __IO uint16_t PSCRL;
+    uint16_t      RESERVED3;
+    __IO uint16_t DIVH;
+    uint16_t      RESERVED4;
+    __IO uint16_t DIVL;
+    uint16_t      RESERVED5;
+    __IO uint16_t CNTH;
+    uint16_t      RESERVED6;
+    __IO uint16_t CNTL;
+    uint16_t      RESERVED7;
+    __IO uint16_t ALRMH;
+    uint16_t      RESERVED8;
+    __IO uint16_t ALRML;
+    uint16_t      RESERVED9;
+} RTC_TypeDef;
+
+/* Serial Peripheral Interface */
+typedef struct
+{
+    __IO uint16_t CTLR1;
+    uint16_t      RESERVED0;
+    __IO uint16_t CTLR2;
+    uint16_t      RESERVED1;
+    __IO uint16_t STATR;
+    uint16_t      RESERVED2;
+    __IO uint16_t DATAR;
+    uint16_t      RESERVED3;
+    __IO uint16_t CRCR;
+    uint16_t      RESERVED4;
+    __IO uint16_t RCRCR;
+    uint16_t      RESERVED5;
+    __IO uint16_t TCRCR;
+    uint16_t      RESERVED6;
+    __IO uint16_t I2SCFGR;
+    uint16_t      RESERVED7;
+    __IO uint16_t I2SPR;
+    uint16_t      RESERVED8;
+    __IO uint16_t HSCR;
+    uint16_t      RESERVED9;
+} SPI_TypeDef;
+
+/* TIM */
+typedef struct
+{
+    __IO uint16_t CTLR1;
+    uint16_t      RESERVED0;
+    __IO uint16_t CTLR2;
+    uint16_t      RESERVED1;
+    __IO uint16_t SMCFGR;
+    uint16_t      RESERVED2;
+    __IO uint16_t DMAINTENR;
+    uint16_t      RESERVED3;
+    __IO uint16_t INTFR;
+    uint16_t      RESERVED4;
+    __IO uint16_t SWEVGR;
+    uint16_t      RESERVED5;
+    __IO uint16_t CHCTLR1;
+    uint16_t      RESERVED6;
+    __IO uint16_t CHCTLR2;
+    uint16_t      RESERVED7;
+    __IO uint16_t CCER;
+    uint16_t      RESERVED8;
+    __IO uint16_t CNT;
+    uint16_t      RESERVED9;
+    __IO uint16_t PSC;
+    uint16_t      RESERVED10;
+    __IO uint16_t ATRLR;
+    uint16_t      RESERVED11;
+    __IO uint16_t RPTCR;
+    uint16_t      RESERVED12;
+    __IO uint16_t CH1CVR;
+    uint16_t      RESERVED13;
+    __IO uint16_t CH2CVR;
+    uint16_t      RESERVED14;
+    __IO uint16_t CH3CVR;
+    uint16_t      RESERVED15;
+    __IO uint16_t CH4CVR;
+    uint16_t      RESERVED16;
+    __IO uint16_t BDTR;
+    uint16_t      RESERVED17;
+    __IO uint16_t DMACFGR;
+    uint16_t      RESERVED18;
+    __IO uint16_t DMAADR;
+    uint16_t      RESERVED19;
+} TIM_TypeDef;
+
+/* Universal Synchronous Asynchronous Receiver Transmitter */
+typedef struct
+{
+    __IO uint16_t STATR;
+    uint16_t      RESERVED0;
+    __IO uint16_t DATAR;
+    uint16_t      RESERVED1;
+    __IO uint16_t BRR;
+    uint16_t      RESERVED2;
+    __IO uint16_t CTLR1;
+    uint16_t      RESERVED3;
+    __IO uint16_t CTLR2;
+    uint16_t      RESERVED4;
+    __IO uint16_t CTLR3;
+    uint16_t      RESERVED5;
+    __IO uint16_t GPR;
+    uint16_t      RESERVED6;
+} USART_TypeDef;
+
+/* Window WatchDog */
+typedef struct
+{
+    __IO uint32_t CTLR;
+    __IO uint32_t CFGR;
+    __IO uint32_t STATR;
+} WWDG_TypeDef;
+
+/* Enhanced Registers */
+typedef struct
+{
+    __IO uint32_t EXTEN_CTR;
+} EXTEN_TypeDef;
+
+/* OPA Registers */
+typedef struct
+{
+    __IO uint32_t CR;
+} OPA_TypeDef;
+
+/* USBFS Registers */
+typedef struct
+{
+    __IO uint8_t  BASE_CTRL;
+    __IO uint8_t  UDEV_CTRL;
+    __IO uint8_t  INT_EN;
+    __IO uint8_t  DEV_ADDR;
+    __IO uint8_t  Reserve0;
+    __IO uint8_t  MIS_ST;
+    __IO uint8_t  INT_FG;
+    __IO uint8_t  INT_ST;
+    __IO uint32_t RX_LEN;
+    __IO uint8_t  UEP4_1_MOD;
+    __IO uint8_t  UEP2_3_MOD;
+    __IO uint8_t  UEP5_6_MOD;
+    __IO uint8_t  UEP7_MOD;
+    __IO uint32_t UEP0_DMA;
+    __IO uint32_t UEP1_DMA;
+    __IO uint32_t UEP2_DMA;
+    __IO uint32_t UEP3_DMA;
+    __IO uint32_t UEP4_DMA;
+    __IO uint32_t UEP5_DMA;
+    __IO uint32_t UEP6_DMA;
+    __IO uint32_t UEP7_DMA;
+    __IO uint16_t UEP0_TX_LEN;
+    __IO uint8_t  UEP0_TX_CTRL;
+    __IO uint8_t  UEP0_RX_CTRL;
+    __IO uint16_t UEP1_TX_LEN;
+    __IO uint8_t  UEP1_TX_CTRL;
+    __IO uint8_t  UEP1_RX_CTRL;
+    __IO uint16_t UEP2_TX_LEN;
+    __IO uint8_t  UEP2_TX_CTRL;
+    __IO uint8_t  UEP2_RX_CTRL;
+    __IO uint16_t UEP3_TX_LEN;
+    __IO uint8_t  UEP3_TX_CTRL;
+    __IO uint8_t  UEP3_RX_CTRL;
+    __IO uint16_t UEP4_TX_LEN;
+    __IO uint8_t  UEP4_TX_CTRL;
+    __IO uint8_t  UEP4_RX_CTRL;
+    __IO uint16_t UEP5_TX_LEN;
+    __IO uint8_t  UEP5_TX_CTRL;
+    __IO uint8_t  UEP5_RX_CTRL;
+    __IO uint16_t UEP6_TX_LEN;
+    __IO uint8_t  UEP6_TX_CTRL;
+    __IO uint8_t  UEP6_RX_CTRL;
+    __IO uint16_t UEP7_TX_LEN;
+    __IO uint8_t  UEP7_TX_CTRL;
+    __IO uint8_t  UEP7_RX_CTRL;
+    __IO uint32_t Reserve1;
+    __IO uint32_t OTG_CR;
+    __IO uint32_t OTG_SR;
+} USBOTG_FS_TypeDef;
+
+typedef struct
+{
+    __IO uint8_t   BASE_CTRL;
+    __IO uint8_t   HOST_CTRL;
+    __IO uint8_t   INT_EN;
+    __IO uint8_t   DEV_ADDR;
+    __IO uint8_t   Reserve0;
+    __IO uint8_t   MIS_ST;
+    __IO uint8_t   INT_FG;
+    __IO uint8_t   INT_ST;
+    __IO uint16_t  RX_LEN;
+    __IO uint16_t  Reserve1;
+    __IO uint8_t   Reserve2;
+    __IO uint8_t   HOST_EP_MOD;
+    __IO uint16_t  Reserve3;
+    __IO uint32_t  Reserve4;
+    __IO uint32_t  Reserve5;
+    __IO uint32_t  HOST_RX_DMA;
+    __IO uint32_t  HOST_TX_DMA;
+    __IO uint32_t  Reserve6;
+    __IO uint32_t  Reserve7;
+    __IO uint32_t  Reserve8;
+    __IO uint32_t  Reserve9;
+    __IO uint32_t  Reserve10;
+    __IO uint16_t  Reserve11;
+    __IO uint16_t  HOST_SETUP;
+    __IO uint8_t   HOST_EP_PID;
+    __IO uint8_t   Reserve12;
+    __IO uint8_t   Reserve13;
+    __IO uint8_t   HOST_RX_CTRL;
+    __IO uint16_t  HOST_TX_LEN;
+    __IO uint8_t   HOST_TX_CTRL;
+    __IO uint8_t   Reserve14;
+    __IO uint32_t  Reserve15;
+    __IO uint32_t  Reserve16;
+    __IO uint32_t  Reserve17;
+    __IO uint32_t  Reserve18;
+    __IO uint32_t  Reserve19;
+    __IO uint32_t  OTG_CR;
+    __IO uint32_t  OTG_SR;
+} USBOTG_FS_HOST_TypeDef;
+
+#if defined(CH32V20x_D8) || defined(CH32V20x_D8W)
+/* ETH10M Registers */
+typedef struct
+{
+    __IO uint8_t reserved1;
+    __IO uint8_t reserved2;
+    __IO uint8_t reserved3;
+    __IO uint8_t EIE;
+
+    __IO uint8_t EIR;
+    __IO uint8_t ESTAT;
+    __IO uint8_t ECON2;
+    __IO uint8_t ECON1;
+
+    __IO uint16_t ETXST;
+    __IO uint16_t ETXLN;
+
+    __IO uint16_t ERXST;
+    __IO uint16_t ERXLN;
+
+    __IO uint32_t HTL;
+    __IO uint32_t HTH;
+
+    __IO uint8_t ERXFON;
+    __IO uint8_t MACON1;
+    __IO uint8_t MACON2;
+    __IO uint8_t MABBIPG;
+
+    __IO uint16_t EPAUS;
+    __IO uint16_t MAMXFL;
+
+    __IO uint16_t MIRD;
+    __IO uint16_t reserved4;
+
+    __IO uint8_t MIERGADR;
+    __IO uint8_t MISTAT;
+    __IO uint16_t MIWR;
+
+    __IO uint32_t MAADRL;
+
+    __IO uint16_t MAADRH;
+    __IO uint16_t reserved5;
+} ETH10M_TypeDef;
+#endif
+
+#if defined(CH32V20x_D8) || defined(CH32V20x_D8W)
+/* OSC Registers */
+typedef struct
+{
+    __IO uint32_t HSE_CAL_CTRL;
+    __IO uint32_t Reserve0;
+    __IO uint16_t Reserve1;
+    __IO uint16_t LSI32K_TUNE;
+    __IO uint32_t Reserve2;
+    __IO uint32_t Reserve3;
+    __IO uint32_t Reserve4;
+    __IO uint32_t Reserve5;
+    __IO uint8_t  Reserve6;
+    __IO uint8_t  LSI32K_CAL_CFG;
+    __IO uint16_t Reserve7;
+    __IO uint16_t LSI32K_CAL_STATR;
+    __IO uint8_t  LSI32K_CAL_OV_CNT;
+    __IO uint8_t  LSI32K_CAL_CTRL;
+} OSC_TypeDef;
+
+#endif
+
+/* Peripheral memory map */
+#define FLASH_BASE                              ((uint32_t)0x08000000) /* FLASH base address in the alias region */
+#define SRAM_BASE                               ((uint32_t)0x20000000) /* SRAM base address in the alias region */
+#define PERIPH_BASE                             ((uint32_t)0x40000000) /* Peripheral base address in the alias region */
+
+#define APB1PERIPH_BASE                         (PERIPH_BASE)
+#define APB2PERIPH_BASE                         (PERIPH_BASE + 0x10000)
+#define AHBPERIPH_BASE                          (PERIPH_BASE + 0x20000)
+
+#define TIM2_BASE                               (APB1PERIPH_BASE + 0x0000)
+#define TIM3_BASE                               (APB1PERIPH_BASE + 0x0400)
+#define TIM4_BASE                               (APB1PERIPH_BASE + 0x0800)
+#define TIM5_BASE                               (APB1PERIPH_BASE + 0x0C00)
+#define RTC_BASE                                (APB1PERIPH_BASE + 0x2800)
+#define WWDG_BASE                               (APB1PERIPH_BASE + 0x2C00)
+#define IWDG_BASE                               (APB1PERIPH_BASE + 0x3000)
+#define SPI2_BASE                               (APB1PERIPH_BASE + 0x3800)
+#define USART2_BASE                             (APB1PERIPH_BASE + 0x4400)
+#define USART3_BASE                             (APB1PERIPH_BASE + 0x4800)
+#define UART4_BASE                              (APB1PERIPH_BASE + 0x4C00)
+#define I2C1_BASE                               (APB1PERIPH_BASE + 0x5400)
+#define I2C2_BASE                               (APB1PERIPH_BASE + 0x5800)
+#define CAN1_BASE                               (APB1PERIPH_BASE + 0x6400)
+#define BKP_BASE                                (APB1PERIPH_BASE + 0x6C00)
+#define PWR_BASE                                (APB1PERIPH_BASE + 0x7000)
+
+#define AFIO_BASE                               (APB2PERIPH_BASE + 0x0000)
+#define EXTI_BASE                               (APB2PERIPH_BASE + 0x0400)
+#define GPIOA_BASE                              (APB2PERIPH_BASE + 0x0800)
+#define GPIOB_BASE                              (APB2PERIPH_BASE + 0x0C00)
+#define GPIOC_BASE                              (APB2PERIPH_BASE + 0x1000)
+#define GPIOD_BASE                              (APB2PERIPH_BASE + 0x1400)
+#define GPIOE_BASE                              (APB2PERIPH_BASE + 0x1800)
+#define GPIOF_BASE                              (APB2PERIPH_BASE + 0x1C00)
+#define GPIOG_BASE                              (APB2PERIPH_BASE + 0x2000)
+#define ADC1_BASE                               (APB2PERIPH_BASE + 0x2400)
+#define ADC2_BASE                               (APB2PERIPH_BASE + 0x2800)
+#define TIM1_BASE                               (APB2PERIPH_BASE + 0x2C00)
+#define SPI1_BASE                               (APB2PERIPH_BASE + 0x3000)
+#define USART1_BASE                             (APB2PERIPH_BASE + 0x3800)
+
+#define DMA1_BASE                               (AHBPERIPH_BASE + 0x0000)
+#define DMA1_Channel1_BASE                      (AHBPERIPH_BASE + 0x0008)
+#define DMA1_Channel2_BASE                      (AHBPERIPH_BASE + 0x001C)
+#define DMA1_Channel3_BASE                      (AHBPERIPH_BASE + 0x0030)
+#define DMA1_Channel4_BASE                      (AHBPERIPH_BASE + 0x0044)
+#define DMA1_Channel5_BASE                      (AHBPERIPH_BASE + 0x0058)
+#define DMA1_Channel6_BASE                      (AHBPERIPH_BASE + 0x006C)
+#define DMA1_Channel7_BASE                      (AHBPERIPH_BASE + 0x0080)
+#define DMA1_Channel8_BASE                      (AHBPERIPH_BASE + 0x0094)
+#define RCC_BASE                                (AHBPERIPH_BASE + 0x1000)
+#define FLASH_R_BASE                            (AHBPERIPH_BASE + 0x2000)
+#define CRC_BASE                                (AHBPERIPH_BASE + 0x3000)
+#define EXTEN_BASE                              (AHBPERIPH_BASE + 0x3800)
+#define OPA_BASE                                (AHBPERIPH_BASE + 0x3804)
+#define ETH10M_BASE                             (AHBPERIPH_BASE + 0x8000)
+
+#define USBFS_BASE                              ((uint32_t)0x50000000)
+
+#define OB_BASE                                 ((uint32_t)0x1FFFF800)
+
+#if defined(CH32V20x_D8) || defined(CH32V20x_D8W)
+#define OSC_BASE                                (AHBPERIPH_BASE + 0x202C)
+#endif
+
+/* Peripheral declaration */
+#define TIM2                                    ((TIM_TypeDef *)TIM2_BASE)
+#define TIM3                                    ((TIM_TypeDef *)TIM3_BASE)
+#define TIM4                                    ((TIM_TypeDef *)TIM4_BASE)
+#define TIM5                                    ((TIM_TypeDef *)TIM5_BASE)
+#define RTC                                     ((RTC_TypeDef *)RTC_BASE)
+#define WWDG                                    ((WWDG_TypeDef *)WWDG_BASE)
+#define IWDG                                    ((IWDG_TypeDef *)IWDG_BASE)
+#define SPI2                                    ((SPI_TypeDef *)SPI2_BASE)
+#define USART2                                  ((USART_TypeDef *)USART2_BASE)
+#define USART3                                  ((USART_TypeDef *)USART3_BASE)
+#define UART4                                   ((USART_TypeDef *)UART4_BASE)
+#define I2C1                                    ((I2C_TypeDef *)I2C1_BASE)
+#define I2C2                                    ((I2C_TypeDef *)I2C2_BASE)
+#define CAN1                                    ((CAN_TypeDef *)CAN1_BASE)
+#define BKP                                     ((BKP_TypeDef *)BKP_BASE)
+#define PWR                                     ((PWR_TypeDef *)PWR_BASE)
+
+#define AFIO                                    ((AFIO_TypeDef *)AFIO_BASE)
+#define EXTI                                    ((EXTI_TypeDef *)EXTI_BASE)
+#define GPIOA                                   ((GPIO_TypeDef *)GPIOA_BASE)
+#define GPIOB                                   ((GPIO_TypeDef *)GPIOB_BASE)
+#define GPIOC                                   ((GPIO_TypeDef *)GPIOC_BASE)
+#define GPIOD                                   ((GPIO_TypeDef *)GPIOD_BASE)
+#define GPIOE                                   ((GPIO_TypeDef *)GPIOE_BASE)
+#define GPIOF                                   ((GPIO_TypeDef *)GPIOF_BASE)
+#define GPIOG                                   ((GPIO_TypeDef *)GPIOG_BASE)
+#define ADC1                                    ((ADC_TypeDef *)ADC1_BASE)
+#define ADC2                                    ((ADC_TypeDef *)ADC2_BASE)
+#define TKey1                                   ((ADC_TypeDef *)ADC1_BASE)
+#define TKey2                                   ((ADC_TypeDef *)ADC2_BASE)
+#define TIM1                                    ((TIM_TypeDef *)TIM1_BASE)
+#define SPI1                                    ((SPI_TypeDef *)SPI1_BASE)
+#define USART1                                  ((USART_TypeDef *)USART1_BASE)
+
+#define DMA1                                    ((DMA_TypeDef *)DMA1_BASE)
+#define DMA1_Channel1                           ((DMA_Channel_TypeDef *)DMA1_Channel1_BASE)
+#define DMA1_Channel2                           ((DMA_Channel_TypeDef *)DMA1_Channel2_BASE)
+#define DMA1_Channel3                           ((DMA_Channel_TypeDef *)DMA1_Channel3_BASE)
+#define DMA1_Channel4                           ((DMA_Channel_TypeDef *)DMA1_Channel4_BASE)
+#define DMA1_Channel5                           ((DMA_Channel_TypeDef *)DMA1_Channel5_BASE)
+#define DMA1_Channel6                           ((DMA_Channel_TypeDef *)DMA1_Channel6_BASE)
+#define DMA1_Channel7                           ((DMA_Channel_TypeDef *)DMA1_Channel7_BASE)
+#define DMA1_Channel8                           ((DMA_Channel_TypeDef *)DMA1_Channel8_BASE)
+#define RCC                                     ((RCC_TypeDef *)RCC_BASE)
+#define FLASH                                   ((FLASH_TypeDef *)FLASH_R_BASE)
+#define CRC                                     ((CRC_TypeDef *)CRC_BASE)
+#define USBOTG_FS                               ((USBOTG_FS_TypeDef *)USBFS_BASE)
+#define USBOTG_H_FS                             ((USBOTG_FS_HOST_TypeDef *)USBFS_BASE)
+#define EXTEN                                   ((EXTEN_TypeDef *)EXTEN_BASE)
+#define OPA                                     ((OPA_TypeDef *)OPA_BASE)
+#define ETH10M                                  ((ETH10M_TypeDef *)ETH10M_BASE)
+
+#define OB                                      ((OB_TypeDef *)OB_BASE)
+
+#if defined(CH32V20x_D8) || defined(CH32V20x_D8W)
+#define OSC                                     ((OSC_TypeDef *)OSC_BASE)
+#endif
+
+
+/******************************************************************************/
+/*                         Peripheral Registers Bits Definition               */
+/******************************************************************************/
+
+/******************************************************************************/
+/*                        Analog to Digital Converter                         */
+/******************************************************************************/
+
+/********************  Bit definition for ADC_STATR register  ********************/
+#define ADC_AWD                                 ((uint8_t)0x01) /* Analog watchdog flag */
+#define ADC_EOC                                 ((uint8_t)0x02) /* End of conversion */
+#define ADC_JEOC                                ((uint8_t)0x04) /* Injected channel end of conversion */
+#define ADC_JSTRT                               ((uint8_t)0x08) /* Injected channel Start flag */
+#define ADC_STRT                                ((uint8_t)0x10) /* Regular channel Start flag */
+
+/*******************  Bit definition for ADC_CTLR1 register  ********************/
+#define ADC_AWDCH                               ((uint32_t)0x0000001F) /* AWDCH[4:0] bits (Analog watchdog channel select bits) */
+#define ADC_AWDCH_0                             ((uint32_t)0x00000001) /* Bit 0 */
+#define ADC_AWDCH_1                             ((uint32_t)0x00000002) /* Bit 1 */
+#define ADC_AWDCH_2                             ((uint32_t)0x00000004) /* Bit 2 */
+#define ADC_AWDCH_3                             ((uint32_t)0x00000008) /* Bit 3 */
+#define ADC_AWDCH_4                             ((uint32_t)0x00000010) /* Bit 4 */
+
+#define ADC_EOCIE                               ((uint32_t)0x00000020) /* Interrupt enable for EOC */
+#define ADC_AWDIE                               ((uint32_t)0x00000040) /* Analog Watchdog interrupt enable */
+#define ADC_JEOCIE                              ((uint32_t)0x00000080) /* Interrupt enable for injected channels */
+#define ADC_SCAN                                ((uint32_t)0x00000100) /* Scan mode */
+#define ADC_AWDSGL                              ((uint32_t)0x00000200) /* Enable the watchdog on a single channel in scan mode */
+#define ADC_JAUTO                               ((uint32_t)0x00000400) /* Automatic injected group conversion */
+#define ADC_DISCEN                              ((uint32_t)0x00000800) /* Discontinuous mode on regular channels */
+#define ADC_JDISCEN                             ((uint32_t)0x00001000) /* Discontinuous mode on injected channels */
+
+#define ADC_DISCNUM                             ((uint32_t)0x0000E000) /* DISCNUM[2:0] bits (Discontinuous mode channel count) */
+#define ADC_DISCNUM_0                           ((uint32_t)0x00002000) /* Bit 0 */
+#define ADC_DISCNUM_1                           ((uint32_t)0x00004000) /* Bit 1 */
+#define ADC_DISCNUM_2                           ((uint32_t)0x00008000) /* Bit 2 */
+
+#define ADC_DUALMOD                             ((uint32_t)0x000F0000) /* DUALMOD[3:0] bits (Dual mode selection) */
+#define ADC_DUALMOD_0                           ((uint32_t)0x00010000) /* Bit 0 */
+#define ADC_DUALMOD_1                           ((uint32_t)0x00020000) /* Bit 1 */
+#define ADC_DUALMOD_2                           ((uint32_t)0x00040000) /* Bit 2 */
+#define ADC_DUALMOD_3                           ((uint32_t)0x00080000) /* Bit 3 */
+
+#define ADC_JAWDEN                              ((uint32_t)0x00400000) /* Analog watchdog enable on injected channels */
+#define ADC_AWDEN                               ((uint32_t)0x00800000) /* Analog watchdog enable on regular channels */
+
+/*******************  Bit definition for ADC_CTLR2 register  ********************/
+#define ADC_ADON                                ((uint32_t)0x00000001) /* A/D Converter ON / OFF */
+#define ADC_CONT                                ((uint32_t)0x00000002) /* Continuous Conversion */
+#define ADC_CAL                                 ((uint32_t)0x00000004) /* A/D Calibration */
+#define ADC_RSTCAL                              ((uint32_t)0x00000008) /* Reset Calibration */
+#define ADC_DMA                                 ((uint32_t)0x00000100) /* Direct Memory access mode */
+#define ADC_ALIGN                               ((uint32_t)0x00000800) /* Data Alignment */
+
+#define ADC_JEXTSEL                             ((uint32_t)0x00007000) /* JEXTSEL[2:0] bits (External event select for injected group) */
+#define ADC_JEXTSEL_0                           ((uint32_t)0x00001000) /* Bit 0 */
+#define ADC_JEXTSEL_1                           ((uint32_t)0x00002000) /* Bit 1 */
+#define ADC_JEXTSEL_2                           ((uint32_t)0x00004000) /* Bit 2 */
+
+#define ADC_JEXTTRIG                            ((uint32_t)0x00008000) /* External Trigger Conversion mode for injected channels */
+
+#define ADC_EXTSEL                              ((uint32_t)0x000E0000) /* EXTSEL[2:0] bits (External Event Select for regular group) */
+#define ADC_EXTSEL_0                            ((uint32_t)0x00020000) /* Bit 0 */
+#define ADC_EXTSEL_1                            ((uint32_t)0x00040000) /* Bit 1 */
+#define ADC_EXTSEL_2                            ((uint32_t)0x00080000) /* Bit 2 */
+
+#define ADC_EXTTRIG                             ((uint32_t)0x00100000) /* External Trigger Conversion mode for regular channels */
+#define ADC_JSWSTART                            ((uint32_t)0x00200000) /* Start Conversion of injected channels */
+#define ADC_SWSTART                             ((uint32_t)0x00400000) /* Start Conversion of regular channels */
+#define ADC_TSVREFE                             ((uint32_t)0x00800000) /* Temperature Sensor and VREFINT Enable */
+
+/******************  Bit definition for ADC_SAMPTR1 register  *******************/
+#define ADC_SMP10                               ((uint32_t)0x00000007) /* SMP10[2:0] bits (Channel 10 Sample time selection) */
+#define ADC_SMP10_0                             ((uint32_t)0x00000001) /* Bit 0 */
+#define ADC_SMP10_1                             ((uint32_t)0x00000002) /* Bit 1 */
+#define ADC_SMP10_2                             ((uint32_t)0x00000004) /* Bit 2 */
+
+#define ADC_SMP11                               ((uint32_t)0x00000038) /* SMP11[2:0] bits (Channel 11 Sample time selection) */
+#define ADC_SMP11_0                             ((uint32_t)0x00000008) /* Bit 0 */
+#define ADC_SMP11_1                             ((uint32_t)0x00000010) /* Bit 1 */
+#define ADC_SMP11_2                             ((uint32_t)0x00000020) /* Bit 2 */
+
+#define ADC_SMP12                               ((uint32_t)0x000001C0) /* SMP12[2:0] bits (Channel 12 Sample time selection) */
+#define ADC_SMP12_0                             ((uint32_t)0x00000040) /* Bit 0 */
+#define ADC_SMP12_1                             ((uint32_t)0x00000080) /* Bit 1 */
+#define ADC_SMP12_2                             ((uint32_t)0x00000100) /* Bit 2 */
+
+#define ADC_SMP13                               ((uint32_t)0x00000E00) /* SMP13[2:0] bits (Channel 13 Sample time selection) */
+#define ADC_SMP13_0                             ((uint32_t)0x00000200) /* Bit 0 */
+#define ADC_SMP13_1                             ((uint32_t)0x00000400) /* Bit 1 */
+#define ADC_SMP13_2                             ((uint32_t)0x00000800) /* Bit 2 */
+
+#define ADC_SMP14                               ((uint32_t)0x00007000) /* SMP14[2:0] bits (Channel 14 Sample time selection) */
+#define ADC_SMP14_0                             ((uint32_t)0x00001000) /* Bit 0 */
+#define ADC_SMP14_1                             ((uint32_t)0x00002000) /* Bit 1 */
+#define ADC_SMP14_2                             ((uint32_t)0x00004000) /* Bit 2 */
+
+#define ADC_SMP15                               ((uint32_t)0x00038000) /* SMP15[2:0] bits (Channel 15 Sample time selection) */
+#define ADC_SMP15_0                             ((uint32_t)0x00008000) /* Bit 0 */
+#define ADC_SMP15_1                             ((uint32_t)0x00010000) /* Bit 1 */
+#define ADC_SMP15_2                             ((uint32_t)0x00020000) /* Bit 2 */
+
+#define ADC_SMP16                               ((uint32_t)0x001C0000) /* SMP16[2:0] bits (Channel 16 Sample time selection) */
+#define ADC_SMP16_0                             ((uint32_t)0x00040000) /* Bit 0 */
+#define ADC_SMP16_1                             ((uint32_t)0x00080000) /* Bit 1 */
+#define ADC_SMP16_2                             ((uint32_t)0x00100000) /* Bit 2 */
+
+#define ADC_SMP17                               ((uint32_t)0x00E00000) /* SMP17[2:0] bits (Channel 17 Sample time selection) */
+#define ADC_SMP17_0                             ((uint32_t)0x00200000) /* Bit 0 */
+#define ADC_SMP17_1                             ((uint32_t)0x00400000) /* Bit 1 */
+#define ADC_SMP17_2                             ((uint32_t)0x00800000) /* Bit 2 */
+
+/******************  Bit definition for ADC_SAMPTR2 register  *******************/
+#define ADC_SMP0                                ((uint32_t)0x00000007) /* SMP0[2:0] bits (Channel 0 Sample time selection) */
+#define ADC_SMP0_0                              ((uint32_t)0x00000001) /* Bit 0 */
+#define ADC_SMP0_1                              ((uint32_t)0x00000002) /* Bit 1 */
+#define ADC_SMP0_2                              ((uint32_t)0x00000004) /* Bit 2 */
+
+#define ADC_SMP1                                ((uint32_t)0x00000038) /* SMP1[2:0] bits (Channel 1 Sample time selection) */
+#define ADC_SMP1_0                              ((uint32_t)0x00000008) /* Bit 0 */
+#define ADC_SMP1_1                              ((uint32_t)0x00000010) /* Bit 1 */
+#define ADC_SMP1_2                              ((uint32_t)0x00000020) /* Bit 2 */
+
+#define ADC_SMP2                                ((uint32_t)0x000001C0) /* SMP2[2:0] bits (Channel 2 Sample time selection) */
+#define ADC_SMP2_0                              ((uint32_t)0x00000040) /* Bit 0 */
+#define ADC_SMP2_1                              ((uint32_t)0x00000080) /* Bit 1 */
+#define ADC_SMP2_2                              ((uint32_t)0x00000100) /* Bit 2 */
+
+#define ADC_SMP3                                ((uint32_t)0x00000E00) /* SMP3[2:0] bits (Channel 3 Sample time selection) */
+#define ADC_SMP3_0                              ((uint32_t)0x00000200) /* Bit 0 */
+#define ADC_SMP3_1                              ((uint32_t)0x00000400) /* Bit 1 */
+#define ADC_SMP3_2                              ((uint32_t)0x00000800) /* Bit 2 */
+
+#define ADC_SMP4                                ((uint32_t)0x00007000) /* SMP4[2:0] bits (Channel 4 Sample time selection) */
+#define ADC_SMP4_0                              ((uint32_t)0x00001000) /* Bit 0 */
+#define ADC_SMP4_1                              ((uint32_t)0x00002000) /* Bit 1 */
+#define ADC_SMP4_2                              ((uint32_t)0x00004000) /* Bit 2 */
+
+#define ADC_SMP5                                ((uint32_t)0x00038000) /* SMP5[2:0] bits (Channel 5 Sample time selection) */
+#define ADC_SMP5_0                              ((uint32_t)0x00008000) /* Bit 0 */
+#define ADC_SMP5_1                              ((uint32_t)0x00010000) /* Bit 1 */
+#define ADC_SMP5_2                              ((uint32_t)0x00020000) /* Bit 2 */
+
+#define ADC_SMP6                                ((uint32_t)0x001C0000) /* SMP6[2:0] bits (Channel 6 Sample time selection) */
+#define ADC_SMP6_0                              ((uint32_t)0x00040000) /* Bit 0 */
+#define ADC_SMP6_1                              ((uint32_t)0x00080000) /* Bit 1 */
+#define ADC_SMP6_2                              ((uint32_t)0x00100000) /* Bit 2 */
+
+#define ADC_SMP7                                ((uint32_t)0x00E00000) /* SMP7[2:0] bits (Channel 7 Sample time selection) */
+#define ADC_SMP7_0                              ((uint32_t)0x00200000) /* Bit 0 */
+#define ADC_SMP7_1                              ((uint32_t)0x00400000) /* Bit 1 */
+#define ADC_SMP7_2                              ((uint32_t)0x00800000) /* Bit 2 */
+
+#define ADC_SMP8                                ((uint32_t)0x07000000) /* SMP8[2:0] bits (Channel 8 Sample time selection) */
+#define ADC_SMP8_0                              ((uint32_t)0x01000000) /* Bit 0 */
+#define ADC_SMP8_1                              ((uint32_t)0x02000000) /* Bit 1 */
+#define ADC_SMP8_2                              ((uint32_t)0x04000000) /* Bit 2 */
+
+#define ADC_SMP9                                ((uint32_t)0x38000000) /* SMP9[2:0] bits (Channel 9 Sample time selection) */
+#define ADC_SMP9_0                              ((uint32_t)0x08000000) /* Bit 0 */
+#define ADC_SMP9_1                              ((uint32_t)0x10000000) /* Bit 1 */
+#define ADC_SMP9_2                              ((uint32_t)0x20000000) /* Bit 2 */
+
+/******************  Bit definition for ADC_IOFR1 register  *******************/
+#define ADC_JOFFSET1                            ((uint16_t)0x0FFF) /* Data offset for injected channel 1 */
+
+/******************  Bit definition for ADC_IOFR2 register  *******************/
+#define ADC_JOFFSET2                            ((uint16_t)0x0FFF) /* Data offset for injected channel 2 */
+
+/******************  Bit definition for ADC_IOFR3 register  *******************/
+#define ADC_JOFFSET3                            ((uint16_t)0x0FFF) /* Data offset for injected channel 3 */
+
+/******************  Bit definition for ADC_IOFR4 register  *******************/
+#define ADC_JOFFSET4                            ((uint16_t)0x0FFF) /* Data offset for injected channel 4 */
+
+/*******************  Bit definition for ADC_WDHTR register  ********************/
+#define ADC_HT                                  ((uint16_t)0x0FFF) /* Analog watchdog high threshold */
+
+/*******************  Bit definition for ADC_WDLTR register  ********************/
+#define ADC_LT                                  ((uint16_t)0x0FFF) /* Analog watchdog low threshold */
+
+/*******************  Bit definition for ADC_RSQR1 register  *******************/
+#define ADC_SQ13                                ((uint32_t)0x0000001F) /* SQ13[4:0] bits (13th conversion in regular sequence) */
+#define ADC_SQ13_0                              ((uint32_t)0x00000001) /* Bit 0 */
+#define ADC_SQ13_1                              ((uint32_t)0x00000002) /* Bit 1 */
+#define ADC_SQ13_2                              ((uint32_t)0x00000004) /* Bit 2 */
+#define ADC_SQ13_3                              ((uint32_t)0x00000008) /* Bit 3 */
+#define ADC_SQ13_4                              ((uint32_t)0x00000010) /* Bit 4 */
+
+#define ADC_SQ14                                ((uint32_t)0x000003E0) /* SQ14[4:0] bits (14th conversion in regular sequence) */
+#define ADC_SQ14_0                              ((uint32_t)0x00000020) /* Bit 0 */
+#define ADC_SQ14_1                              ((uint32_t)0x00000040) /* Bit 1 */
+#define ADC_SQ14_2                              ((uint32_t)0x00000080) /* Bit 2 */
+#define ADC_SQ14_3                              ((uint32_t)0x00000100) /* Bit 3 */
+#define ADC_SQ14_4                              ((uint32_t)0x00000200) /* Bit 4 */
+
+#define ADC_SQ15                                ((uint32_t)0x00007C00) /* SQ15[4:0] bits (15th conversion in regular sequence) */
+#define ADC_SQ15_0                              ((uint32_t)0x00000400) /* Bit 0 */
+#define ADC_SQ15_1                              ((uint32_t)0x00000800) /* Bit 1 */
+#define ADC_SQ15_2                              ((uint32_t)0x00001000) /* Bit 2 */
+#define ADC_SQ15_3                              ((uint32_t)0x00002000) /* Bit 3 */
+#define ADC_SQ15_4                              ((uint32_t)0x00004000) /* Bit 4 */
+
+#define ADC_SQ16                                ((uint32_t)0x000F8000) /* SQ16[4:0] bits (16th conversion in regular sequence) */
+#define ADC_SQ16_0                              ((uint32_t)0x00008000) /* Bit 0 */
+#define ADC_SQ16_1                              ((uint32_t)0x00010000) /* Bit 1 */
+#define ADC_SQ16_2                              ((uint32_t)0x00020000) /* Bit 2 */
+#define ADC_SQ16_3                              ((uint32_t)0x00040000) /* Bit 3 */
+#define ADC_SQ16_4                              ((uint32_t)0x00080000) /* Bit 4 */
+
+#define ADC_L                                   ((uint32_t)0x00F00000) /* L[3:0] bits (Regular channel sequence length) */
+#define ADC_L_0                                 ((uint32_t)0x00100000) /* Bit 0 */
+#define ADC_L_1                                 ((uint32_t)0x00200000) /* Bit 1 */
+#define ADC_L_2                                 ((uint32_t)0x00400000) /* Bit 2 */
+#define ADC_L_3                                 ((uint32_t)0x00800000) /* Bit 3 */
+
+/*******************  Bit definition for ADC_RSQR2 register  *******************/
+#define ADC_SQ7                                 ((uint32_t)0x0000001F) /* SQ7[4:0] bits (7th conversion in regular sequence) */
+#define ADC_SQ7_0                               ((uint32_t)0x00000001) /* Bit 0 */
+#define ADC_SQ7_1                               ((uint32_t)0x00000002) /* Bit 1 */
+#define ADC_SQ7_2                               ((uint32_t)0x00000004) /* Bit 2 */
+#define ADC_SQ7_3                               ((uint32_t)0x00000008) /* Bit 3 */
+#define ADC_SQ7_4                               ((uint32_t)0x00000010) /* Bit 4 */
+
+#define ADC_SQ8                                 ((uint32_t)0x000003E0) /* SQ8[4:0] bits (8th conversion in regular sequence) */
+#define ADC_SQ8_0                               ((uint32_t)0x00000020) /* Bit 0 */
+#define ADC_SQ8_1                               ((uint32_t)0x00000040) /* Bit 1 */
+#define ADC_SQ8_2                               ((uint32_t)0x00000080) /* Bit 2 */
+#define ADC_SQ8_3                               ((uint32_t)0x00000100) /* Bit 3 */
+#define ADC_SQ8_4                               ((uint32_t)0x00000200) /* Bit 4 */
+
+#define ADC_SQ9                                 ((uint32_t)0x00007C00) /* SQ9[4:0] bits (9th conversion in regular sequence) */
+#define ADC_SQ9_0                               ((uint32_t)0x00000400) /* Bit 0 */
+#define ADC_SQ9_1                               ((uint32_t)0x00000800) /* Bit 1 */
+#define ADC_SQ9_2                               ((uint32_t)0x00001000) /* Bit 2 */
+#define ADC_SQ9_3                               ((uint32_t)0x00002000) /* Bit 3 */
+#define ADC_SQ9_4                               ((uint32_t)0x00004000) /* Bit 4 */
+
+#define ADC_SQ10                                ((uint32_t)0x000F8000) /* SQ10[4:0] bits (10th conversion in regular sequence) */
+#define ADC_SQ10_0                              ((uint32_t)0x00008000) /* Bit 0 */
+#define ADC_SQ10_1                              ((uint32_t)0x00010000) /* Bit 1 */
+#define ADC_SQ10_2                              ((uint32_t)0x00020000) /* Bit 2 */
+#define ADC_SQ10_3                              ((uint32_t)0x00040000) /* Bit 3 */
+#define ADC_SQ10_4                              ((uint32_t)0x00080000) /* Bit 4 */
+
+#define ADC_SQ11                                ((uint32_t)0x01F00000) /* SQ11[4:0] bits (11th conversion in regular sequence) */
+#define ADC_SQ11_0                              ((uint32_t)0x00100000) /* Bit 0 */
+#define ADC_SQ11_1                              ((uint32_t)0x00200000) /* Bit 1 */
+#define ADC_SQ11_2                              ((uint32_t)0x00400000) /* Bit 2 */
+#define ADC_SQ11_3                              ((uint32_t)0x00800000) /* Bit 3 */
+#define ADC_SQ11_4                              ((uint32_t)0x01000000) /* Bit 4 */
+
+#define ADC_SQ12                                ((uint32_t)0x3E000000) /* SQ12[4:0] bits (12th conversion in regular sequence) */
+#define ADC_SQ12_0                              ((uint32_t)0x02000000) /* Bit 0 */
+#define ADC_SQ12_1                              ((uint32_t)0x04000000) /* Bit 1 */
+#define ADC_SQ12_2                              ((uint32_t)0x08000000) /* Bit 2 */
+#define ADC_SQ12_3                              ((uint32_t)0x10000000) /* Bit 3 */
+#define ADC_SQ12_4                              ((uint32_t)0x20000000) /* Bit 4 */
+
+/*******************  Bit definition for ADC_RSQR3 register  *******************/
+#define ADC_SQ1                                 ((uint32_t)0x0000001F) /* SQ1[4:0] bits (1st conversion in regular sequence) */
+#define ADC_SQ1_0                               ((uint32_t)0x00000001) /* Bit 0 */
+#define ADC_SQ1_1                               ((uint32_t)0x00000002) /* Bit 1 */
+#define ADC_SQ1_2                               ((uint32_t)0x00000004) /* Bit 2 */
+#define ADC_SQ1_3                               ((uint32_t)0x00000008) /* Bit 3 */
+#define ADC_SQ1_4                               ((uint32_t)0x00000010) /* Bit 4 */
+
+#define ADC_SQ2                                 ((uint32_t)0x000003E0) /* SQ2[4:0] bits (2nd conversion in regular sequence) */
+#define ADC_SQ2_0                               ((uint32_t)0x00000020) /* Bit 0 */
+#define ADC_SQ2_1                               ((uint32_t)0x00000040) /* Bit 1 */
+#define ADC_SQ2_2                               ((uint32_t)0x00000080) /* Bit 2 */
+#define ADC_SQ2_3                               ((uint32_t)0x00000100) /* Bit 3 */
+#define ADC_SQ2_4                               ((uint32_t)0x00000200) /* Bit 4 */
+
+#define ADC_SQ3                                 ((uint32_t)0x00007C00) /* SQ3[4:0] bits (3rd conversion in regular sequence) */
+#define ADC_SQ3_0                               ((uint32_t)0x00000400) /* Bit 0 */
+#define ADC_SQ3_1                               ((uint32_t)0x00000800) /* Bit 1 */
+#define ADC_SQ3_2                               ((uint32_t)0x00001000) /* Bit 2 */
+#define ADC_SQ3_3                               ((uint32_t)0x00002000) /* Bit 3 */
+#define ADC_SQ3_4                               ((uint32_t)0x00004000) /* Bit 4 */
+
+#define ADC_SQ4                                 ((uint32_t)0x000F8000) /* SQ4[4:0] bits (4th conversion in regular sequence) */
+#define ADC_SQ4_0                               ((uint32_t)0x00008000) /* Bit 0 */
+#define ADC_SQ4_1                               ((uint32_t)0x00010000) /* Bit 1 */
+#define ADC_SQ4_2                               ((uint32_t)0x00020000) /* Bit 2 */
+#define ADC_SQ4_3                               ((uint32_t)0x00040000) /* Bit 3 */
+#define ADC_SQ4_4                               ((uint32_t)0x00080000) /* Bit 4 */
+
+#define ADC_SQ5                                 ((uint32_t)0x01F00000) /* SQ5[4:0] bits (5th conversion in regular sequence) */
+#define ADC_SQ5_0                               ((uint32_t)0x00100000) /* Bit 0 */
+#define ADC_SQ5_1                               ((uint32_t)0x00200000) /* Bit 1 */
+#define ADC_SQ5_2                               ((uint32_t)0x00400000) /* Bit 2 */
+#define ADC_SQ5_3                               ((uint32_t)0x00800000) /* Bit 3 */
+#define ADC_SQ5_4                               ((uint32_t)0x01000000) /* Bit 4 */
+
+#define ADC_SQ6                                 ((uint32_t)0x3E000000) /* SQ6[4:0] bits (6th conversion in regular sequence) */
+#define ADC_SQ6_0                               ((uint32_t)0x02000000) /* Bit 0 */
+#define ADC_SQ6_1                               ((uint32_t)0x04000000) /* Bit 1 */
+#define ADC_SQ6_2                               ((uint32_t)0x08000000) /* Bit 2 */
+#define ADC_SQ6_3                               ((uint32_t)0x10000000) /* Bit 3 */
+#define ADC_SQ6_4                               ((uint32_t)0x20000000) /* Bit 4 */
+
+/*******************  Bit definition for ADC_ISQR register  *******************/
+#define ADC_JSQ1                                ((uint32_t)0x0000001F) /* JSQ1[4:0] bits (1st conversion in injected sequence) */
+#define ADC_JSQ1_0                              ((uint32_t)0x00000001) /* Bit 0 */
+#define ADC_JSQ1_1                              ((uint32_t)0x00000002) /* Bit 1 */
+#define ADC_JSQ1_2                              ((uint32_t)0x00000004) /* Bit 2 */
+#define ADC_JSQ1_3                              ((uint32_t)0x00000008) /* Bit 3 */
+#define ADC_JSQ1_4                              ((uint32_t)0x00000010) /* Bit 4 */
+
+#define ADC_JSQ2                                ((uint32_t)0x000003E0) /* JSQ2[4:0] bits (2nd conversion in injected sequence) */
+#define ADC_JSQ2_0                              ((uint32_t)0x00000020) /* Bit 0 */
+#define ADC_JSQ2_1                              ((uint32_t)0x00000040) /* Bit 1 */
+#define ADC_JSQ2_2                              ((uint32_t)0x00000080) /* Bit 2 */
+#define ADC_JSQ2_3                              ((uint32_t)0x00000100) /* Bit 3 */
+#define ADC_JSQ2_4                              ((uint32_t)0x00000200) /* Bit 4 */
+
+#define ADC_JSQ3                                ((uint32_t)0x00007C00) /* JSQ3[4:0] bits (3rd conversion in injected sequence) */
+#define ADC_JSQ3_0                              ((uint32_t)0x00000400) /* Bit 0 */
+#define ADC_JSQ3_1                              ((uint32_t)0x00000800) /* Bit 1 */
+#define ADC_JSQ3_2                              ((uint32_t)0x00001000) /* Bit 2 */
+#define ADC_JSQ3_3                              ((uint32_t)0x00002000) /* Bit 3 */
+#define ADC_JSQ3_4                              ((uint32_t)0x00004000) /* Bit 4 */
+
+#define ADC_JSQ4                                ((uint32_t)0x000F8000) /* JSQ4[4:0] bits (4th conversion in injected sequence) */
+#define ADC_JSQ4_0                              ((uint32_t)0x00008000) /* Bit 0 */
+#define ADC_JSQ4_1                              ((uint32_t)0x00010000) /* Bit 1 */
+#define ADC_JSQ4_2                              ((uint32_t)0x00020000) /* Bit 2 */
+#define ADC_JSQ4_3                              ((uint32_t)0x00040000) /* Bit 3 */
+#define ADC_JSQ4_4                              ((uint32_t)0x00080000) /* Bit 4 */
+
+#define ADC_JL                                  ((uint32_t)0x00300000) /* JL[1:0] bits (Injected Sequence length) */
+#define ADC_JL_0                                ((uint32_t)0x00100000) /* Bit 0 */
+#define ADC_JL_1                                ((uint32_t)0x00200000) /* Bit 1 */
+
+/*******************  Bit definition for ADC_IDATAR1 register  *******************/
+#define ADC_IDATAR1_JDATA                       ((uint16_t)0xFFFF) /* Injected data */
+
+/*******************  Bit definition for ADC_IDATAR2 register  *******************/
+#define ADC_IDATAR2_JDATA                       ((uint16_t)0xFFFF) /* Injected data */
+
+/*******************  Bit definition for ADC_IDATAR3 register  *******************/
+#define ADC_IDATAR3_JDATA                       ((uint16_t)0xFFFF) /* Injected data */
+
+/*******************  Bit definition for ADC_IDATAR4 register  *******************/
+#define ADC_IDATAR4_JDATA                       ((uint16_t)0xFFFF) /* Injected data */
+
+/********************  Bit definition for ADC_RDATAR register  ********************/
+#define ADC_RDATAR_DATA                         ((uint32_t)0x0000FFFF) /* Regular data */
+#define ADC_RDATAR_ADC2DATA                     ((uint32_t)0xFFFF0000) /* ADC2 data */
+
+/******************************************************************************/
+/*                            Backup registers                                */
+/******************************************************************************/
+
+/*******************  Bit definition for BKP_DATAR1 register  ********************/
+#define BKP_DATAR1_D                            ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR2 register  ********************/
+#define BKP_DATAR2_D                            ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR3 register  ********************/
+#define BKP_DATAR3_D                            ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR4 register  ********************/
+#define BKP_DATAR4_D                            ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR5 register  ********************/
+#define BKP_DATAR5_D                            ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR6 register  ********************/
+#define BKP_DATAR6_D                            ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR7 register  ********************/
+#define BKP_DATAR7_D                            ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR8 register  ********************/
+#define BKP_DATAR8_D                            ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR9 register  ********************/
+#define BKP_DATAR9_D                            ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR10 register  *******************/
+#define BKP_DATAR10_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR11 register  *******************/
+#define BKP_DATAR11_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR12 register  *******************/
+#define BKP_DATAR12_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR13 register  *******************/
+#define BKP_DATAR13_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR14 register  *******************/
+#define BKP_DATAR14_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR15 register  *******************/
+#define BKP_DATAR15_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR16 register  *******************/
+#define BKP_DATAR16_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR17 register  *******************/
+#define BKP_DATAR17_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/******************  Bit definition for BKP_DATAR18 register  ********************/
+#define BKP_DATAR18_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR19 register  *******************/
+#define BKP_DATAR19_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR20 register  *******************/
+#define BKP_DATAR20_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR21 register  *******************/
+#define BKP_DATAR21_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR22 register  *******************/
+#define BKP_DATAR22_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR23 register  *******************/
+#define BKP_DATAR23_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR24 register  *******************/
+#define BKP_DATAR24_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR25 register  *******************/
+#define BKP_DATAR25_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR26 register  *******************/
+#define BKP_DATAR26_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR27 register  *******************/
+#define BKP_DATAR27_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR28 register  *******************/
+#define BKP_DATAR28_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR29 register  *******************/
+#define BKP_DATAR29_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR30 register  *******************/
+#define BKP_DATAR30_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR31 register  *******************/
+#define BKP_DATAR31_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR32 register  *******************/
+#define BKP_DATAR32_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR33 register  *******************/
+#define BKP_DATAR33_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR34 register  *******************/
+#define BKP_DATAR34_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR35 register  *******************/
+#define BKP_DATAR35_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR36 register  *******************/
+#define BKP_DATAR36_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR37 register  *******************/
+#define BKP_DATAR37_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR38 register  *******************/
+#define BKP_DATAR38_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR39 register  *******************/
+#define BKP_DATAR39_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR40 register  *******************/
+#define BKP_DATAR40_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR41 register  *******************/
+#define BKP_DATAR41_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR42 register  *******************/
+#define BKP_DATAR42_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/******************  Bit definition for BKP_OCTLR register  *******************/
+#define BKP_CAL                                 ((uint16_t)0x007F) /* Calibration value */
+#define BKP_CCO                                 ((uint16_t)0x0080) /* Calibration Clock Output */
+#define BKP_ASOE                                ((uint16_t)0x0100) /* Alarm or Second Output Enable */
+#define BKP_ASOS                                ((uint16_t)0x0200) /* Alarm or Second Output Selection */
+
+/********************  Bit definition for BKP_TPCTLR register  ********************/
+#define BKP_TPE                                 ((uint8_t)0x01) /* TAMPER pin enable */
+#define BKP_TPAL                                ((uint8_t)0x02) /* TAMPER pin active level */
+
+/*******************  Bit definition for BKP_TPCSR register  ********************/
+#define BKP_CTE                                 ((uint16_t)0x0001) /* Clear Tamper event */
+#define BKP_CTI                                 ((uint16_t)0x0002) /* Clear Tamper Interrupt */
+#define BKP_TPIE                                ((uint16_t)0x0004) /* TAMPER Pin interrupt enable */
+#define BKP_TEF                                 ((uint16_t)0x0100) /* Tamper Event Flag */
+#define BKP_TIF                                 ((uint16_t)0x0200) /* Tamper Interrupt Flag */
+
+/******************************************************************************/
+/*                         Controller Area Network                            */
+/******************************************************************************/
+
+/*******************  Bit definition for CAN_CTLR register  ********************/
+#define CAN_CTLR_INRQ                           ((uint16_t)0x0001) /* Initialization Request */
+#define CAN_CTLR_SLEEP                          ((uint16_t)0x0002) /* Sleep Mode Request */
+#define CAN_CTLR_TXFP                           ((uint16_t)0x0004) /* Transmit FIFO Priority */
+#define CAN_CTLR_RFLM                           ((uint16_t)0x0008) /* Receive FIFO Locked Mode */
+#define CAN_CTLR_NART                           ((uint16_t)0x0010) /* No Automatic Retransmission */
+#define CAN_CTLR_AWUM                           ((uint16_t)0x0020) /* Automatic Wakeup Mode */
+#define CAN_CTLR_ABOM                           ((uint16_t)0x0040) /* Automatic Bus-Off Management */
+#define CAN_CTLR_TTCM                           ((uint16_t)0x0080) /* Time Triggered Communication Mode */
+#define CAN_CTLR_RESET                          ((uint16_t)0x8000) /* CAN software master reset */
+
+/*******************  Bit definition for CAN_STATR register  ********************/
+#define CAN_STATR_INAK                          ((uint16_t)0x0001) /* Initialization Acknowledge */
+#define CAN_STATR_SLAK                          ((uint16_t)0x0002) /* Sleep Acknowledge */
+#define CAN_STATR_ERRI                          ((uint16_t)0x0004) /* Error Interrupt */
+#define CAN_STATR_WKUI                          ((uint16_t)0x0008) /* Wakeup Interrupt */
+#define CAN_STATR_SLAKI                         ((uint16_t)0x0010) /* Sleep Acknowledge Interrupt */
+#define CAN_STATR_TXM                           ((uint16_t)0x0100) /* Transmit Mode */
+#define CAN_STATR_RXM                           ((uint16_t)0x0200) /* Receive Mode */
+#define CAN_STATR_SAMP                          ((uint16_t)0x0400) /* Last Sample Point */
+#define CAN_STATR_RX                            ((uint16_t)0x0800) /* CAN Rx Signal */
+
+/*******************  Bit definition for CAN_TSTATR register  ********************/
+#define CAN_TSTATR_RQCP0                        ((uint32_t)0x00000001) /* Request Completed Mailbox0 */
+#define CAN_TSTATR_TXOK0                        ((uint32_t)0x00000002) /* Transmission OK of Mailbox0 */
+#define CAN_TSTATR_ALST0                        ((uint32_t)0x00000004) /* Arbitration Lost for Mailbox0 */
+#define CAN_TSTATR_TERR0                        ((uint32_t)0x00000008) /* Transmission Error of Mailbox0 */
+#define CAN_TSTATR_ABRQ0                        ((uint32_t)0x00000080) /* Abort Request for Mailbox0 */
+#define CAN_TSTATR_RQCP1                        ((uint32_t)0x00000100) /* Request Completed Mailbox1 */
+#define CAN_TSTATR_TXOK1                        ((uint32_t)0x00000200) /* Transmission OK of Mailbox1 */
+#define CAN_TSTATR_ALST1                        ((uint32_t)0x00000400) /* Arbitration Lost for Mailbox1 */
+#define CAN_TSTATR_TERR1                        ((uint32_t)0x00000800) /* Transmission Error of Mailbox1 */
+#define CAN_TSTATR_ABRQ1                        ((uint32_t)0x00008000) /* Abort Request for Mailbox 1 */
+#define CAN_TSTATR_RQCP2                        ((uint32_t)0x00010000) /* Request Completed Mailbox2 */
+#define CAN_TSTATR_TXOK2                        ((uint32_t)0x00020000) /* Transmission OK of Mailbox 2 */
+#define CAN_TSTATR_ALST2                        ((uint32_t)0x00040000) /* Arbitration Lost for mailbox 2 */
+#define CAN_TSTATR_TERR2                        ((uint32_t)0x00080000) /* Transmission Error of Mailbox 2 */
+#define CAN_TSTATR_ABRQ2                        ((uint32_t)0x00800000) /* Abort Request for Mailbox 2 */
+#define CAN_TSTATR_CODE                         ((uint32_t)0x03000000) /* Mailbox Code */
+
+#define CAN_TSTATR_TME                          ((uint32_t)0x1C000000) /* TME[2:0] bits */
+#define CAN_TSTATR_TME0                         ((uint32_t)0x04000000) /* Transmit Mailbox 0 Empty */
+#define CAN_TSTATR_TME1                         ((uint32_t)0x08000000) /* Transmit Mailbox 1 Empty */
+#define CAN_TSTATR_TME2                         ((uint32_t)0x10000000) /* Transmit Mailbox 2 Empty */
+
+#define CAN_TSTATR_LOW                          ((uint32_t)0xE0000000) /* LOW[2:0] bits */
+#define CAN_TSTATR_LOW0                         ((uint32_t)0x20000000) /* Lowest Priority Flag for Mailbox 0 */
+#define CAN_TSTATR_LOW1                         ((uint32_t)0x40000000) /* Lowest Priority Flag for Mailbox 1 */
+#define CAN_TSTATR_LOW2                         ((uint32_t)0x80000000) /* Lowest Priority Flag for Mailbox 2 */
+
+/*******************  Bit definition for CAN_RFIFO0 register  *******************/
+#define CAN_RFIFO0_FMP0                         ((uint8_t)0x03) /* FIFO 0 Message Pending */
+#define CAN_RFIFO0_FULL0                        ((uint8_t)0x08) /* FIFO 0 Full */
+#define CAN_RFIFO0_FOVR0                        ((uint8_t)0x10) /* FIFO 0 Overrun */
+#define CAN_RFIFO0_RFOM0                        ((uint8_t)0x20) /* Release FIFO 0 Output Mailbox */
+
+/*******************  Bit definition for CAN_RFIFO1 register  *******************/
+#define CAN_RFIFO1_FMP1                         ((uint8_t)0x03) /* FIFO 1 Message Pending */
+#define CAN_RFIFO1_FULL1                        ((uint8_t)0x08) /* FIFO 1 Full */
+#define CAN_RFIFO1_FOVR1                        ((uint8_t)0x10) /* FIFO 1 Overrun */
+#define CAN_RFIFO1_RFOM1                        ((uint8_t)0x20) /* Release FIFO 1 Output Mailbox */
+
+/********************  Bit definition for CAN_INTENR register  *******************/
+#define CAN_INTENR_TMEIE                        ((uint32_t)0x00000001) /* Transmit Mailbox Empty Interrupt Enable */
+#define CAN_INTENR_FMPIE0                       ((uint32_t)0x00000002) /* FIFO Message Pending Interrupt Enable */
+#define CAN_INTENR_FFIE0                        ((uint32_t)0x00000004) /* FIFO Full Interrupt Enable */
+#define CAN_INTENR_FOVIE0                       ((uint32_t)0x00000008) /* FIFO Overrun Interrupt Enable */
+#define CAN_INTENR_FMPIE1                       ((uint32_t)0x00000010) /* FIFO Message Pending Interrupt Enable */
+#define CAN_INTENR_FFIE1                        ((uint32_t)0x00000020) /* FIFO Full Interrupt Enable */
+#define CAN_INTENR_FOVIE1                       ((uint32_t)0x00000040) /* FIFO Overrun Interrupt Enable */
+#define CAN_INTENR_EWGIE                        ((uint32_t)0x00000100) /* Error Warning Interrupt Enable */
+#define CAN_INTENR_EPVIE                        ((uint32_t)0x00000200) /* Error Passive Interrupt Enable */
+#define CAN_INTENR_BOFIE                        ((uint32_t)0x00000400) /* Bus-Off Interrupt Enable */
+#define CAN_INTENR_LECIE                        ((uint32_t)0x00000800) /* Last Error Code Interrupt Enable */
+#define CAN_INTENR_ERRIE                        ((uint32_t)0x00008000) /* Error Interrupt Enable */
+#define CAN_INTENR_WKUIE                        ((uint32_t)0x00010000) /* Wakeup Interrupt Enable */
+#define CAN_INTENR_SLKIE                        ((uint32_t)0x00020000) /* Sleep Interrupt Enable */
+
+/********************  Bit definition for CAN_ERRSR register  *******************/
+#define CAN_ERRSR_EWGF                          ((uint32_t)0x00000001) /* Error Warning Flag */
+#define CAN_ERRSR_EPVF                          ((uint32_t)0x00000002) /* Error Passive Flag */
+#define CAN_ERRSR_BOFF                          ((uint32_t)0x00000004) /* Bus-Off Flag */
+
+#define CAN_ERRSR_LEC                           ((uint32_t)0x00000070) /* LEC[2:0] bits (Last Error Code) */
+#define CAN_ERRSR_LEC_0                         ((uint32_t)0x00000010) /* Bit 0 */
+#define CAN_ERRSR_LEC_1                         ((uint32_t)0x00000020) /* Bit 1 */
+#define CAN_ERRSR_LEC_2                         ((uint32_t)0x00000040) /* Bit 2 */
+
+#define CAN_ERRSR_TEC                           ((uint32_t)0x00FF0000) /* Least significant byte of the 9-bit Transmit Error Counter */
+#define CAN_ERRSR_REC                           ((uint32_t)0xFF000000) /* Receive Error Counter */
+
+/*******************  Bit definition for CAN_BTIMR register  ********************/
+#define CAN_BTIMR_BRP                           ((uint32_t)0x000003FF) /* Baud Rate Prescaler */
+#define CAN_BTIMR_TS1                           ((uint32_t)0x000F0000) /* Time Segment 1 */
+#define CAN_BTIMR_TS2                           ((uint32_t)0x00700000) /* Time Segment 2 */
+#define CAN_BTIMR_SJW                           ((uint32_t)0x03000000) /* Resynchronization Jump Width */
+#define CAN_BTIMR_LBKM                          ((uint32_t)0x40000000) /* Loop Back Mode (Debug) */
+#define CAN_BTIMR_SILM                          ((uint32_t)0x80000000) /* Silent Mode */
+
+/******************  Bit definition for CAN_TXMI0R register  ********************/
+#define CAN_TXMI0R_TXRQ                         ((uint32_t)0x00000001) /* Transmit Mailbox Request */
+#define CAN_TXMI0R_RTR                          ((uint32_t)0x00000002) /* Remote Transmission Request */
+#define CAN_TXMI0R_IDE                          ((uint32_t)0x00000004) /* Identifier Extension */
+#define CAN_TXMI0R_EXID                         ((uint32_t)0x001FFFF8) /* Extended Identifier */
+#define CAN_TXMI0R_STID                         ((uint32_t)0xFFE00000) /* Standard Identifier or Extended Identifier */
+
+/******************  Bit definition for CAN_TXMDT0R register  *******************/
+#define CAN_TXMDT0R_DLC                         ((uint32_t)0x0000000F) /* Data Length Code */
+#define CAN_TXMDT0R_TGT                         ((uint32_t)0x00000100) /* Transmit Global Time */
+#define CAN_TXMDT0R_TIME                        ((uint32_t)0xFFFF0000) /* Message Time Stamp */
+
+/******************  Bit definition for CAN_TXMDL0R register  *******************/
+#define CAN_TXMDL0R_DATA0                       ((uint32_t)0x000000FF) /* Data byte 0 */
+#define CAN_TXMDL0R_DATA1                       ((uint32_t)0x0000FF00) /* Data byte 1 */
+#define CAN_TXMDL0R_DATA2                       ((uint32_t)0x00FF0000) /* Data byte 2 */
+#define CAN_TXMDL0R_DATA3                       ((uint32_t)0xFF000000) /* Data byte 3 */
+
+/******************  Bit definition for CAN_TXMDH0R register  *******************/
+#define CAN_TXMDH0R_DATA4                       ((uint32_t)0x000000FF) /* Data byte 4 */
+#define CAN_TXMDH0R_DATA5                       ((uint32_t)0x0000FF00) /* Data byte 5 */
+#define CAN_TXMDH0R_DATA6                       ((uint32_t)0x00FF0000) /* Data byte 6 */
+#define CAN_TXMDH0R_DATA7                       ((uint32_t)0xFF000000) /* Data byte 7 */
+
+/*******************  Bit definition for CAN_TXMI1R register  *******************/
+#define CAN_TXMI1R_TXRQ                         ((uint32_t)0x00000001) /* Transmit Mailbox Request */
+#define CAN_TXMI1R_RTR                          ((uint32_t)0x00000002) /* Remote Transmission Request */
+#define CAN_TXMI1R_IDE                          ((uint32_t)0x00000004) /* Identifier Extension */
+#define CAN_TXMI1R_EXID                         ((uint32_t)0x001FFFF8) /* Extended Identifier */
+#define CAN_TXMI1R_STID                         ((uint32_t)0xFFE00000) /* Standard Identifier or Extended Identifier */
+
+/*******************  Bit definition for CAN_TXMDT1R register  ******************/
+#define CAN_TXMDT1R_DLC                         ((uint32_t)0x0000000F) /* Data Length Code */
+#define CAN_TXMDT1R_TGT                         ((uint32_t)0x00000100) /* Transmit Global Time */
+#define CAN_TXMDT1R_TIME                        ((uint32_t)0xFFFF0000) /* Message Time Stamp */
+
+/*******************  Bit definition for CAN_TXMDL1R register  ******************/
+#define CAN_TXMDL1R_DATA0                       ((uint32_t)0x000000FF) /* Data byte 0 */
+#define CAN_TXMDL1R_DATA1                       ((uint32_t)0x0000FF00) /* Data byte 1 */
+#define CAN_TXMDL1R_DATA2                       ((uint32_t)0x00FF0000) /* Data byte 2 */
+#define CAN_TXMDL1R_DATA3                       ((uint32_t)0xFF000000) /* Data byte 3 */
+
+/*******************  Bit definition for CAN_TXMDH1R register  ******************/
+#define CAN_TXMDH1R_DATA4                       ((uint32_t)0x000000FF) /* Data byte 4 */
+#define CAN_TXMDH1R_DATA5                       ((uint32_t)0x0000FF00) /* Data byte 5 */
+#define CAN_TXMDH1R_DATA6                       ((uint32_t)0x00FF0000) /* Data byte 6 */
+#define CAN_TXMDH1R_DATA7                       ((uint32_t)0xFF000000) /* Data byte 7 */
+
+/*******************  Bit definition for CAN_TXMI2R register  *******************/
+#define CAN_TXMI2R_TXRQ                         ((uint32_t)0x00000001) /* Transmit Mailbox Request */
+#define CAN_TXMI2R_RTR                          ((uint32_t)0x00000002) /* Remote Transmission Request */
+#define CAN_TXMI2R_IDE                          ((uint32_t)0x00000004) /* Identifier Extension */
+#define CAN_TXMI2R_EXID                         ((uint32_t)0x001FFFF8) /* Extended identifier */
+#define CAN_TXMI2R_STID                         ((uint32_t)0xFFE00000) /* Standard Identifier or Extended Identifier */
+
+/*******************  Bit definition for CAN_TXMDT2R register  ******************/
+#define CAN_TXMDT2R_DLC                         ((uint32_t)0x0000000F) /* Data Length Code */
+#define CAN_TXMDT2R_TGT                         ((uint32_t)0x00000100) /* Transmit Global Time */
+#define CAN_TXMDT2R_TIME                        ((uint32_t)0xFFFF0000) /* Message Time Stamp */
+
+/*******************  Bit definition for CAN_TXMDL2R register  ******************/
+#define CAN_TXMDL2R_DATA0                       ((uint32_t)0x000000FF) /* Data byte 0 */
+#define CAN_TXMDL2R_DATA1                       ((uint32_t)0x0000FF00) /* Data byte 1 */
+#define CAN_TXMDL2R_DATA2                       ((uint32_t)0x00FF0000) /* Data byte 2 */
+#define CAN_TXMDL2R_DATA3                       ((uint32_t)0xFF000000) /* Data byte 3 */
+
+/*******************  Bit definition for CAN_TXMDH2R register  ******************/
+#define CAN_TXMDH2R_DATA4                       ((uint32_t)0x000000FF) /* Data byte 4 */
+#define CAN_TXMDH2R_DATA5                       ((uint32_t)0x0000FF00) /* Data byte 5 */
+#define CAN_TXMDH2R_DATA6                       ((uint32_t)0x00FF0000) /* Data byte 6 */
+#define CAN_TXMDH2R_DATA7                       ((uint32_t)0xFF000000) /* Data byte 7 */
+
+/*******************  Bit definition for CAN_RXMI0R register  *******************/
+#define CAN_RXMI0R_RTR                          ((uint32_t)0x00000002) /* Remote Transmission Request */
+#define CAN_RXMI0R_IDE                          ((uint32_t)0x00000004) /* Identifier Extension */
+#define CAN_RXMI0R_EXID                         ((uint32_t)0x001FFFF8) /* Extended Identifier */
+#define CAN_RXMI0R_STID                         ((uint32_t)0xFFE00000) /* Standard Identifier or Extended Identifier */
+
+/*******************  Bit definition for CAN_RXMDT0R register  ******************/
+#define CAN_RXMDT0R_DLC                         ((uint32_t)0x0000000F) /* Data Length Code */
+#define CAN_RXMDT0R_FMI                         ((uint32_t)0x0000FF00) /* Filter Match Index */
+#define CAN_RXMDT0R_TIME                        ((uint32_t)0xFFFF0000) /* Message Time Stamp */
+
+/*******************  Bit definition for CAN_RXMDL0R register  ******************/
+#define CAN_RXMDL0R_DATA0                       ((uint32_t)0x000000FF) /* Data byte 0 */
+#define CAN_RXMDL0R_DATA1                       ((uint32_t)0x0000FF00) /* Data byte 1 */
+#define CAN_RXMDL0R_DATA2                       ((uint32_t)0x00FF0000) /* Data byte 2 */
+#define CAN_RXMDL0R_DATA3                       ((uint32_t)0xFF000000) /* Data byte 3 */
+
+/*******************  Bit definition for CAN_RXMDH0R register  ******************/
+#define CAN_RXMDH0R_DATA4                       ((uint32_t)0x000000FF) /* Data byte 4 */
+#define CAN_RXMDH0R_DATA5                       ((uint32_t)0x0000FF00) /* Data byte 5 */
+#define CAN_RXMDH0R_DATA6                       ((uint32_t)0x00FF0000) /* Data byte 6 */
+#define CAN_RXMDH0R_DATA7                       ((uint32_t)0xFF000000) /* Data byte 7 */
+
+/*******************  Bit definition for CAN_RXMI1R register  *******************/
+#define CAN_RXMI1R_RTR                          ((uint32_t)0x00000002) /* Remote Transmission Request */
+#define CAN_RXMI1R_IDE                          ((uint32_t)0x00000004) /* Identifier Extension */
+#define CAN_RXMI1R_EXID                         ((uint32_t)0x001FFFF8) /* Extended identifier */
+#define CAN_RXMI1R_STID                         ((uint32_t)0xFFE00000) /* Standard Identifier or Extended Identifier */
+
+/*******************  Bit definition for CAN_RXMDT1R register  ******************/
+#define CAN_RXMDT1R_DLC                         ((uint32_t)0x0000000F) /* Data Length Code */
+#define CAN_RXMDT1R_FMI                         ((uint32_t)0x0000FF00) /* Filter Match Index */
+#define CAN_RXMDT1R_TIME                        ((uint32_t)0xFFFF0000) /* Message Time Stamp */
+
+/*******************  Bit definition for CAN_RXMDL1R register  ******************/
+#define CAN_RXMDL1R_DATA0                       ((uint32_t)0x000000FF) /* Data byte 0 */
+#define CAN_RXMDL1R_DATA1                       ((uint32_t)0x0000FF00) /* Data byte 1 */
+#define CAN_RXMDL1R_DATA2                       ((uint32_t)0x00FF0000) /* Data byte 2 */
+#define CAN_RXMDL1R_DATA3                       ((uint32_t)0xFF000000) /* Data byte 3 */
+
+/*******************  Bit definition for CAN_RXMDH1R register  ******************/
+#define CAN_RXMDH1R_DATA4                       ((uint32_t)0x000000FF) /* Data byte 4 */
+#define CAN_RXMDH1R_DATA5                       ((uint32_t)0x0000FF00) /* Data byte 5 */
+#define CAN_RXMDH1R_DATA6                       ((uint32_t)0x00FF0000) /* Data byte 6 */
+#define CAN_RXMDH1R_DATA7                       ((uint32_t)0xFF000000) /* Data byte 7 */
+
+/*******************  Bit definition for CAN_FCTLR register  ********************/
+#define CAN_FCTLR_FINIT                         ((uint8_t)0x01) /* Filter Init Mode */
+
+/*******************  Bit definition for CAN_FMCFGR register  *******************/
+#define CAN_FMCFGR_FBM                          ((uint16_t)0x3FFF) /* Filter Mode */
+#define CAN_FMCFGR_FBM0                         ((uint16_t)0x0001) /* Filter Init Mode bit 0 */
+#define CAN_FMCFGR_FBM1                         ((uint16_t)0x0002) /* Filter Init Mode bit 1 */
+#define CAN_FMCFGR_FBM2                         ((uint16_t)0x0004) /* Filter Init Mode bit 2 */
+#define CAN_FMCFGR_FBM3                         ((uint16_t)0x0008) /* Filter Init Mode bit 3 */
+#define CAN_FMCFGR_FBM4                         ((uint16_t)0x0010) /* Filter Init Mode bit 4 */
+#define CAN_FMCFGR_FBM5                         ((uint16_t)0x0020) /* Filter Init Mode bit 5 */
+#define CAN_FMCFGR_FBM6                         ((uint16_t)0x0040) /* Filter Init Mode bit 6 */
+#define CAN_FMCFGR_FBM7                         ((uint16_t)0x0080) /* Filter Init Mode bit 7 */
+#define CAN_FMCFGR_FBM8                         ((uint16_t)0x0100) /* Filter Init Mode bit 8 */
+#define CAN_FMCFGR_FBM9                         ((uint16_t)0x0200) /* Filter Init Mode bit 9 */
+#define CAN_FMCFGR_FBM10                        ((uint16_t)0x0400) /* Filter Init Mode bit 10 */
+#define CAN_FMCFGR_FBM11                        ((uint16_t)0x0800) /* Filter Init Mode bit 11 */
+#define CAN_FMCFGR_FBM12                        ((uint16_t)0x1000) /* Filter Init Mode bit 12 */
+#define CAN_FMCFGR_FBM13                        ((uint16_t)0x2000) /* Filter Init Mode bit 13 */
+
+/*******************  Bit definition for CAN_FSCFGR register  *******************/
+#define CAN_FSCFGR_FSC                          ((uint16_t)0x3FFF) /* Filter Scale Configuration */
+#define CAN_FSCFGR_FSC0                         ((uint16_t)0x0001) /* Filter Scale Configuration bit 0 */
+#define CAN_FSCFGR_FSC1                         ((uint16_t)0x0002) /* Filter Scale Configuration bit 1 */
+#define CAN_FSCFGR_FSC2                         ((uint16_t)0x0004) /* Filter Scale Configuration bit 2 */
+#define CAN_FSCFGR_FSC3                         ((uint16_t)0x0008) /* Filter Scale Configuration bit 3 */
+#define CAN_FSCFGR_FSC4                         ((uint16_t)0x0010) /* Filter Scale Configuration bit 4 */
+#define CAN_FSCFGR_FSC5                         ((uint16_t)0x0020) /* Filter Scale Configuration bit 5 */
+#define CAN_FSCFGR_FSC6                         ((uint16_t)0x0040) /* Filter Scale Configuration bit 6 */
+#define CAN_FSCFGR_FSC7                         ((uint16_t)0x0080) /* Filter Scale Configuration bit 7 */
+#define CAN_FSCFGR_FSC8                         ((uint16_t)0x0100) /* Filter Scale Configuration bit 8 */
+#define CAN_FSCFGR_FSC9                         ((uint16_t)0x0200) /* Filter Scale Configuration bit 9 */
+#define CAN_FSCFGR_FSC10                        ((uint16_t)0x0400) /* Filter Scale Configuration bit 10 */
+#define CAN_FSCFGR_FSC11                        ((uint16_t)0x0800) /* Filter Scale Configuration bit 11 */
+#define CAN_FSCFGR_FSC12                        ((uint16_t)0x1000) /* Filter Scale Configuration bit 12 */
+#define CAN_FSCFGR_FSC13                        ((uint16_t)0x2000) /* Filter Scale Configuration bit 13 */
+
+/******************  Bit definition for CAN_FAFIFOR register  *******************/
+#define CAN_FAFIFOR_FFA                         ((uint16_t)0x3FFF) /* Filter FIFO Assignment */
+#define CAN_FAFIFOR_FFA0                        ((uint16_t)0x0001) /* Filter FIFO Assignment for Filter 0 */
+#define CAN_FAFIFOR_FFA1                        ((uint16_t)0x0002) /* Filter FIFO Assignment for Filter 1 */
+#define CAN_FAFIFOR_FFA2                        ((uint16_t)0x0004) /* Filter FIFO Assignment for Filter 2 */
+#define CAN_FAFIFOR_FFA3                        ((uint16_t)0x0008) /* Filter FIFO Assignment for Filter 3 */
+#define CAN_FAFIFOR_FFA4                        ((uint16_t)0x0010) /* Filter FIFO Assignment for Filter 4 */
+#define CAN_FAFIFOR_FFA5                        ((uint16_t)0x0020) /* Filter FIFO Assignment for Filter 5 */
+#define CAN_FAFIFOR_FFA6                        ((uint16_t)0x0040) /* Filter FIFO Assignment for Filter 6 */
+#define CAN_FAFIFOR_FFA7                        ((uint16_t)0x0080) /* Filter FIFO Assignment for Filter 7 */
+#define CAN_FAFIFOR_FFA8                        ((uint16_t)0x0100) /* Filter FIFO Assignment for Filter 8 */
+#define CAN_FAFIFOR_FFA9                        ((uint16_t)0x0200) /* Filter FIFO Assignment for Filter 9 */
+#define CAN_FAFIFOR_FFA10                       ((uint16_t)0x0400) /* Filter FIFO Assignment for Filter 10 */
+#define CAN_FAFIFOR_FFA11                       ((uint16_t)0x0800) /* Filter FIFO Assignment for Filter 11 */
+#define CAN_FAFIFOR_FFA12                       ((uint16_t)0x1000) /* Filter FIFO Assignment for Filter 12 */
+#define CAN_FAFIFOR_FFA13                       ((uint16_t)0x2000) /* Filter FIFO Assignment for Filter 13 */
+
+/*******************  Bit definition for CAN_FWR register  *******************/
+#define CAN_FWR_FACT                            ((uint16_t)0x3FFF) /* Filter Active */
+#define CAN_FWR_FACT0                           ((uint16_t)0x0001) /* Filter 0 Active */
+#define CAN_FWR_FACT1                           ((uint16_t)0x0002) /* Filter 1 Active */
+#define CAN_FWR_FACT2                           ((uint16_t)0x0004) /* Filter 2 Active */
+#define CAN_FWR_FACT3                           ((uint16_t)0x0008) /* Filter 3 Active */
+#define CAN_FWR_FACT4                           ((uint16_t)0x0010) /* Filter 4 Active */
+#define CAN_FWR_FACT5                           ((uint16_t)0x0020) /* Filter 5 Active */
+#define CAN_FWR_FACT6                           ((uint16_t)0x0040) /* Filter 6 Active */
+#define CAN_FWR_FACT7                           ((uint16_t)0x0080) /* Filter 7 Active */
+#define CAN_FWR_FACT8                           ((uint16_t)0x0100) /* Filter 8 Active */
+#define CAN_FWR_FACT9                           ((uint16_t)0x0200) /* Filter 9 Active */
+#define CAN_FWR_FACT10                          ((uint16_t)0x0400) /* Filter 10 Active */
+#define CAN_FWR_FACT11                          ((uint16_t)0x0800) /* Filter 11 Active */
+#define CAN_FWR_FACT12                          ((uint16_t)0x1000) /* Filter 12 Active */
+#define CAN_FWR_FACT13                          ((uint16_t)0x2000) /* Filter 13 Active */
+
+/*******************  Bit definition for CAN_F0R1 register  *******************/
+#define CAN_F0R1_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F0R1_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F0R1_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F0R1_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F0R1_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F0R1_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F0R1_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F0R1_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F0R1_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F0R1_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F0R1_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F0R1_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F0R1_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F0R1_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F0R1_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F0R1_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F0R1_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F0R1_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F0R1_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F0R1_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F0R1_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F0R1_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F0R1_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F0R1_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F0R1_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F0R1_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F0R1_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F0R1_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F0R1_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F0R1_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F0R1_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F0R1_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F1R1 register  *******************/
+#define CAN_F1R1_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F1R1_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F1R1_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F1R1_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F1R1_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F1R1_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F1R1_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F1R1_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F1R1_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F1R1_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F1R1_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F1R1_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F1R1_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F1R1_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F1R1_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F1R1_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F1R1_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F1R1_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F1R1_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F1R1_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F1R1_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F1R1_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F1R1_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F1R1_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F1R1_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F1R1_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F1R1_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F1R1_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F1R1_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F1R1_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F1R1_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F1R1_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F2R1 register  *******************/
+#define CAN_F2R1_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F2R1_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F2R1_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F2R1_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F2R1_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F2R1_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F2R1_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F2R1_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F2R1_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F2R1_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F2R1_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F2R1_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F2R1_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F2R1_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F2R1_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F2R1_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F2R1_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F2R1_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F2R1_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F2R1_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F2R1_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F2R1_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F2R1_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F2R1_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F2R1_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F2R1_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F2R1_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F2R1_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F2R1_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F2R1_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F2R1_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F2R1_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F3R1 register  *******************/
+#define CAN_F3R1_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F3R1_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F3R1_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F3R1_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F3R1_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F3R1_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F3R1_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F3R1_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F3R1_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F3R1_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F3R1_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F3R1_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F3R1_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F3R1_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F3R1_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F3R1_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F3R1_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F3R1_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F3R1_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F3R1_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F3R1_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F3R1_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F3R1_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F3R1_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F3R1_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F3R1_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F3R1_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F3R1_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F3R1_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F3R1_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F3R1_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F3R1_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F4R1 register  *******************/
+#define CAN_F4R1_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F4R1_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F4R1_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F4R1_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F4R1_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F4R1_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F4R1_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F4R1_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F4R1_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F4R1_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F4R1_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F4R1_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F4R1_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F4R1_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F4R1_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F4R1_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F4R1_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F4R1_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F4R1_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F4R1_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F4R1_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F4R1_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F4R1_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F4R1_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F4R1_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F4R1_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F4R1_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F4R1_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F4R1_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F4R1_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F4R1_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F4R1_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F5R1 register  *******************/
+#define CAN_F5R1_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F5R1_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F5R1_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F5R1_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F5R1_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F5R1_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F5R1_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F5R1_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F5R1_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F5R1_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F5R1_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F5R1_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F5R1_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F5R1_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F5R1_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F5R1_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F5R1_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F5R1_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F5R1_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F5R1_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F5R1_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F5R1_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F5R1_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F5R1_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F5R1_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F5R1_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F5R1_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F5R1_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F5R1_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F5R1_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F5R1_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F5R1_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F6R1 register  *******************/
+#define CAN_F6R1_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F6R1_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F6R1_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F6R1_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F6R1_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F6R1_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F6R1_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F6R1_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F6R1_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F6R1_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F6R1_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F6R1_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F6R1_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F6R1_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F6R1_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F6R1_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F6R1_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F6R1_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F6R1_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F6R1_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F6R1_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F6R1_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F6R1_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F6R1_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F6R1_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F6R1_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F6R1_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F6R1_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F6R1_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F6R1_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F6R1_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F6R1_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F7R1 register  *******************/
+#define CAN_F7R1_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F7R1_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F7R1_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F7R1_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F7R1_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F7R1_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F7R1_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F7R1_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F7R1_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F7R1_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F7R1_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F7R1_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F7R1_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F7R1_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F7R1_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F7R1_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F7R1_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F7R1_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F7R1_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F7R1_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F7R1_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F7R1_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F7R1_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F7R1_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F7R1_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F7R1_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F7R1_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F7R1_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F7R1_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F7R1_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F7R1_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F7R1_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F8R1 register  *******************/
+#define CAN_F8R1_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F8R1_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F8R1_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F8R1_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F8R1_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F8R1_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F8R1_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F8R1_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F8R1_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F8R1_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F8R1_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F8R1_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F8R1_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F8R1_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F8R1_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F8R1_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F8R1_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F8R1_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F8R1_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F8R1_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F8R1_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F8R1_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F8R1_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F8R1_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F8R1_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F8R1_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F8R1_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F8R1_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F8R1_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F8R1_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F8R1_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F8R1_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F9R1 register  *******************/
+#define CAN_F9R1_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F9R1_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F9R1_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F9R1_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F9R1_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F9R1_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F9R1_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F9R1_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F9R1_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F9R1_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F9R1_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F9R1_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F9R1_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F9R1_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F9R1_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F9R1_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F9R1_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F9R1_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F9R1_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F9R1_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F9R1_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F9R1_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F9R1_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F9R1_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F9R1_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F9R1_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F9R1_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F9R1_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F9R1_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F9R1_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F9R1_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F9R1_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F10R1 register  ******************/
+#define CAN_F10R1_FB0                           ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F10R1_FB1                           ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F10R1_FB2                           ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F10R1_FB3                           ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F10R1_FB4                           ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F10R1_FB5                           ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F10R1_FB6                           ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F10R1_FB7                           ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F10R1_FB8                           ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F10R1_FB9                           ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F10R1_FB10                          ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F10R1_FB11                          ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F10R1_FB12                          ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F10R1_FB13                          ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F10R1_FB14                          ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F10R1_FB15                          ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F10R1_FB16                          ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F10R1_FB17                          ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F10R1_FB18                          ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F10R1_FB19                          ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F10R1_FB20                          ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F10R1_FB21                          ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F10R1_FB22                          ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F10R1_FB23                          ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F10R1_FB24                          ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F10R1_FB25                          ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F10R1_FB26                          ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F10R1_FB27                          ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F10R1_FB28                          ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F10R1_FB29                          ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F10R1_FB30                          ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F10R1_FB31                          ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F11R1 register  ******************/
+#define CAN_F11R1_FB0                           ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F11R1_FB1                           ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F11R1_FB2                           ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F11R1_FB3                           ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F11R1_FB4                           ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F11R1_FB5                           ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F11R1_FB6                           ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F11R1_FB7                           ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F11R1_FB8                           ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F11R1_FB9                           ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F11R1_FB10                          ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F11R1_FB11                          ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F11R1_FB12                          ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F11R1_FB13                          ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F11R1_FB14                          ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F11R1_FB15                          ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F11R1_FB16                          ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F11R1_FB17                          ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F11R1_FB18                          ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F11R1_FB19                          ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F11R1_FB20                          ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F11R1_FB21                          ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F11R1_FB22                          ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F11R1_FB23                          ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F11R1_FB24                          ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F11R1_FB25                          ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F11R1_FB26                          ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F11R1_FB27                          ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F11R1_FB28                          ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F11R1_FB29                          ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F11R1_FB30                          ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F11R1_FB31                          ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F12R1 register  ******************/
+#define CAN_F12R1_FB0                           ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F12R1_FB1                           ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F12R1_FB2                           ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F12R1_FB3                           ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F12R1_FB4                           ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F12R1_FB5                           ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F12R1_FB6                           ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F12R1_FB7                           ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F12R1_FB8                           ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F12R1_FB9                           ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F12R1_FB10                          ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F12R1_FB11                          ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F12R1_FB12                          ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F12R1_FB13                          ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F12R1_FB14                          ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F12R1_FB15                          ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F12R1_FB16                          ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F12R1_FB17                          ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F12R1_FB18                          ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F12R1_FB19                          ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F12R1_FB20                          ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F12R1_FB21                          ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F12R1_FB22                          ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F12R1_FB23                          ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F12R1_FB24                          ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F12R1_FB25                          ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F12R1_FB26                          ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F12R1_FB27                          ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F12R1_FB28                          ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F12R1_FB29                          ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F12R1_FB30                          ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F12R1_FB31                          ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F13R1 register  ******************/
+#define CAN_F13R1_FB0                           ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F13R1_FB1                           ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F13R1_FB2                           ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F13R1_FB3                           ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F13R1_FB4                           ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F13R1_FB5                           ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F13R1_FB6                           ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F13R1_FB7                           ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F13R1_FB8                           ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F13R1_FB9                           ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F13R1_FB10                          ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F13R1_FB11                          ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F13R1_FB12                          ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F13R1_FB13                          ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F13R1_FB14                          ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F13R1_FB15                          ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F13R1_FB16                          ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F13R1_FB17                          ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F13R1_FB18                          ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F13R1_FB19                          ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F13R1_FB20                          ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F13R1_FB21                          ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F13R1_FB22                          ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F13R1_FB23                          ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F13R1_FB24                          ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F13R1_FB25                          ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F13R1_FB26                          ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F13R1_FB27                          ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F13R1_FB28                          ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F13R1_FB29                          ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F13R1_FB30                          ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F13R1_FB31                          ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F0R2 register  *******************/
+#define CAN_F0R2_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F0R2_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F0R2_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F0R2_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F0R2_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F0R2_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F0R2_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F0R2_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F0R2_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F0R2_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F0R2_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F0R2_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F0R2_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F0R2_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F0R2_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F0R2_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F0R2_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F0R2_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F0R2_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F0R2_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F0R2_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F0R2_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F0R2_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F0R2_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F0R2_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F0R2_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F0R2_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F0R2_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F0R2_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F0R2_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F0R2_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F0R2_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F1R2 register  *******************/
+#define CAN_F1R2_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F1R2_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F1R2_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F1R2_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F1R2_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F1R2_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F1R2_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F1R2_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F1R2_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F1R2_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F1R2_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F1R2_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F1R2_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F1R2_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F1R2_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F1R2_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F1R2_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F1R2_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F1R2_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F1R2_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F1R2_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F1R2_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F1R2_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F1R2_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F1R2_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F1R2_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F1R2_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F1R2_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F1R2_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F1R2_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F1R2_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F1R2_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F2R2 register  *******************/
+#define CAN_F2R2_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F2R2_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F2R2_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F2R2_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F2R2_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F2R2_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F2R2_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F2R2_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F2R2_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F2R2_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F2R2_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F2R2_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F2R2_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F2R2_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F2R2_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F2R2_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F2R2_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F2R2_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F2R2_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F2R2_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F2R2_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F2R2_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F2R2_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F2R2_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F2R2_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F2R2_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F2R2_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F2R2_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F2R2_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F2R2_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F2R2_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F2R2_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F3R2 register  *******************/
+#define CAN_F3R2_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F3R2_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F3R2_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F3R2_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F3R2_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F3R2_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F3R2_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F3R2_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F3R2_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F3R2_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F3R2_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F3R2_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F3R2_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F3R2_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F3R2_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F3R2_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F3R2_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F3R2_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F3R2_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F3R2_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F3R2_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F3R2_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F3R2_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F3R2_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F3R2_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F3R2_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F3R2_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F3R2_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F3R2_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F3R2_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F3R2_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F3R2_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F4R2 register  *******************/
+#define CAN_F4R2_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F4R2_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F4R2_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F4R2_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F4R2_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F4R2_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F4R2_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F4R2_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F4R2_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F4R2_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F4R2_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F4R2_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F4R2_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F4R2_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F4R2_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F4R2_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F4R2_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F4R2_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F4R2_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F4R2_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F4R2_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F4R2_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F4R2_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F4R2_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F4R2_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F4R2_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F4R2_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F4R2_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F4R2_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F4R2_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F4R2_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F4R2_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F5R2 register  *******************/
+#define CAN_F5R2_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F5R2_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F5R2_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F5R2_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F5R2_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F5R2_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F5R2_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F5R2_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F5R2_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F5R2_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F5R2_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F5R2_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F5R2_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F5R2_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F5R2_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F5R2_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F5R2_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F5R2_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F5R2_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F5R2_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F5R2_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F5R2_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F5R2_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F5R2_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F5R2_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F5R2_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F5R2_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F5R2_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F5R2_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F5R2_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F5R2_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F5R2_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F6R2 register  *******************/
+#define CAN_F6R2_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F6R2_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F6R2_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F6R2_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F6R2_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F6R2_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F6R2_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F6R2_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F6R2_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F6R2_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F6R2_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F6R2_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F6R2_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F6R2_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F6R2_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F6R2_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F6R2_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F6R2_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F6R2_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F6R2_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F6R2_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F6R2_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F6R2_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F6R2_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F6R2_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F6R2_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F6R2_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F6R2_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F6R2_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F6R2_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F6R2_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F6R2_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F7R2 register  *******************/
+#define CAN_F7R2_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F7R2_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F7R2_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F7R2_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F7R2_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F7R2_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F7R2_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F7R2_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F7R2_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F7R2_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F7R2_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F7R2_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F7R2_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F7R2_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F7R2_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F7R2_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F7R2_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F7R2_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F7R2_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F7R2_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F7R2_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F7R2_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F7R2_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F7R2_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F7R2_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F7R2_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F7R2_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F7R2_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F7R2_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F7R2_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F7R2_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F7R2_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F8R2 register  *******************/
+#define CAN_F8R2_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F8R2_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F8R2_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F8R2_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F8R2_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F8R2_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F8R2_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F8R2_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F8R2_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F8R2_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F8R2_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F8R2_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F8R2_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F8R2_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F8R2_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F8R2_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F8R2_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F8R2_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F8R2_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F8R2_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F8R2_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F8R2_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F8R2_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F8R2_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F8R2_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F8R2_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F8R2_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F8R2_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F8R2_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F8R2_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F8R2_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F8R2_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F9R2 register  *******************/
+#define CAN_F9R2_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F9R2_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F9R2_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F9R2_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F9R2_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F9R2_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F9R2_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F9R2_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F9R2_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F9R2_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F9R2_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F9R2_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F9R2_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F9R2_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F9R2_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F9R2_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F9R2_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F9R2_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F9R2_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F9R2_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F9R2_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F9R2_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F9R2_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F9R2_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F9R2_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F9R2_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F9R2_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F9R2_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F9R2_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F9R2_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F9R2_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F9R2_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F10R2 register  ******************/
+#define CAN_F10R2_FB0                           ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F10R2_FB1                           ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F10R2_FB2                           ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F10R2_FB3                           ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F10R2_FB4                           ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F10R2_FB5                           ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F10R2_FB6                           ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F10R2_FB7                           ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F10R2_FB8                           ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F10R2_FB9                           ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F10R2_FB10                          ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F10R2_FB11                          ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F10R2_FB12                          ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F10R2_FB13                          ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F10R2_FB14                          ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F10R2_FB15                          ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F10R2_FB16                          ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F10R2_FB17                          ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F10R2_FB18                          ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F10R2_FB19                          ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F10R2_FB20                          ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F10R2_FB21                          ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F10R2_FB22                          ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F10R2_FB23                          ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F10R2_FB24                          ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F10R2_FB25                          ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F10R2_FB26                          ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F10R2_FB27                          ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F10R2_FB28                          ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F10R2_FB29                          ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F10R2_FB30                          ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F10R2_FB31                          ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F11R2 register  ******************/
+#define CAN_F11R2_FB0                           ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F11R2_FB1                           ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F11R2_FB2                           ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F11R2_FB3                           ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F11R2_FB4                           ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F11R2_FB5                           ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F11R2_FB6                           ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F11R2_FB7                           ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F11R2_FB8                           ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F11R2_FB9                           ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F11R2_FB10                          ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F11R2_FB11                          ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F11R2_FB12                          ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F11R2_FB13                          ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F11R2_FB14                          ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F11R2_FB15                          ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F11R2_FB16                          ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F11R2_FB17                          ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F11R2_FB18                          ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F11R2_FB19                          ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F11R2_FB20                          ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F11R2_FB21                          ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F11R2_FB22                          ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F11R2_FB23                          ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F11R2_FB24                          ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F11R2_FB25                          ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F11R2_FB26                          ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F11R2_FB27                          ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F11R2_FB28                          ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F11R2_FB29                          ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F11R2_FB30                          ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F11R2_FB31                          ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F12R2 register  ******************/
+#define CAN_F12R2_FB0                           ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F12R2_FB1                           ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F12R2_FB2                           ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F12R2_FB3                           ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F12R2_FB4                           ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F12R2_FB5                           ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F12R2_FB6                           ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F12R2_FB7                           ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F12R2_FB8                           ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F12R2_FB9                           ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F12R2_FB10                          ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F12R2_FB11                          ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F12R2_FB12                          ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F12R2_FB13                          ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F12R2_FB14                          ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F12R2_FB15                          ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F12R2_FB16                          ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F12R2_FB17                          ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F12R2_FB18                          ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F12R2_FB19                          ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F12R2_FB20                          ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F12R2_FB21                          ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F12R2_FB22                          ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F12R2_FB23                          ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F12R2_FB24                          ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F12R2_FB25                          ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F12R2_FB26                          ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F12R2_FB27                          ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F12R2_FB28                          ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F12R2_FB29                          ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F12R2_FB30                          ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F12R2_FB31                          ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F13R2 register  ******************/
+#define CAN_F13R2_FB0                           ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F13R2_FB1                           ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F13R2_FB2                           ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F13R2_FB3                           ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F13R2_FB4                           ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F13R2_FB5                           ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F13R2_FB6                           ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F13R2_FB7                           ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F13R2_FB8                           ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F13R2_FB9                           ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F13R2_FB10                          ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F13R2_FB11                          ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F13R2_FB12                          ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F13R2_FB13                          ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F13R2_FB14                          ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F13R2_FB15                          ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F13R2_FB16                          ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F13R2_FB17                          ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F13R2_FB18                          ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F13R2_FB19                          ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F13R2_FB20                          ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F13R2_FB21                          ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F13R2_FB22                          ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F13R2_FB23                          ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F13R2_FB24                          ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F13R2_FB25                          ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F13R2_FB26                          ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F13R2_FB27                          ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F13R2_FB28                          ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F13R2_FB29                          ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F13R2_FB30                          ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F13R2_FB31                          ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/******************************************************************************/
+/*                          CRC Calculation Unit                              */
+/******************************************************************************/
+
+/*******************  Bit definition for CRC_DATAR register  *********************/
+#define CRC_DATAR_DR                            ((uint32_t)0xFFFFFFFF) /* Data register bits */
+
+/*******************  Bit definition for CRC_IDATAR register  ********************/
+#define CRC_IDR_IDATAR                          ((uint8_t)0xFF) /* General-purpose 8-bit data register bits */
+
+/********************  Bit definition for CRC_CTLR register  ********************/
+#define CRC_CTLR_RESET                          ((uint8_t)0x01) /* RESET bit */
+
+/******************************************************************************/
+/*                             DMA Controller                                 */
+/******************************************************************************/
+
+/*******************  Bit definition for DMA_INTFR register  ********************/
+#define DMA_GIF1                                ((uint32_t)0x00000001) /* Channel 1 Global interrupt flag */
+#define DMA_TCIF1                               ((uint32_t)0x00000002) /* Channel 1 Transfer Complete flag */
+#define DMA_HTIF1                               ((uint32_t)0x00000004) /* Channel 1 Half Transfer flag */
+#define DMA_TEIF1                               ((uint32_t)0x00000008) /* Channel 1 Transfer Error flag */
+#define DMA_GIF2                                ((uint32_t)0x00000010) /* Channel 2 Global interrupt flag */
+#define DMA_TCIF2                               ((uint32_t)0x00000020) /* Channel 2 Transfer Complete flag */
+#define DMA_HTIF2                               ((uint32_t)0x00000040) /* Channel 2 Half Transfer flag */
+#define DMA_TEIF2                               ((uint32_t)0x00000080) /* Channel 2 Transfer Error flag */
+#define DMA_GIF3                                ((uint32_t)0x00000100) /* Channel 3 Global interrupt flag */
+#define DMA_TCIF3                               ((uint32_t)0x00000200) /* Channel 3 Transfer Complete flag */
+#define DMA_HTIF3                               ((uint32_t)0x00000400) /* Channel 3 Half Transfer flag */
+#define DMA_TEIF3                               ((uint32_t)0x00000800) /* Channel 3 Transfer Error flag */
+#define DMA_GIF4                                ((uint32_t)0x00001000) /* Channel 4 Global interrupt flag */
+#define DMA_TCIF4                               ((uint32_t)0x00002000) /* Channel 4 Transfer Complete flag */
+#define DMA_HTIF4                               ((uint32_t)0x00004000) /* Channel 4 Half Transfer flag */
+#define DMA_TEIF4                               ((uint32_t)0x00008000) /* Channel 4 Transfer Error flag */
+#define DMA_GIF5                                ((uint32_t)0x00010000) /* Channel 5 Global interrupt flag */
+#define DMA_TCIF5                               ((uint32_t)0x00020000) /* Channel 5 Transfer Complete flag */
+#define DMA_HTIF5                               ((uint32_t)0x00040000) /* Channel 5 Half Transfer flag */
+#define DMA_TEIF5                               ((uint32_t)0x00080000) /* Channel 5 Transfer Error flag */
+#define DMA_GIF6                                ((uint32_t)0x00100000) /* Channel 6 Global interrupt flag */
+#define DMA_TCIF6                               ((uint32_t)0x00200000) /* Channel 6 Transfer Complete flag */
+#define DMA_HTIF6                               ((uint32_t)0x00400000) /* Channel 6 Half Transfer flag */
+#define DMA_TEIF6                               ((uint32_t)0x00800000) /* Channel 6 Transfer Error flag */
+#define DMA_GIF7                                ((uint32_t)0x01000000) /* Channel 7 Global interrupt flag */
+#define DMA_TCIF7                               ((uint32_t)0x02000000) /* Channel 7 Transfer Complete flag */
+#define DMA_HTIF7                               ((uint32_t)0x04000000) /* Channel 7 Half Transfer flag */
+#define DMA_TEIF7                               ((uint32_t)0x08000000) /* Channel 7 Transfer Error flag */
+
+#define DMA_GIF8                                ((uint32_t)0x00000001) /* Channel 8 Global interrupt flag */
+#define DMA_TCIF8                               ((uint32_t)0x00000002) /* Channel 8 Transfer Complete flag */
+#define DMA_HTIF8                               ((uint32_t)0x00000004) /* Channel 8 Half Transfer flag */
+#define DMA_TEIF8                               ((uint32_t)0x00000008) /* Channel 8 Transfer Error flag */
+#define DMA_GIF9                                ((uint32_t)0x00000010) /* Channel 9 Global interrupt flag */
+#define DMA_TCIF9                               ((uint32_t)0x00000020) /* Channel 9 Transfer Complete flag */
+#define DMA_HTIF9                               ((uint32_t)0x00000040) /* Channel 9 Half Transfer flag */
+#define DMA_TEIF9                               ((uint32_t)0x00000080) /* Channel 9 Transfer Error flag */
+#define DMA_GIF10                               ((uint32_t)0x00000100) /* Channel 10 Global interrupt flag */
+#define DMA_TCIF10                              ((uint32_t)0x00000200) /* Channel 10 Transfer Complete flag */
+#define DMA_HTIF10                              ((uint32_t)0x00000400) /* Channel 10 Half Transfer flag */
+#define DMA_TEIF10                              ((uint32_t)0x00000800) /* Channel 10 Transfer Error flag */
+#define DMA_GIF11                               ((uint32_t)0x00001000) /* Channel 11 Global interrupt flag */
+#define DMA_TCIF11                              ((uint32_t)0x00002000) /* Channel 11 Transfer Complete flag */
+#define DMA_HTIF11                              ((uint32_t)0x00004000) /* Channel 11 Half Transfer flag */
+#define DMA_TEIF11                              ((uint32_t)0x00008000) /* Channel 11 Transfer Error flag */
+
+/*******************  Bit definition for DMA_INTFCR register  *******************/
+#define DMA_CGIF1                               ((uint32_t)0x00000001) /* Channel 1 Global interrupt clear */
+#define DMA_CTCIF1                              ((uint32_t)0x00000002) /* Channel 1 Transfer Complete clear */
+#define DMA_CHTIF1                              ((uint32_t)0x00000004) /* Channel 1 Half Transfer clear */
+#define DMA_CTEIF1                              ((uint32_t)0x00000008) /* Channel 1 Transfer Error clear */
+#define DMA_CGIF2                               ((uint32_t)0x00000010) /* Channel 2 Global interrupt clear */
+#define DMA_CTCIF2                              ((uint32_t)0x00000020) /* Channel 2 Transfer Complete clear */
+#define DMA_CHTIF2                              ((uint32_t)0x00000040) /* Channel 2 Half Transfer clear */
+#define DMA_CTEIF2                              ((uint32_t)0x00000080) /* Channel 2 Transfer Error clear */
+#define DMA_CGIF3                               ((uint32_t)0x00000100) /* Channel 3 Global interrupt clear */
+#define DMA_CTCIF3                              ((uint32_t)0x00000200) /* Channel 3 Transfer Complete clear */
+#define DMA_CHTIF3                              ((uint32_t)0x00000400) /* Channel 3 Half Transfer clear */
+#define DMA_CTEIF3                              ((uint32_t)0x00000800) /* Channel 3 Transfer Error clear */
+#define DMA_CGIF4                               ((uint32_t)0x00001000) /* Channel 4 Global interrupt clear */
+#define DMA_CTCIF4                              ((uint32_t)0x00002000) /* Channel 4 Transfer Complete clear */
+#define DMA_CHTIF4                              ((uint32_t)0x00004000) /* Channel 4 Half Transfer clear */
+#define DMA_CTEIF4                              ((uint32_t)0x00008000) /* Channel 4 Transfer Error clear */
+#define DMA_CGIF5                               ((uint32_t)0x00010000) /* Channel 5 Global interrupt clear */
+#define DMA_CTCIF5                              ((uint32_t)0x00020000) /* Channel 5 Transfer Complete clear */
+#define DMA_CHTIF5                              ((uint32_t)0x00040000) /* Channel 5 Half Transfer clear */
+#define DMA_CTEIF5                              ((uint32_t)0x00080000) /* Channel 5 Transfer Error clear */
+#define DMA_CGIF6                               ((uint32_t)0x00100000) /* Channel 6 Global interrupt clear */
+#define DMA_CTCIF6                              ((uint32_t)0x00200000) /* Channel 6 Transfer Complete clear */
+#define DMA_CHTIF6                              ((uint32_t)0x00400000) /* Channel 6 Half Transfer clear */
+#define DMA_CTEIF6                              ((uint32_t)0x00800000) /* Channel 6 Transfer Error clear */
+#define DMA_CGIF7                               ((uint32_t)0x01000000) /* Channel 7 Global interrupt clear */
+#define DMA_CTCIF7                              ((uint32_t)0x02000000) /* Channel 7 Transfer Complete clear */
+#define DMA_CHTIF7                              ((uint32_t)0x04000000) /* Channel 7 Half Transfer clear */
+#define DMA_CTEIF7                              ((uint32_t)0x08000000) /* Channel 7 Transfer Error clear */
+
+/*******************  Bit definition for DMA_CFGR1 register  *******************/
+#define DMA_CFGR1_EN                            ((uint16_t)0x0001) /* Channel enable*/
+#define DMA_CFGR1_TCIE                          ((uint16_t)0x0002) /* Transfer complete interrupt enable */
+#define DMA_CFGR1_HTIE                          ((uint16_t)0x0004) /* Half Transfer interrupt enable */
+#define DMA_CFGR1_TEIE                          ((uint16_t)0x0008) /* Transfer error interrupt enable */
+#define DMA_CFGR1_DIR                           ((uint16_t)0x0010) /* Data transfer direction */
+#define DMA_CFGR1_CIRC                          ((uint16_t)0x0020) /* Circular mode */
+#define DMA_CFGR1_PINC                          ((uint16_t)0x0040) /* Peripheral increment mode */
+#define DMA_CFGR1_MINC                          ((uint16_t)0x0080) /* Memory increment mode */
+
+#define DMA_CFGR1_PSIZE                         ((uint16_t)0x0300) /* PSIZE[1:0] bits (Peripheral size) */
+#define DMA_CFGR1_PSIZE_0                       ((uint16_t)0x0100) /* Bit 0 */
+#define DMA_CFGR1_PSIZE_1                       ((uint16_t)0x0200) /* Bit 1 */
+
+#define DMA_CFGR1_MSIZE                         ((uint16_t)0x0C00) /* MSIZE[1:0] bits (Memory size) */
+#define DMA_CFGR1_MSIZE_0                       ((uint16_t)0x0400) /* Bit 0 */
+#define DMA_CFGR1_MSIZE_1                       ((uint16_t)0x0800) /* Bit 1 */
+
+#define DMA_CFGR1_PL                            ((uint16_t)0x3000) /* PL[1:0] bits(Channel Priority level) */
+#define DMA_CFGR1_PL_0                          ((uint16_t)0x1000) /* Bit 0 */
+#define DMA_CFGR1_PL_1                          ((uint16_t)0x2000) /* Bit 1 */
+
+#define DMA_CFGR1_MEM2MEM                       ((uint16_t)0x4000) /* Memory to memory mode */
+
+/*******************  Bit definition for DMA_CFGR2 register  *******************/
+#define DMA_CFGR2_EN                            ((uint16_t)0x0001) /* Channel enable */
+#define DMA_CFGR2_TCIE                          ((uint16_t)0x0002) /* Transfer complete interrupt enable */
+#define DMA_CFGR2_HTIE                          ((uint16_t)0x0004) /* Half Transfer interrupt enable */
+#define DMA_CFGR2_TEIE                          ((uint16_t)0x0008) /* Transfer error interrupt enable */
+#define DMA_CFGR2_DIR                           ((uint16_t)0x0010) /* Data transfer direction */
+#define DMA_CFGR2_CIRC                          ((uint16_t)0x0020) /* Circular mode */
+#define DMA_CFGR2_PINC                          ((uint16_t)0x0040) /* Peripheral increment mode */
+#define DMA_CFGR2_MINC                          ((uint16_t)0x0080) /* Memory increment mode */
+
+#define DMA_CFGR2_PSIZE                         ((uint16_t)0x0300) /* PSIZE[1:0] bits (Peripheral size) */
+#define DMA_CFGR2_PSIZE_0                       ((uint16_t)0x0100) /* Bit 0 */
+#define DMA_CFGR2_PSIZE_1                       ((uint16_t)0x0200) /* Bit 1 */
+
+#define DMA_CFGR2_MSIZE                         ((uint16_t)0x0C00) /* MSIZE[1:0] bits (Memory size) */
+#define DMA_CFGR2_MSIZE_0                       ((uint16_t)0x0400) /* Bit 0 */
+#define DMA_CFGR2_MSIZE_1                       ((uint16_t)0x0800) /* Bit 1 */
+
+#define DMA_CFGR2_PL                            ((uint16_t)0x3000) /* PL[1:0] bits (Channel Priority level) */
+#define DMA_CFGR2_PL_0                          ((uint16_t)0x1000) /* Bit 0 */
+#define DMA_CFGR2_PL_1                          ((uint16_t)0x2000) /* Bit 1 */
+
+#define DMA_CFGR2_MEM2MEM                       ((uint16_t)0x4000) /* Memory to memory mode */
+
+/*******************  Bit definition for DMA_CFGR3 register  *******************/
+#define DMA_CFGR3_EN                            ((uint16_t)0x0001) /* Channel enable */
+#define DMA_CFGR3_TCIE                          ((uint16_t)0x0002) /* Transfer complete interrupt enable */
+#define DMA_CFGR3_HTIE                          ((uint16_t)0x0004) /* Half Transfer interrupt enable */
+#define DMA_CFGR3_TEIE                          ((uint16_t)0x0008) /* Transfer error interrupt enable */
+#define DMA_CFGR3_DIR                           ((uint16_t)0x0010) /* Data transfer direction */
+#define DMA_CFGR3_CIRC                          ((uint16_t)0x0020) /* Circular mode */
+#define DMA_CFGR3_PINC                          ((uint16_t)0x0040) /* Peripheral increment mode */
+#define DMA_CFGR3_MINC                          ((uint16_t)0x0080) /* Memory increment mode */
+
+#define DMA_CFGR3_PSIZE                         ((uint16_t)0x0300) /* PSIZE[1:0] bits (Peripheral size) */
+#define DMA_CFGR3_PSIZE_0                       ((uint16_t)0x0100) /* Bit 0 */
+#define DMA_CFGR3_PSIZE_1                       ((uint16_t)0x0200) /* Bit 1 */
+
+#define DMA_CFGR3_MSIZE                         ((uint16_t)0x0C00) /* MSIZE[1:0] bits (Memory size) */
+#define DMA_CFGR3_MSIZE_0                       ((uint16_t)0x0400) /* Bit 0 */
+#define DMA_CFGR3_MSIZE_1                       ((uint16_t)0x0800) /* Bit 1 */
+
+#define DMA_CFGR3_PL                            ((uint16_t)0x3000) /* PL[1:0] bits (Channel Priority level) */
+#define DMA_CFGR3_PL_0                          ((uint16_t)0x1000) /* Bit 0 */
+#define DMA_CFGR3_PL_1                          ((uint16_t)0x2000) /* Bit 1 */
+
+#define DMA_CFGR3_MEM2MEM                       ((uint16_t)0x4000) /* Memory to memory mode */
+
+/*******************  Bit definition for DMA_CFG4 register  *******************/
+#define DMA_CFG4_EN                             ((uint16_t)0x0001) /* Channel enable */
+#define DMA_CFG4_TCIE                           ((uint16_t)0x0002) /* Transfer complete interrupt enable */
+#define DMA_CFG4_HTIE                           ((uint16_t)0x0004) /* Half Transfer interrupt enable */
+#define DMA_CFG4_TEIE                           ((uint16_t)0x0008) /* Transfer error interrupt enable */
+#define DMA_CFG4_DIR                            ((uint16_t)0x0010) /* Data transfer direction */
+#define DMA_CFG4_CIRC                           ((uint16_t)0x0020) /* Circular mode */
+#define DMA_CFG4_PINC                           ((uint16_t)0x0040) /* Peripheral increment mode */
+#define DMA_CFG4_MINC                           ((uint16_t)0x0080) /* Memory increment mode */
+
+#define DMA_CFG4_PSIZE                          ((uint16_t)0x0300) /* PSIZE[1:0] bits (Peripheral size) */
+#define DMA_CFG4_PSIZE_0                        ((uint16_t)0x0100) /* Bit 0 */
+#define DMA_CFG4_PSIZE_1                        ((uint16_t)0x0200) /* Bit 1 */
+
+#define DMA_CFG4_MSIZE                          ((uint16_t)0x0C00) /* MSIZE[1:0] bits (Memory size) */
+#define DMA_CFG4_MSIZE_0                        ((uint16_t)0x0400) /* Bit 0 */
+#define DMA_CFG4_MSIZE_1                        ((uint16_t)0x0800) /* Bit 1 */
+
+#define DMA_CFG4_PL                             ((uint16_t)0x3000) /* PL[1:0] bits (Channel Priority level) */
+#define DMA_CFG4_PL_0                           ((uint16_t)0x1000) /* Bit 0 */
+#define DMA_CFG4_PL_1                           ((uint16_t)0x2000) /* Bit 1 */
+
+#define DMA_CFG4_MEM2MEM                        ((uint16_t)0x4000) /* Memory to memory mode */
+
+/******************  Bit definition for DMA_CFG5 register  *******************/
+#define DMA_CFG5_EN                             ((uint16_t)0x0001) /* Channel enable */
+#define DMA_CFG5_TCIE                           ((uint16_t)0x0002) /* Transfer complete interrupt enable */
+#define DMA_CFG5_HTIE                           ((uint16_t)0x0004) /* Half Transfer interrupt enable */
+#define DMA_CFG5_TEIE                           ((uint16_t)0x0008) /* Transfer error interrupt enable */
+#define DMA_CFG5_DIR                            ((uint16_t)0x0010) /* Data transfer direction */
+#define DMA_CFG5_CIRC                           ((uint16_t)0x0020) /* Circular mode */
+#define DMA_CFG5_PINC                           ((uint16_t)0x0040) /* Peripheral increment mode */
+#define DMA_CFG5_MINC                           ((uint16_t)0x0080) /* Memory increment mode */
+
+#define DMA_CFG5_PSIZE                          ((uint16_t)0x0300) /* PSIZE[1:0] bits (Peripheral size) */
+#define DMA_CFG5_PSIZE_0                        ((uint16_t)0x0100) /* Bit 0 */
+#define DMA_CFG5_PSIZE_1                        ((uint16_t)0x0200) /* Bit 1 */
+
+#define DMA_CFG5_MSIZE                          ((uint16_t)0x0C00) /* MSIZE[1:0] bits (Memory size) */
+#define DMA_CFG5_MSIZE_0                        ((uint16_t)0x0400) /* Bit 0 */
+#define DMA_CFG5_MSIZE_1                        ((uint16_t)0x0800) /* Bit 1 */
+
+#define DMA_CFG5_PL                             ((uint16_t)0x3000) /* PL[1:0] bits (Channel Priority level) */
+#define DMA_CFG5_PL_0                           ((uint16_t)0x1000) /* Bit 0 */
+#define DMA_CFG5_PL_1                           ((uint16_t)0x2000) /* Bit 1 */
+
+#define DMA_CFG5_MEM2MEM                        ((uint16_t)0x4000) /* Memory to memory mode enable */
+
+/*******************  Bit definition for DMA_CFG6 register  *******************/
+#define DMA_CFG6_EN                             ((uint16_t)0x0001) /* Channel enable */
+#define DMA_CFG6_TCIE                           ((uint16_t)0x0002) /* Transfer complete interrupt enable */
+#define DMA_CFG6_HTIE                           ((uint16_t)0x0004) /* Half Transfer interrupt enable */
+#define DMA_CFG6_TEIE                           ((uint16_t)0x0008) /* Transfer error interrupt enable */
+#define DMA_CFG6_DIR                            ((uint16_t)0x0010) /* Data transfer direction */
+#define DMA_CFG6_CIRC                           ((uint16_t)0x0020) /* Circular mode */
+#define DMA_CFG6_PINC                           ((uint16_t)0x0040) /* Peripheral increment mode */
+#define DMA_CFG6_MINC                           ((uint16_t)0x0080) /* Memory increment mode */
+
+#define DMA_CFG6_PSIZE                          ((uint16_t)0x0300) /* PSIZE[1:0] bits (Peripheral size) */
+#define DMA_CFG6_PSIZE_0                        ((uint16_t)0x0100) /* Bit 0 */
+#define DMA_CFG6_PSIZE_1                        ((uint16_t)0x0200) /* Bit 1 */
+
+#define DMA_CFG6_MSIZE                          ((uint16_t)0x0C00) /* MSIZE[1:0] bits (Memory size) */
+#define DMA_CFG6_MSIZE_0                        ((uint16_t)0x0400) /* Bit 0 */
+#define DMA_CFG6_MSIZE_1                        ((uint16_t)0x0800) /* Bit 1 */
+
+#define DMA_CFG6_PL                             ((uint16_t)0x3000) /* PL[1:0] bits (Channel Priority level) */
+#define DMA_CFG6_PL_0                           ((uint16_t)0x1000) /* Bit 0 */
+#define DMA_CFG6_PL_1                           ((uint16_t)0x2000) /* Bit 1 */
+
+#define DMA_CFG6_MEM2MEM                        ((uint16_t)0x4000) /* Memory to memory mode */
+
+/*******************  Bit definition for DMA_CFG7 register  *******************/
+#define DMA_CFG7_EN                             ((uint16_t)0x0001) /* Channel enable */
+#define DMA_CFG7_TCIE                           ((uint16_t)0x0002) /* Transfer complete interrupt enable */
+#define DMA_CFG7_HTIE                           ((uint16_t)0x0004) /* Half Transfer interrupt enable */
+#define DMA_CFG7_TEIE                           ((uint16_t)0x0008) /* Transfer error interrupt enable */
+#define DMA_CFG7_DIR                            ((uint16_t)0x0010) /* Data transfer direction */
+#define DMA_CFG7_CIRC                           ((uint16_t)0x0020) /* Circular mode */
+#define DMA_CFG7_PINC                           ((uint16_t)0x0040) /* Peripheral increment mode */
+#define DMA_CFG7_MINC                           ((uint16_t)0x0080) /* Memory increment mode */
+
+#define DMA_CFG7_PSIZE                          ((uint16_t)0x0300) /* PSIZE[1:0] bits (Peripheral size) */
+#define DMA_CFG7_PSIZE_0                        ((uint16_t)0x0100) /* Bit 0 */
+#define DMA_CFG7_PSIZE_1                        ((uint16_t)0x0200) /* Bit 1 */
+
+#define DMA_CFG7_MSIZE                          ((uint16_t)0x0C00) /* MSIZE[1:0] bits (Memory size) */
+#define DMA_CFG7_MSIZE_0                        ((uint16_t)0x0400) /* Bit 0 */
+#define DMA_CFG7_MSIZE_1                        ((uint16_t)0x0800) /* Bit 1 */
+
+#define DMA_CFG7_PL                             ((uint16_t)0x3000) /* PL[1:0] bits (Channel Priority level) */
+#define DMA_CFG7_PL_0                           ((uint16_t)0x1000) /* Bit 0 */
+#define DMA_CFG7_PL_1                           ((uint16_t)0x2000) /* Bit 1 */
+
+#define DMA_CFG7_MEM2MEM                        ((uint16_t)0x4000) /* Memory to memory mode enable */
+
+/******************  Bit definition for DMA_CNTR1 register  ******************/
+#define DMA_CNTR1_NDT                           ((uint16_t)0xFFFF) /* Number of data to Transfer */
+
+/******************  Bit definition for DMA_CNTR2 register  ******************/
+#define DMA_CNTR2_NDT                           ((uint16_t)0xFFFF) /* Number of data to Transfer */
+
+/******************  Bit definition for DMA_CNTR3 register  ******************/
+#define DMA_CNTR3_NDT                           ((uint16_t)0xFFFF) /* Number of data to Transfer */
+
+/******************  Bit definition for DMA_CNTR4 register  ******************/
+#define DMA_CNTR4_NDT                           ((uint16_t)0xFFFF) /* Number of data to Transfer */
+
+/******************  Bit definition for DMA_CNTR5 register  ******************/
+#define DMA_CNTR5_NDT                           ((uint16_t)0xFFFF) /* Number of data to Transfer */
+
+/******************  Bit definition for DMA_CNTR6 register  ******************/
+#define DMA_CNTR6_NDT                           ((uint16_t)0xFFFF) /* Number of data to Transfer */
+
+/******************  Bit definition for DMA_CNTR7 register  ******************/
+#define DMA_CNTR7_NDT                           ((uint16_t)0xFFFF) /* Number of data to Transfer */
+
+/******************  Bit definition for DMA_PADDR1 register  *******************/
+#define DMA_PADDR1_PA                           ((uint32_t)0xFFFFFFFF) /* Peripheral Address */
+
+/******************  Bit definition for DMA_PADDR2 register  *******************/
+#define DMA_PADDR2_PA                           ((uint32_t)0xFFFFFFFF) /* Peripheral Address */
+
+/******************  Bit definition for DMA_PADDR3 register  *******************/
+#define DMA_PADDR3_PA                           ((uint32_t)0xFFFFFFFF) /* Peripheral Address */
+
+/******************  Bit definition for DMA_PADDR4 register  *******************/
+#define DMA_PADDR4_PA                           ((uint32_t)0xFFFFFFFF) /* Peripheral Address */
+
+/******************  Bit definition for DMA_PADDR5 register  *******************/
+#define DMA_PADDR5_PA                           ((uint32_t)0xFFFFFFFF) /* Peripheral Address */
+
+/******************  Bit definition for DMA_PADDR6 register  *******************/
+#define DMA_PADDR6_PA                           ((uint32_t)0xFFFFFFFF) /* Peripheral Address */
+
+/******************  Bit definition for DMA_PADDR7 register  *******************/
+#define DMA_PADDR7_PA                           ((uint32_t)0xFFFFFFFF) /* Peripheral Address */
+
+/******************  Bit definition for DMA_MADDR1 register  *******************/
+#define DMA_MADDR1_MA                           ((uint32_t)0xFFFFFFFF) /* Memory Address */
+
+/******************  Bit definition for DMA_MADDR2 register  *******************/
+#define DMA_MADDR2_MA                           ((uint32_t)0xFFFFFFFF) /* Memory Address */
+
+/******************  Bit definition for DMA_MADDR3 register  *******************/
+#define DMA_MADDR3_MA                           ((uint32_t)0xFFFFFFFF) /* Memory Address */
+
+/******************  Bit definition for DMA_MADDR4 register  *******************/
+#define DMA_MADDR4_MA                           ((uint32_t)0xFFFFFFFF) /* Memory Address */
+
+/******************  Bit definition for DMA_MADDR5 register  *******************/
+#define DMA_MADDR5_MA                           ((uint32_t)0xFFFFFFFF) /* Memory Address */
+
+/******************  Bit definition for DMA_MADDR6 register  *******************/
+#define DMA_MADDR6_MA                           ((uint32_t)0xFFFFFFFF) /* Memory Address */
+
+/******************  Bit definition for DMA_MADDR7 register  *******************/
+#define DMA_MADDR7_MA                           ((uint32_t)0xFFFFFFFF) /* Memory Address */
+
+/******************************************************************************/
+/*                    External Interrupt/Event Controller                     */
+/******************************************************************************/
+
+/*******************  Bit definition for EXTI_INTENR register  *******************/
+#define EXTI_INTENR_MR0                         ((uint32_t)0x00000001) /* Interrupt Mask on line 0 */
+#define EXTI_INTENR_MR1                         ((uint32_t)0x00000002) /* Interrupt Mask on line 1 */
+#define EXTI_INTENR_MR2                         ((uint32_t)0x00000004) /* Interrupt Mask on line 2 */
+#define EXTI_INTENR_MR3                         ((uint32_t)0x00000008) /* Interrupt Mask on line 3 */
+#define EXTI_INTENR_MR4                         ((uint32_t)0x00000010) /* Interrupt Mask on line 4 */
+#define EXTI_INTENR_MR5                         ((uint32_t)0x00000020) /* Interrupt Mask on line 5 */
+#define EXTI_INTENR_MR6                         ((uint32_t)0x00000040) /* Interrupt Mask on line 6 */
+#define EXTI_INTENR_MR7                         ((uint32_t)0x00000080) /* Interrupt Mask on line 7 */
+#define EXTI_INTENR_MR8                         ((uint32_t)0x00000100) /* Interrupt Mask on line 8 */
+#define EXTI_INTENR_MR9                         ((uint32_t)0x00000200) /* Interrupt Mask on line 9 */
+#define EXTI_INTENR_MR10                        ((uint32_t)0x00000400) /* Interrupt Mask on line 10 */
+#define EXTI_INTENR_MR11                        ((uint32_t)0x00000800) /* Interrupt Mask on line 11 */
+#define EXTI_INTENR_MR12                        ((uint32_t)0x00001000) /* Interrupt Mask on line 12 */
+#define EXTI_INTENR_MR13                        ((uint32_t)0x00002000) /* Interrupt Mask on line 13 */
+#define EXTI_INTENR_MR14                        ((uint32_t)0x00004000) /* Interrupt Mask on line 14 */
+#define EXTI_INTENR_MR15                        ((uint32_t)0x00008000) /* Interrupt Mask on line 15 */
+#define EXTI_INTENR_MR16                        ((uint32_t)0x00010000) /* Interrupt Mask on line 16 */
+#define EXTI_INTENR_MR17                        ((uint32_t)0x00020000) /* Interrupt Mask on line 17 */
+#define EXTI_INTENR_MR18                        ((uint32_t)0x00040000) /* Interrupt Mask on line 18 */
+#define EXTI_INTENR_MR19                        ((uint32_t)0x00080000) /* Interrupt Mask on line 19 */
+
+/*******************  Bit definition for EXTI_EVENR register  *******************/
+#define EXTI_EVENR_MR0                          ((uint32_t)0x00000001) /* Event Mask on line 0 */
+#define EXTI_EVENR_MR1                          ((uint32_t)0x00000002) /* Event Mask on line 1 */
+#define EXTI_EVENR_MR2                          ((uint32_t)0x00000004) /* Event Mask on line 2 */
+#define EXTI_EVENR_MR3                          ((uint32_t)0x00000008) /* Event Mask on line 3 */
+#define EXTI_EVENR_MR4                          ((uint32_t)0x00000010) /* Event Mask on line 4 */
+#define EXTI_EVENR_MR5                          ((uint32_t)0x00000020) /* Event Mask on line 5 */
+#define EXTI_EVENR_MR6                          ((uint32_t)0x00000040) /* Event Mask on line 6 */
+#define EXTI_EVENR_MR7                          ((uint32_t)0x00000080) /* Event Mask on line 7 */
+#define EXTI_EVENR_MR8                          ((uint32_t)0x00000100) /* Event Mask on line 8 */
+#define EXTI_EVENR_MR9                          ((uint32_t)0x00000200) /* Event Mask on line 9 */
+#define EXTI_EVENR_MR10                         ((uint32_t)0x00000400) /* Event Mask on line 10 */
+#define EXTI_EVENR_MR11                         ((uint32_t)0x00000800) /* Event Mask on line 11 */
+#define EXTI_EVENR_MR12                         ((uint32_t)0x00001000) /* Event Mask on line 12 */
+#define EXTI_EVENR_MR13                         ((uint32_t)0x00002000) /* Event Mask on line 13 */
+#define EXTI_EVENR_MR14                         ((uint32_t)0x00004000) /* Event Mask on line 14 */
+#define EXTI_EVENR_MR15                         ((uint32_t)0x00008000) /* Event Mask on line 15 */
+#define EXTI_EVENR_MR16                         ((uint32_t)0x00010000) /* Event Mask on line 16 */
+#define EXTI_EVENR_MR17                         ((uint32_t)0x00020000) /* Event Mask on line 17 */
+#define EXTI_EVENR_MR18                         ((uint32_t)0x00040000) /* Event Mask on line 18 */
+#define EXTI_EVENR_MR19                         ((uint32_t)0x00080000) /* Event Mask on line 19 */
+
+/******************  Bit definition for EXTI_RTENR register  *******************/
+#define EXTI_RTENR_TR0                          ((uint32_t)0x00000001) /* Rising trigger event configuration bit of line 0 */
+#define EXTI_RTENR_TR1                          ((uint32_t)0x00000002) /* Rising trigger event configuration bit of line 1 */
+#define EXTI_RTENR_TR2                          ((uint32_t)0x00000004) /* Rising trigger event configuration bit of line 2 */
+#define EXTI_RTENR_TR3                          ((uint32_t)0x00000008) /* Rising trigger event configuration bit of line 3 */
+#define EXTI_RTENR_TR4                          ((uint32_t)0x00000010) /* Rising trigger event configuration bit of line 4 */
+#define EXTI_RTENR_TR5                          ((uint32_t)0x00000020) /* Rising trigger event configuration bit of line 5 */
+#define EXTI_RTENR_TR6                          ((uint32_t)0x00000040) /* Rising trigger event configuration bit of line 6 */
+#define EXTI_RTENR_TR7                          ((uint32_t)0x00000080) /* Rising trigger event configuration bit of line 7 */
+#define EXTI_RTENR_TR8                          ((uint32_t)0x00000100) /* Rising trigger event configuration bit of line 8 */
+#define EXTI_RTENR_TR9                          ((uint32_t)0x00000200) /* Rising trigger event configuration bit of line 9 */
+#define EXTI_RTENR_TR10                         ((uint32_t)0x00000400) /* Rising trigger event configuration bit of line 10 */
+#define EXTI_RTENR_TR11                         ((uint32_t)0x00000800) /* Rising trigger event configuration bit of line 11 */
+#define EXTI_RTENR_TR12                         ((uint32_t)0x00001000) /* Rising trigger event configuration bit of line 12 */
+#define EXTI_RTENR_TR13                         ((uint32_t)0x00002000) /* Rising trigger event configuration bit of line 13 */
+#define EXTI_RTENR_TR14                         ((uint32_t)0x00004000) /* Rising trigger event configuration bit of line 14 */
+#define EXTI_RTENR_TR15                         ((uint32_t)0x00008000) /* Rising trigger event configuration bit of line 15 */
+#define EXTI_RTENR_TR16                         ((uint32_t)0x00010000) /* Rising trigger event configuration bit of line 16 */
+#define EXTI_RTENR_TR17                         ((uint32_t)0x00020000) /* Rising trigger event configuration bit of line 17 */
+#define EXTI_RTENR_TR18                         ((uint32_t)0x00040000) /* Rising trigger event configuration bit of line 18 */
+#define EXTI_RTENR_TR19                         ((uint32_t)0x00080000) /* Rising trigger event configuration bit of line 19 */
+
+/******************  Bit definition for EXTI_FTENR register  *******************/
+#define EXTI_FTENR_TR0                          ((uint32_t)0x00000001) /* Falling trigger event configuration bit of line 0 */
+#define EXTI_FTENR_TR1                          ((uint32_t)0x00000002) /* Falling trigger event configuration bit of line 1 */
+#define EXTI_FTENR_TR2                          ((uint32_t)0x00000004) /* Falling trigger event configuration bit of line 2 */
+#define EXTI_FTENR_TR3                          ((uint32_t)0x00000008) /* Falling trigger event configuration bit of line 3 */
+#define EXTI_FTENR_TR4                          ((uint32_t)0x00000010) /* Falling trigger event configuration bit of line 4 */
+#define EXTI_FTENR_TR5                          ((uint32_t)0x00000020) /* Falling trigger event configuration bit of line 5 */
+#define EXTI_FTENR_TR6                          ((uint32_t)0x00000040) /* Falling trigger event configuration bit of line 6 */
+#define EXTI_FTENR_TR7                          ((uint32_t)0x00000080) /* Falling trigger event configuration bit of line 7 */
+#define EXTI_FTENR_TR8                          ((uint32_t)0x00000100) /* Falling trigger event configuration bit of line 8 */
+#define EXTI_FTENR_TR9                          ((uint32_t)0x00000200) /* Falling trigger event configuration bit of line 9 */
+#define EXTI_FTENR_TR10                         ((uint32_t)0x00000400) /* Falling trigger event configuration bit of line 10 */
+#define EXTI_FTENR_TR11                         ((uint32_t)0x00000800) /* Falling trigger event configuration bit of line 11 */
+#define EXTI_FTENR_TR12                         ((uint32_t)0x00001000) /* Falling trigger event configuration bit of line 12 */
+#define EXTI_FTENR_TR13                         ((uint32_t)0x00002000) /* Falling trigger event configuration bit of line 13 */
+#define EXTI_FTENR_TR14                         ((uint32_t)0x00004000) /* Falling trigger event configuration bit of line 14 */
+#define EXTI_FTENR_TR15                         ((uint32_t)0x00008000) /* Falling trigger event configuration bit of line 15 */
+#define EXTI_FTENR_TR16                         ((uint32_t)0x00010000) /* Falling trigger event configuration bit of line 16 */
+#define EXTI_FTENR_TR17                         ((uint32_t)0x00020000) /* Falling trigger event configuration bit of line 17 */
+#define EXTI_FTENR_TR18                         ((uint32_t)0x00040000) /* Falling trigger event configuration bit of line 18 */
+#define EXTI_FTENR_TR19                         ((uint32_t)0x00080000) /* Falling trigger event configuration bit of line 19 */
+
+/******************  Bit definition for EXTI_SWIEVR register  ******************/
+#define EXTI_SWIEVR_SWIEVR0                     ((uint32_t)0x00000001) /* Software Interrupt on line 0 */
+#define EXTI_SWIEVR_SWIEVR1                     ((uint32_t)0x00000002) /* Software Interrupt on line 1 */
+#define EXTI_SWIEVR_SWIEVR2                     ((uint32_t)0x00000004) /* Software Interrupt on line 2 */
+#define EXTI_SWIEVR_SWIEVR3                     ((uint32_t)0x00000008) /* Software Interrupt on line 3 */
+#define EXTI_SWIEVR_SWIEVR4                     ((uint32_t)0x00000010) /* Software Interrupt on line 4 */
+#define EXTI_SWIEVR_SWIEVR5                     ((uint32_t)0x00000020) /* Software Interrupt on line 5 */
+#define EXTI_SWIEVR_SWIEVR6                     ((uint32_t)0x00000040) /* Software Interrupt on line 6 */
+#define EXTI_SWIEVR_SWIEVR7                     ((uint32_t)0x00000080) /* Software Interrupt on line 7 */
+#define EXTI_SWIEVR_SWIEVR8                     ((uint32_t)0x00000100) /* Software Interrupt on line 8 */
+#define EXTI_SWIEVR_SWIEVR9                     ((uint32_t)0x00000200) /* Software Interrupt on line 9 */
+#define EXTI_SWIEVR_SWIEVR10                    ((uint32_t)0x00000400) /* Software Interrupt on line 10 */
+#define EXTI_SWIEVR_SWIEVR11                    ((uint32_t)0x00000800) /* Software Interrupt on line 11 */
+#define EXTI_SWIEVR_SWIEVR12                    ((uint32_t)0x00001000) /* Software Interrupt on line 12 */
+#define EXTI_SWIEVR_SWIEVR13                    ((uint32_t)0x00002000) /* Software Interrupt on line 13 */
+#define EXTI_SWIEVR_SWIEVR14                    ((uint32_t)0x00004000) /* Software Interrupt on line 14 */
+#define EXTI_SWIEVR_SWIEVR15                    ((uint32_t)0x00008000) /* Software Interrupt on line 15 */
+#define EXTI_SWIEVR_SWIEVR16                    ((uint32_t)0x00010000) /* Software Interrupt on line 16 */
+#define EXTI_SWIEVR_SWIEVR17                    ((uint32_t)0x00020000) /* Software Interrupt on line 17 */
+#define EXTI_SWIEVR_SWIEVR18                    ((uint32_t)0x00040000) /* Software Interrupt on line 18 */
+#define EXTI_SWIEVR_SWIEVR19                    ((uint32_t)0x00080000) /* Software Interrupt on line 19 */
+
+/*******************  Bit definition for EXTI_INTFR register  ********************/
+#define EXTI_INTF_INTF0                         ((uint32_t)0x00000001) /* Pending bit for line 0 */
+#define EXTI_INTF_INTF1                         ((uint32_t)0x00000002) /* Pending bit for line 1 */
+#define EXTI_INTF_INTF2                         ((uint32_t)0x00000004) /* Pending bit for line 2 */
+#define EXTI_INTF_INTF3                         ((uint32_t)0x00000008) /* Pending bit for line 3 */
+#define EXTI_INTF_INTF4                         ((uint32_t)0x00000010) /* Pending bit for line 4 */
+#define EXTI_INTF_INTF5                         ((uint32_t)0x00000020) /* Pending bit for line 5 */
+#define EXTI_INTF_INTF6                         ((uint32_t)0x00000040) /* Pending bit for line 6 */
+#define EXTI_INTF_INTF7                         ((uint32_t)0x00000080) /* Pending bit for line 7 */
+#define EXTI_INTF_INTF8                         ((uint32_t)0x00000100) /* Pending bit for line 8 */
+#define EXTI_INTF_INTF9                         ((uint32_t)0x00000200) /* Pending bit for line 9 */
+#define EXTI_INTF_INTF10                        ((uint32_t)0x00000400) /* Pending bit for line 10 */
+#define EXTI_INTF_INTF11                        ((uint32_t)0x00000800) /* Pending bit for line 11 */
+#define EXTI_INTF_INTF12                        ((uint32_t)0x00001000) /* Pending bit for line 12 */
+#define EXTI_INTF_INTF13                        ((uint32_t)0x00002000) /* Pending bit for line 13 */
+#define EXTI_INTF_INTF14                        ((uint32_t)0x00004000) /* Pending bit for line 14 */
+#define EXTI_INTF_INTF15                        ((uint32_t)0x00008000) /* Pending bit for line 15 */
+#define EXTI_INTF_INTF16                        ((uint32_t)0x00010000) /* Pending bit for line 16 */
+#define EXTI_INTF_INTF17                        ((uint32_t)0x00020000) /* Pending bit for line 17 */
+#define EXTI_INTF_INTF18                        ((uint32_t)0x00040000) /* Pending bit for line 18 */
+#define EXTI_INTF_INTF19                        ((uint32_t)0x00080000) /* Pending bit for line 19 */
+
+/******************************************************************************/
+/*                      FLASH and Option Bytes Registers                      */
+/******************************************************************************/
+
+/*******************  Bit definition for FLASH_ACTLR register  ******************/
+
+/******************  Bit definition for FLASH_KEYR register  ******************/
+#define FLASH_KEYR_FKEYR                        ((uint32_t)0xFFFFFFFF) /* FPEC Key */
+
+/*****************  Bit definition for FLASH_OBKEYR register  ****************/
+#define FLASH_OBKEYR_OBKEYR                     ((uint32_t)0xFFFFFFFF) /* Option Byte Key */
+
+/******************  Bit definition for FLASH_STATR register  *******************/
+#define FLASH_STATR_BSY                         ((uint8_t)0x01) /* Busy */
+#define FLASH_STATR_PGERR                       ((uint8_t)0x04) /* Programming Error */
+#define FLASH_STATR_WRPRTERR                    ((uint8_t)0x10) /* Write Protection Error */
+#define FLASH_STATR_EOP                         ((uint8_t)0x20) /* End of operation */
+
+/*******************  Bit definition for FLASH_CTLR register  *******************/
+#define FLASH_CTLR_PG                           ((uint32_t)0x00000001) /* Programming */
+#define FLASH_CTLR_PER                          ((uint32_t)0x00000002) /* Sector Erase 4K */
+#define FLASH_CTLR_MER                          ((uint32_t)0x00000004) /* Mass Erase */
+#define FLASH_CTLR_OPTPG                        ((uint32_t)0x00000010) /* Option Byte Programming */
+#define FLASH_CTLR_OPTER                        ((uint32_t)0x00000020) /* Option Byte Erase */
+#define FLASH_CTLR_STRT                         ((uint32_t)0x00000040) /* Start */
+#define FLASH_CTLR_LOCK                         ((uint32_t)0x00000080) /* Lock */
+#define FLASH_CTLR_OPTWRE                       ((uint32_t)0x00000200) /* Option Bytes Write Enable */
+#define FLASH_CTLR_ERRIE                        ((uint32_t)0x00000400) /* Error Interrupt Enable */
+#define FLASH_CTLR_EOPIE                        ((uint32_t)0x00001000) /* End of operation interrupt enable */
+#define FLASH_CTLR_FAST_LOCK                    ((uint32_t)0x00008000) /* Fast Lock */
+#define FLASH_CTLR_PAGE_PG                      ((uint32_t)0x00010000) /* Page Programming 256Byte */
+#define FLASH_CTLR_PAGE_ER                      ((uint32_t)0x00020000) /* Page Erase 256Byte */
+#define FLASH_CTLR_PAGE_BER32                   ((uint32_t)0x00040000) /* Block Erase 32K */
+#define FLASH_CTLR_PAGE_BER64                   ((uint32_t)0x00080000) /* Block Erase 64K */
+#define FLASH_CTLR_PG_STRT                      ((uint32_t)0x00200000) /* Page Programming Start */
+
+/*******************  Bit definition for FLASH_ADDR register  *******************/
+#define FLASH_ADDR_FAR                          ((uint32_t)0xFFFFFFFF) /* Flash Address */
+
+/******************  Bit definition for FLASH_OBR register  *******************/
+#define FLASH_OBR_OPTERR                        ((uint16_t)0x0001) /* Option Byte Error */
+#define FLASH_OBR_RDPRT                         ((uint16_t)0x0002) /* Read protection */
+
+#define FLASH_OBR_USER                          ((uint16_t)0x03FC) /* User Option Bytes */
+#define FLASH_OBR_WDG_SW                        ((uint16_t)0x0004) /* WDG_SW */
+#define FLASH_OBR_nRST_STOP                     ((uint16_t)0x0008) /* nRST_STOP */
+#define FLASH_OBR_nRST_STDBY                    ((uint16_t)0x0010) /* nRST_STDBY */
+#define FLASH_OBR_BFB2                          ((uint16_t)0x0020) /* BFB2 */
+
+/******************  Bit definition for FLASH_WPR register  ******************/
+#define FLASH_WPR_WRP                           ((uint32_t)0xFFFFFFFF) /* Write Protect */
+
+/******************  Bit definition for FLASH_RDPR register  *******************/
+#define FLASH_RDPR_RDPR                         ((uint32_t)0x000000FF) /* Read protection option byte */
+#define FLASH_RDPR_nRDPR                        ((uint32_t)0x0000FF00) /* Read protection complemented option byte */
+
+/******************  Bit definition for FLASH_USER register  ******************/
+#define FLASH_USER_USER                         ((uint32_t)0x00FF0000) /* User option byte */
+#define FLASH_USER_nUSER                        ((uint32_t)0xFF000000) /* User complemented option byte */
+
+/******************  Bit definition for FLASH_Data0 register  *****************/
+#define FLASH_Data0_Data0                       ((uint32_t)0x000000FF) /* User data storage option byte */
+#define FLASH_Data0_nData0                      ((uint32_t)0x0000FF00) /* User data storage complemented option byte */
+
+/******************  Bit definition for FLASH_Data1 register  *****************/
+#define FLASH_Data1_Data1                       ((uint32_t)0x00FF0000) /* User data storage option byte */
+#define FLASH_Data1_nData1                      ((uint32_t)0xFF000000) /* User data storage complemented option byte */
+
+/******************  Bit definition for FLASH_WRPR0 register  ******************/
+#define FLASH_WRPR0_WRPR0                       ((uint32_t)0x000000FF) /* Flash memory write protection option bytes */
+#define FLASH_WRPR0_nWRPR0                      ((uint32_t)0x0000FF00) /* Flash memory write protection complemented option bytes */
+
+/******************  Bit definition for FLASH_WRPR1 register  ******************/
+#define FLASH_WRPR1_WRPR1                       ((uint32_t)0x00FF0000) /* Flash memory write protection option bytes */
+#define FLASH_WRPR1_nWRPR1                      ((uint32_t)0xFF000000) /* Flash memory write protection complemented option bytes */
+
+/******************  Bit definition for FLASH_WRPR2 register  ******************/
+#define FLASH_WRPR2_WRPR2                       ((uint32_t)0x000000FF) /* Flash memory write protection option bytes */
+#define FLASH_WRPR2_nWRPR2                      ((uint32_t)0x0000FF00) /* Flash memory write protection complemented option bytes */
+
+/******************  Bit definition for FLASH_WRPR3 register  ******************/
+#define FLASH_WRPR3_WRPR3                       ((uint32_t)0x00FF0000) /* Flash memory write protection option bytes */
+#define FLASH_WRPR3_nWRPR3                      ((uint32_t)0xFF000000) /* Flash memory write protection complemented option bytes */
+
+/******************************************************************************/
+/*                General Purpose and Alternate Function I/O                  */
+/******************************************************************************/
+
+/*******************  Bit definition for GPIO_CFGLR register  *******************/
+#define GPIO_CFGLR_MODE                         ((uint32_t)0x33333333) /* Port x mode bits */
+
+#define GPIO_CFGLR_MODE0                        ((uint32_t)0x00000003) /* MODE0[1:0] bits (Port x mode bits, pin 0) */
+#define GPIO_CFGLR_MODE0_0                      ((uint32_t)0x00000001) /* Bit 0 */
+#define GPIO_CFGLR_MODE0_1                      ((uint32_t)0x00000002) /* Bit 1 */
+
+#define GPIO_CFGLR_MODE1                        ((uint32_t)0x00000030) /* MODE1[1:0] bits (Port x mode bits, pin 1) */
+#define GPIO_CFGLR_MODE1_0                      ((uint32_t)0x00000010) /* Bit 0 */
+#define GPIO_CFGLR_MODE1_1                      ((uint32_t)0x00000020) /* Bit 1 */
+
+#define GPIO_CFGLR_MODE2                        ((uint32_t)0x00000300) /* MODE2[1:0] bits (Port x mode bits, pin 2) */
+#define GPIO_CFGLR_MODE2_0                      ((uint32_t)0x00000100) /* Bit 0 */
+#define GPIO_CFGLR_MODE2_1                      ((uint32_t)0x00000200) /* Bit 1 */
+
+#define GPIO_CFGLR_MODE3                        ((uint32_t)0x00003000) /* MODE3[1:0] bits (Port x mode bits, pin 3) */
+#define GPIO_CFGLR_MODE3_0                      ((uint32_t)0x00001000) /* Bit 0 */
+#define GPIO_CFGLR_MODE3_1                      ((uint32_t)0x00002000) /* Bit 1 */
+
+#define GPIO_CFGLR_MODE4                        ((uint32_t)0x00030000) /* MODE4[1:0] bits (Port x mode bits, pin 4) */
+#define GPIO_CFGLR_MODE4_0                      ((uint32_t)0x00010000) /* Bit 0 */
+#define GPIO_CFGLR_MODE4_1                      ((uint32_t)0x00020000) /* Bit 1 */
+
+#define GPIO_CFGLR_MODE5                        ((uint32_t)0x00300000) /* MODE5[1:0] bits (Port x mode bits, pin 5) */
+#define GPIO_CFGLR_MODE5_0                      ((uint32_t)0x00100000) /* Bit 0 */
+#define GPIO_CFGLR_MODE5_1                      ((uint32_t)0x00200000) /* Bit 1 */
+
+#define GPIO_CFGLR_MODE6                        ((uint32_t)0x03000000) /* MODE6[1:0] bits (Port x mode bits, pin 6) */
+#define GPIO_CFGLR_MODE6_0                      ((uint32_t)0x01000000) /* Bit 0 */
+#define GPIO_CFGLR_MODE6_1                      ((uint32_t)0x02000000) /* Bit 1 */
+
+#define GPIO_CFGLR_MODE7                        ((uint32_t)0x30000000) /* MODE7[1:0] bits (Port x mode bits, pin 7) */
+#define GPIO_CFGLR_MODE7_0                      ((uint32_t)0x10000000) /* Bit 0 */
+#define GPIO_CFGLR_MODE7_1                      ((uint32_t)0x20000000) /* Bit 1 */
+
+#define GPIO_CFGLR_CNF                          ((uint32_t)0xCCCCCCCC) /* Port x configuration bits */
+
+#define GPIO_CFGLR_CNF0                         ((uint32_t)0x0000000C) /* CNF0[1:0] bits (Port x configuration bits, pin 0) */
+#define GPIO_CFGLR_CNF0_0                       ((uint32_t)0x00000004) /* Bit 0 */
+#define GPIO_CFGLR_CNF0_1                       ((uint32_t)0x00000008) /* Bit 1 */
+
+#define GPIO_CFGLR_CNF1                         ((uint32_t)0x000000C0) /* CNF1[1:0] bits (Port x configuration bits, pin 1) */
+#define GPIO_CFGLR_CNF1_0                       ((uint32_t)0x00000040) /* Bit 0 */
+#define GPIO_CFGLR_CNF1_1                       ((uint32_t)0x00000080) /* Bit 1 */
+
+#define GPIO_CFGLR_CNF2                         ((uint32_t)0x00000C00) /* CNF2[1:0] bits (Port x configuration bits, pin 2) */
+#define GPIO_CFGLR_CNF2_0                       ((uint32_t)0x00000400) /* Bit 0 */
+#define GPIO_CFGLR_CNF2_1                       ((uint32_t)0x00000800) /* Bit 1 */
+
+#define GPIO_CFGLR_CNF3                         ((uint32_t)0x0000C000) /* CNF3[1:0] bits (Port x configuration bits, pin 3) */
+#define GPIO_CFGLR_CNF3_0                       ((uint32_t)0x00004000) /* Bit 0 */
+#define GPIO_CFGLR_CNF3_1                       ((uint32_t)0x00008000) /* Bit 1 */
+
+#define GPIO_CFGLR_CNF4                         ((uint32_t)0x000C0000) /* CNF4[1:0] bits (Port x configuration bits, pin 4) */
+#define GPIO_CFGLR_CNF4_0                       ((uint32_t)0x00040000) /* Bit 0 */
+#define GPIO_CFGLR_CNF4_1                       ((uint32_t)0x00080000) /* Bit 1 */
+
+#define GPIO_CFGLR_CNF5                         ((uint32_t)0x00C00000) /* CNF5[1:0] bits (Port x configuration bits, pin 5) */
+#define GPIO_CFGLR_CNF5_0                       ((uint32_t)0x00400000) /* Bit 0 */
+#define GPIO_CFGLR_CNF5_1                       ((uint32_t)0x00800000) /* Bit 1 */
+
+#define GPIO_CFGLR_CNF6                         ((uint32_t)0x0C000000) /* CNF6[1:0] bits (Port x configuration bits, pin 6) */
+#define GPIO_CFGLR_CNF6_0                       ((uint32_t)0x04000000) /* Bit 0 */
+#define GPIO_CFGLR_CNF6_1                       ((uint32_t)0x08000000) /* Bit 1 */
+
+#define GPIO_CFGLR_CNF7                         ((uint32_t)0xC0000000) /* CNF7[1:0] bits (Port x configuration bits, pin 7) */
+#define GPIO_CFGLR_CNF7_0                       ((uint32_t)0x40000000) /* Bit 0 */
+#define GPIO_CFGLR_CNF7_1                       ((uint32_t)0x80000000) /* Bit 1 */
+
+/*******************  Bit definition for GPIO_CFGHR register  *******************/
+#define GPIO_CFGHR_MODE                         ((uint32_t)0x33333333) /* Port x mode bits */
+
+#define GPIO_CFGHR_MODE8                        ((uint32_t)0x00000003) /* MODE8[1:0] bits (Port x mode bits, pin 8) */
+#define GPIO_CFGHR_MODE8_0                      ((uint32_t)0x00000001) /* Bit 0 */
+#define GPIO_CFGHR_MODE8_1                      ((uint32_t)0x00000002) /* Bit 1 */
+
+#define GPIO_CFGHR_MODE9                        ((uint32_t)0x00000030) /* MODE9[1:0] bits (Port x mode bits, pin 9) */
+#define GPIO_CFGHR_MODE9_0                      ((uint32_t)0x00000010) /* Bit 0 */
+#define GPIO_CFGHR_MODE9_1                      ((uint32_t)0x00000020) /* Bit 1 */
+
+#define GPIO_CFGHR_MODE10                       ((uint32_t)0x00000300) /* MODE10[1:0] bits (Port x mode bits, pin 10) */
+#define GPIO_CFGHR_MODE10_0                     ((uint32_t)0x00000100) /* Bit 0 */
+#define GPIO_CFGHR_MODE10_1                     ((uint32_t)0x00000200) /* Bit 1 */
+
+#define GPIO_CFGHR_MODE11                       ((uint32_t)0x00003000) /* MODE11[1:0] bits (Port x mode bits, pin 11) */
+#define GPIO_CFGHR_MODE11_0                     ((uint32_t)0x00001000) /* Bit 0 */
+#define GPIO_CFGHR_MODE11_1                     ((uint32_t)0x00002000) /* Bit 1 */
+
+#define GPIO_CFGHR_MODE12                       ((uint32_t)0x00030000) /* MODE12[1:0] bits (Port x mode bits, pin 12) */
+#define GPIO_CFGHR_MODE12_0                     ((uint32_t)0x00010000) /* Bit 0 */
+#define GPIO_CFGHR_MODE12_1                     ((uint32_t)0x00020000) /* Bit 1 */
+
+#define GPIO_CFGHR_MODE13                       ((uint32_t)0x00300000) /* MODE13[1:0] bits (Port x mode bits, pin 13) */
+#define GPIO_CFGHR_MODE13_0                     ((uint32_t)0x00100000) /* Bit 0 */
+#define GPIO_CFGHR_MODE13_1                     ((uint32_t)0x00200000) /* Bit 1 */
+
+#define GPIO_CFGHR_MODE14                       ((uint32_t)0x03000000) /* MODE14[1:0] bits (Port x mode bits, pin 14) */
+#define GPIO_CFGHR_MODE14_0                     ((uint32_t)0x01000000) /* Bit 0 */
+#define GPIO_CFGHR_MODE14_1                     ((uint32_t)0x02000000) /* Bit 1 */
+
+#define GPIO_CFGHR_MODE15                       ((uint32_t)0x30000000) /* MODE15[1:0] bits (Port x mode bits, pin 15) */
+#define GPIO_CFGHR_MODE15_0                     ((uint32_t)0x10000000) /* Bit 0 */
+#define GPIO_CFGHR_MODE15_1                     ((uint32_t)0x20000000) /* Bit 1 */
+
+#define GPIO_CFGHR_CNF                          ((uint32_t)0xCCCCCCCC) /* Port x configuration bits */
+
+#define GPIO_CFGHR_CNF8                         ((uint32_t)0x0000000C) /* CNF8[1:0] bits (Port x configuration bits, pin 8) */
+#define GPIO_CFGHR_CNF8_0                       ((uint32_t)0x00000004) /* Bit 0 */
+#define GPIO_CFGHR_CNF8_1                       ((uint32_t)0x00000008) /* Bit 1 */
+
+#define GPIO_CFGHR_CNF9                         ((uint32_t)0x000000C0) /* CNF9[1:0] bits (Port x configuration bits, pin 9) */
+#define GPIO_CFGHR_CNF9_0                       ((uint32_t)0x00000040) /* Bit 0 */
+#define GPIO_CFGHR_CNF9_1                       ((uint32_t)0x00000080) /* Bit 1 */
+
+#define GPIO_CFGHR_CNF10                        ((uint32_t)0x00000C00) /* CNF10[1:0] bits (Port x configuration bits, pin 10) */
+#define GPIO_CFGHR_CNF10_0                      ((uint32_t)0x00000400) /* Bit 0 */
+#define GPIO_CFGHR_CNF10_1                      ((uint32_t)0x00000800) /* Bit 1 */
+
+#define GPIO_CFGHR_CNF11                        ((uint32_t)0x0000C000) /* CNF11[1:0] bits (Port x configuration bits, pin 11) */
+#define GPIO_CFGHR_CNF11_0                      ((uint32_t)0x00004000) /* Bit 0 */
+#define GPIO_CFGHR_CNF11_1                      ((uint32_t)0x00008000) /* Bit 1 */
+
+#define GPIO_CFGHR_CNF12                        ((uint32_t)0x000C0000) /* CNF12[1:0] bits (Port x configuration bits, pin 12) */
+#define GPIO_CFGHR_CNF12_0                      ((uint32_t)0x00040000) /* Bit 0 */
+#define GPIO_CFGHR_CNF12_1                      ((uint32_t)0x00080000) /* Bit 1 */
+
+#define GPIO_CFGHR_CNF13                        ((uint32_t)0x00C00000) /* CNF13[1:0] bits (Port x configuration bits, pin 13) */
+#define GPIO_CFGHR_CNF13_0                      ((uint32_t)0x00400000) /* Bit 0 */
+#define GPIO_CFGHR_CNF13_1                      ((uint32_t)0x00800000) /* Bit 1 */
+
+#define GPIO_CFGHR_CNF14                        ((uint32_t)0x0C000000) /* CNF14[1:0] bits (Port x configuration bits, pin 14) */
+#define GPIO_CFGHR_CNF14_0                      ((uint32_t)0x04000000) /* Bit 0 */
+#define GPIO_CFGHR_CNF14_1                      ((uint32_t)0x08000000) /* Bit 1 */
+
+#define GPIO_CFGHR_CNF15                        ((uint32_t)0xC0000000) /* CNF15[1:0] bits (Port x configuration bits, pin 15) */
+#define GPIO_CFGHR_CNF15_0                      ((uint32_t)0x40000000) /* Bit 0 */
+#define GPIO_CFGHR_CNF15_1                      ((uint32_t)0x80000000) /* Bit 1 */
+
+/*******************  Bit definition for GPIO_INDR register  *******************/
+#define GPIO_INDR_IDR0                          ((uint16_t)0x0001) /* Port input data, bit 0 */
+#define GPIO_INDR_IDR1                          ((uint16_t)0x0002) /* Port input data, bit 1 */
+#define GPIO_INDR_IDR2                          ((uint16_t)0x0004) /* Port input data, bit 2 */
+#define GPIO_INDR_IDR3                          ((uint16_t)0x0008) /* Port input data, bit 3 */
+#define GPIO_INDR_IDR4                          ((uint16_t)0x0010) /* Port input data, bit 4 */
+#define GPIO_INDR_IDR5                          ((uint16_t)0x0020) /* Port input data, bit 5 */
+#define GPIO_INDR_IDR6                          ((uint16_t)0x0040) /* Port input data, bit 6 */
+#define GPIO_INDR_IDR7                          ((uint16_t)0x0080) /* Port input data, bit 7 */
+#define GPIO_INDR_IDR8                          ((uint16_t)0x0100) /* Port input data, bit 8 */
+#define GPIO_INDR_IDR9                          ((uint16_t)0x0200) /* Port input data, bit 9 */
+#define GPIO_INDR_IDR10                         ((uint16_t)0x0400) /* Port input data, bit 10 */
+#define GPIO_INDR_IDR11                         ((uint16_t)0x0800) /* Port input data, bit 11 */
+#define GPIO_INDR_IDR12                         ((uint16_t)0x1000) /* Port input data, bit 12 */
+#define GPIO_INDR_IDR13                         ((uint16_t)0x2000) /* Port input data, bit 13 */
+#define GPIO_INDR_IDR14                         ((uint16_t)0x4000) /* Port input data, bit 14 */
+#define GPIO_INDR_IDR15                         ((uint16_t)0x8000) /* Port input data, bit 15 */
+
+/*******************  Bit definition for GPIO_OUTDR register  *******************/
+#define GPIO_OUTDR_ODR0                         ((uint16_t)0x0001) /* Port output data, bit 0 */
+#define GPIO_OUTDR_ODR1                         ((uint16_t)0x0002) /* Port output data, bit 1 */
+#define GPIO_OUTDR_ODR2                         ((uint16_t)0x0004) /* Port output data, bit 2 */
+#define GPIO_OUTDR_ODR3                         ((uint16_t)0x0008) /* Port output data, bit 3 */
+#define GPIO_OUTDR_ODR4                         ((uint16_t)0x0010) /* Port output data, bit 4 */
+#define GPIO_OUTDR_ODR5                         ((uint16_t)0x0020) /* Port output data, bit 5 */
+#define GPIO_OUTDR_ODR6                         ((uint16_t)0x0040) /* Port output data, bit 6 */
+#define GPIO_OUTDR_ODR7                         ((uint16_t)0x0080) /* Port output data, bit 7 */
+#define GPIO_OUTDR_ODR8                         ((uint16_t)0x0100) /* Port output data, bit 8 */
+#define GPIO_OUTDR_ODR9                         ((uint16_t)0x0200) /* Port output data, bit 9 */
+#define GPIO_OUTDR_ODR10                        ((uint16_t)0x0400) /* Port output data, bit 10 */
+#define GPIO_OUTDR_ODR11                        ((uint16_t)0x0800) /* Port output data, bit 11 */
+#define GPIO_OUTDR_ODR12                        ((uint16_t)0x1000) /* Port output data, bit 12 */
+#define GPIO_OUTDR_ODR13                        ((uint16_t)0x2000) /* Port output data, bit 13 */
+#define GPIO_OUTDR_ODR14                        ((uint16_t)0x4000) /* Port output data, bit 14 */
+#define GPIO_OUTDR_ODR15                        ((uint16_t)0x8000) /* Port output data, bit 15 */
+
+/******************  Bit definition for GPIO_BSHR register  *******************/
+#define GPIO_BSHR_BS0                           ((uint32_t)0x00000001) /* Port x Set bit 0 */
+#define GPIO_BSHR_BS1                           ((uint32_t)0x00000002) /* Port x Set bit 1 */
+#define GPIO_BSHR_BS2                           ((uint32_t)0x00000004) /* Port x Set bit 2 */
+#define GPIO_BSHR_BS3                           ((uint32_t)0x00000008) /* Port x Set bit 3 */
+#define GPIO_BSHR_BS4                           ((uint32_t)0x00000010) /* Port x Set bit 4 */
+#define GPIO_BSHR_BS5                           ((uint32_t)0x00000020) /* Port x Set bit 5 */
+#define GPIO_BSHR_BS6                           ((uint32_t)0x00000040) /* Port x Set bit 6 */
+#define GPIO_BSHR_BS7                           ((uint32_t)0x00000080) /* Port x Set bit 7 */
+#define GPIO_BSHR_BS8                           ((uint32_t)0x00000100) /* Port x Set bit 8 */
+#define GPIO_BSHR_BS9                           ((uint32_t)0x00000200) /* Port x Set bit 9 */
+#define GPIO_BSHR_BS10                          ((uint32_t)0x00000400) /* Port x Set bit 10 */
+#define GPIO_BSHR_BS11                          ((uint32_t)0x00000800) /* Port x Set bit 11 */
+#define GPIO_BSHR_BS12                          ((uint32_t)0x00001000) /* Port x Set bit 12 */
+#define GPIO_BSHR_BS13                          ((uint32_t)0x00002000) /* Port x Set bit 13 */
+#define GPIO_BSHR_BS14                          ((uint32_t)0x00004000) /* Port x Set bit 14 */
+#define GPIO_BSHR_BS15                          ((uint32_t)0x00008000) /* Port x Set bit 15 */
+
+#define GPIO_BSHR_BR0                           ((uint32_t)0x00010000) /* Port x Reset bit 0 */
+#define GPIO_BSHR_BR1                           ((uint32_t)0x00020000) /* Port x Reset bit 1 */
+#define GPIO_BSHR_BR2                           ((uint32_t)0x00040000) /* Port x Reset bit 2 */
+#define GPIO_BSHR_BR3                           ((uint32_t)0x00080000) /* Port x Reset bit 3 */
+#define GPIO_BSHR_BR4                           ((uint32_t)0x00100000) /* Port x Reset bit 4 */
+#define GPIO_BSHR_BR5                           ((uint32_t)0x00200000) /* Port x Reset bit 5 */
+#define GPIO_BSHR_BR6                           ((uint32_t)0x00400000) /* Port x Reset bit 6 */
+#define GPIO_BSHR_BR7                           ((uint32_t)0x00800000) /* Port x Reset bit 7 */
+#define GPIO_BSHR_BR8                           ((uint32_t)0x01000000) /* Port x Reset bit 8 */
+#define GPIO_BSHR_BR9                           ((uint32_t)0x02000000) /* Port x Reset bit 9 */
+#define GPIO_BSHR_BR10                          ((uint32_t)0x04000000) /* Port x Reset bit 10 */
+#define GPIO_BSHR_BR11                          ((uint32_t)0x08000000) /* Port x Reset bit 11 */
+#define GPIO_BSHR_BR12                          ((uint32_t)0x10000000) /* Port x Reset bit 12 */
+#define GPIO_BSHR_BR13                          ((uint32_t)0x20000000) /* Port x Reset bit 13 */
+#define GPIO_BSHR_BR14                          ((uint32_t)0x40000000) /* Port x Reset bit 14 */
+#define GPIO_BSHR_BR15                          ((uint32_t)0x80000000) /* Port x Reset bit 15 */
+
+/*******************  Bit definition for GPIO_BCR register  *******************/
+#define GPIO_BCR_BR0                            ((uint16_t)0x0001) /* Port x Reset bit 0 */
+#define GPIO_BCR_BR1                            ((uint16_t)0x0002) /* Port x Reset bit 1 */
+#define GPIO_BCR_BR2                            ((uint16_t)0x0004) /* Port x Reset bit 2 */
+#define GPIO_BCR_BR3                            ((uint16_t)0x0008) /* Port x Reset bit 3 */
+#define GPIO_BCR_BR4                            ((uint16_t)0x0010) /* Port x Reset bit 4 */
+#define GPIO_BCR_BR5                            ((uint16_t)0x0020) /* Port x Reset bit 5 */
+#define GPIO_BCR_BR6                            ((uint16_t)0x0040) /* Port x Reset bit 6 */
+#define GPIO_BCR_BR7                            ((uint16_t)0x0080) /* Port x Reset bit 7 */
+#define GPIO_BCR_BR8                            ((uint16_t)0x0100) /* Port x Reset bit 8 */
+#define GPIO_BCR_BR9                            ((uint16_t)0x0200) /* Port x Reset bit 9 */
+#define GPIO_BCR_BR10                           ((uint16_t)0x0400) /* Port x Reset bit 10 */
+#define GPIO_BCR_BR11                           ((uint16_t)0x0800) /* Port x Reset bit 11 */
+#define GPIO_BCR_BR12                           ((uint16_t)0x1000) /* Port x Reset bit 12 */
+#define GPIO_BCR_BR13                           ((uint16_t)0x2000) /* Port x Reset bit 13 */
+#define GPIO_BCR_BR14                           ((uint16_t)0x4000) /* Port x Reset bit 14 */
+#define GPIO_BCR_BR15                           ((uint16_t)0x8000) /* Port x Reset bit 15 */
+
+/******************  Bit definition for GPIO_LCKR register  *******************/
+#define GPIO_LCK0                               ((uint32_t)0x00000001) /* Port x Lock bit 0 */
+#define GPIO_LCK1                               ((uint32_t)0x00000002) /* Port x Lock bit 1 */
+#define GPIO_LCK2                               ((uint32_t)0x00000004) /* Port x Lock bit 2 */
+#define GPIO_LCK3                               ((uint32_t)0x00000008) /* Port x Lock bit 3 */
+#define GPIO_LCK4                               ((uint32_t)0x00000010) /* Port x Lock bit 4 */
+#define GPIO_LCK5                               ((uint32_t)0x00000020) /* Port x Lock bit 5 */
+#define GPIO_LCK6                               ((uint32_t)0x00000040) /* Port x Lock bit 6 */
+#define GPIO_LCK7                               ((uint32_t)0x00000080) /* Port x Lock bit 7 */
+#define GPIO_LCK8                               ((uint32_t)0x00000100) /* Port x Lock bit 8 */
+#define GPIO_LCK9                               ((uint32_t)0x00000200) /* Port x Lock bit 9 */
+#define GPIO_LCK10                              ((uint32_t)0x00000400) /* Port x Lock bit 10 */
+#define GPIO_LCK11                              ((uint32_t)0x00000800) /* Port x Lock bit 11 */
+#define GPIO_LCK12                              ((uint32_t)0x00001000) /* Port x Lock bit 12 */
+#define GPIO_LCK13                              ((uint32_t)0x00002000) /* Port x Lock bit 13 */
+#define GPIO_LCK14                              ((uint32_t)0x00004000) /* Port x Lock bit 14 */
+#define GPIO_LCK15                              ((uint32_t)0x00008000) /* Port x Lock bit 15 */
+#define GPIO_LCKK                               ((uint32_t)0x00010000) /* Lock key */
+
+/******************  Bit definition for AFIO_ECR register  *******************/
+#define AFIO_ECR_PIN                            ((uint8_t)0x0F) /* PIN[3:0] bits (Pin selection) */
+#define AFIO_ECR_PIN_0                          ((uint8_t)0x01) /* Bit 0 */
+#define AFIO_ECR_PIN_1                          ((uint8_t)0x02) /* Bit 1 */
+#define AFIO_ECR_PIN_2                          ((uint8_t)0x04) /* Bit 2 */
+#define AFIO_ECR_PIN_3                          ((uint8_t)0x08) /* Bit 3 */
+
+#define AFIO_ECR_PIN_PX0                        ((uint8_t)0x00) /* Pin 0 selected */
+#define AFIO_ECR_PIN_PX1                        ((uint8_t)0x01) /* Pin 1 selected */
+#define AFIO_ECR_PIN_PX2                        ((uint8_t)0x02) /* Pin 2 selected */
+#define AFIO_ECR_PIN_PX3                        ((uint8_t)0x03) /* Pin 3 selected */
+#define AFIO_ECR_PIN_PX4                        ((uint8_t)0x04) /* Pin 4 selected */
+#define AFIO_ECR_PIN_PX5                        ((uint8_t)0x05) /* Pin 5 selected */
+#define AFIO_ECR_PIN_PX6                        ((uint8_t)0x06) /* Pin 6 selected */
+#define AFIO_ECR_PIN_PX7                        ((uint8_t)0x07) /* Pin 7 selected */
+#define AFIO_ECR_PIN_PX8                        ((uint8_t)0x08) /* Pin 8 selected */
+#define AFIO_ECR_PIN_PX9                        ((uint8_t)0x09) /* Pin 9 selected */
+#define AFIO_ECR_PIN_PX10                       ((uint8_t)0x0A) /* Pin 10 selected */
+#define AFIO_ECR_PIN_PX11                       ((uint8_t)0x0B) /* Pin 11 selected */
+#define AFIO_ECR_PIN_PX12                       ((uint8_t)0x0C) /* Pin 12 selected */
+#define AFIO_ECR_PIN_PX13                       ((uint8_t)0x0D) /* Pin 13 selected */
+#define AFIO_ECR_PIN_PX14                       ((uint8_t)0x0E) /* Pin 14 selected */
+#define AFIO_ECR_PIN_PX15                       ((uint8_t)0x0F) /* Pin 15 selected */
+
+#define AFIO_ECR_PORT                           ((uint8_t)0x70) /* PORT[2:0] bits (Port selection) */
+#define AFIO_ECR_PORT_0                         ((uint8_t)0x10) /* Bit 0 */
+#define AFIO_ECR_PORT_1                         ((uint8_t)0x20) /* Bit 1 */
+#define AFIO_ECR_PORT_2                         ((uint8_t)0x40) /* Bit 2 */
+
+#define AFIO_ECR_PORT_PA                        ((uint8_t)0x00) /* Port A selected */
+#define AFIO_ECR_PORT_PB                        ((uint8_t)0x10) /* Port B selected */
+#define AFIO_ECR_PORT_PC                        ((uint8_t)0x20) /* Port C selected */
+#define AFIO_ECR_PORT_PD                        ((uint8_t)0x30) /* Port D selected */
+#define AFIO_ECR_PORT_PE                        ((uint8_t)0x40) /* Port E selected */
+
+#define AFIO_ECR_EVOE                           ((uint8_t)0x80) /* Event Output Enable */
+
+/******************  Bit definition for AFIO_PCFR1register  *******************/
+#define AFIO_PCFR1_SPI1_REMAP                   ((uint32_t)0x00000001) /* SPI1 remapping */
+#define AFIO_PCFR1_I2C1_REMAP                   ((uint32_t)0x00000002) /* I2C1 remapping */
+#define AFIO_PCFR1_USART1_REMAP                 ((uint32_t)0x00000004) /* USART1 remapping */
+#define AFIO_PCFR1_USART2_REMAP                 ((uint32_t)0x00000008) /* USART2 remapping */
+
+#define AFIO_PCFR1_USART3_REMAP                 ((uint32_t)0x00000030) /* USART3_REMAP[1:0] bits (USART3 remapping) */
+#define AFIO_PCFR1_USART3_REMAP_0               ((uint32_t)0x00000010) /* Bit 0 */
+#define AFIO_PCFR1_USART3_REMAP_1               ((uint32_t)0x00000020) /* Bit 1 */
+
+#define AFIO_PCFR1_USART3_REMAP_NOREMAP         ((uint32_t)0x00000000) /* No remap (TX/PB10, RX/PB11, CK/PB12, CTS/PB13, RTS/PB14) */
+#define AFIO_PCFR1_USART3_REMAP_PARTIALREMAP    ((uint32_t)0x00000010) /* Partial remap (TX/PC10, RX/PC11, CK/PC12, CTS/PB13, RTS/PB14) */
+#define AFIO_PCFR1_USART3_REMAP_FULLREMAP       ((uint32_t)0x00000030) /* Full remap (TX/PD8, RX/PD9, CK/PD10, CTS/PD11, RTS/PD12) */
+
+#define AFIO_PCFR1_TIM1_REMAP                   ((uint32_t)0x000000C0) /* TIM1_REMAP[1:0] bits (TIM1 remapping) */
+#define AFIO_PCFR1_TIM1_REMAP_0                 ((uint32_t)0x00000040) /* Bit 0 */
+#define AFIO_PCFR1_TIM1_REMAP_1                 ((uint32_t)0x00000080) /* Bit 1 */
+
+#define AFIO_PCFR1_TIM1_REMAP_NOREMAP           ((uint32_t)0x00000000) /* No remap (ETR/PA12, CH1/PA8, CH2/PA9, CH3/PA10, CH4/PA11, BKIN/PB12, CH1N/PB13, CH2N/PB14, CH3N/PB15) */
+#define AFIO_PCFR1_TIM1_REMAP_PARTIALREMAP      ((uint32_t)0x00000040) /* Partial remap (ETR/PA12, CH1/PA8, CH2/PA9, CH3/PA10, CH4/PA11, BKIN/PA6, CH1N/PA7, CH2N/PB0, CH3N/PB1) */
+#define AFIO_PCFR1_TIM1_REMAP_FULLREMAP         ((uint32_t)0x000000C0) /* Full remap (ETR/PE7, CH1/PE9, CH2/PE11, CH3/PE13, CH4/PE14, BKIN/PE15, CH1N/PE8, CH2N/PE10, CH3N/PE12) */
+
+#define AFIO_PCFR1_TIM2_REMAP                   ((uint32_t)0x00000300) /* TIM2_REMAP[1:0] bits (TIM2 remapping) */
+#define AFIO_PCFR1_TIM2_REMAP_0                 ((uint32_t)0x00000100) /* Bit 0 */
+#define AFIO_PCFR1_TIM2_REMAP_1                 ((uint32_t)0x00000200) /* Bit 1 */
+
+#define AFIO_PCFR1_TIM2_REMAP_NOREMAP           ((uint32_t)0x00000000) /* No remap (CH1/ETR/PA0, CH2/PA1, CH3/PA2, CH4/PA3) */
+#define AFIO_PCFR1_TIM2_REMAP_PARTIALREMAP1     ((uint32_t)0x00000100) /* Partial remap (CH1/ETR/PA15, CH2/PB3, CH3/PA2, CH4/PA3) */
+#define AFIO_PCFR1_TIM2_REMAP_PARTIALREMAP2     ((uint32_t)0x00000200) /* Partial remap (CH1/ETR/PA0, CH2/PA1, CH3/PB10, CH4/PB11) */
+#define AFIO_PCFR1_TIM2_REMAP_FULLREMAP         ((uint32_t)0x00000300) /* Full remap (CH1/ETR/PA15, CH2/PB3, CH3/PB10, CH4/PB11) */
+
+#define AFIO_PCFR1_TIM3_REMAP                   ((uint32_t)0x00000C00) /* TIM3_REMAP[1:0] bits (TIM3 remapping) */
+#define AFIO_PCFR1_TIM3_REMAP_0                 ((uint32_t)0x00000400) /* Bit 0 */
+#define AFIO_PCFR1_TIM3_REMAP_1                 ((uint32_t)0x00000800) /* Bit 1 */
+
+#define AFIO_PCFR1_TIM3_REMAP_NOREMAP           ((uint32_t)0x00000000) /* No remap (CH1/PA6, CH2/PA7, CH3/PB0, CH4/PB1) */
+#define AFIO_PCFR1_TIM3_REMAP_PARTIALREMAP      ((uint32_t)0x00000800) /* Partial remap (CH1/PB4, CH2/PB5, CH3/PB0, CH4/PB1) */
+#define AFIO_PCFR1_TIM3_REMAP_FULLREMAP         ((uint32_t)0x00000C00) /* Full remap (CH1/PC6, CH2/PC7, CH3/PC8, CH4/PC9) */
+
+#define AFIO_PCFR1_TIM4_REMAP                   ((uint32_t)0x00001000) /* TIM4_REMAP bit (TIM4 remapping) */
+
+#define AFIO_PCFR1_CAN_REMAP                    ((uint32_t)0x00006000) /* CAN_REMAP[1:0] bits (CAN Alternate function remapping) */
+#define AFIO_PCFR1_CAN_REMAP_0                  ((uint32_t)0x00002000) /* Bit 0 */
+#define AFIO_PCFR1_CAN_REMAP_1                  ((uint32_t)0x00004000) /* Bit 1 */
+
+#define AFIO_PCFR1_CAN_REMAP_REMAP1             ((uint32_t)0x00000000) /* CANRX mapped to PA11, CANTX mapped to PA12 */
+#define AFIO_PCFR1_CAN_REMAP_REMAP2             ((uint32_t)0x00004000) /* CANRX mapped to PB8, CANTX mapped to PB9 */
+#define AFIO_PCFR1_CAN_REMAP_REMAP3             ((uint32_t)0x00006000) /* CANRX mapped to PD0, CANTX mapped to PD1 */
+
+#define AFIO_PCFR1_PD01_REMAP                   ((uint32_t)0x00008000) /* Port D0/Port D1 mapping on OSC_IN/OSC_OUT */
+#define AFIO_PCFR1_TIM5CH4_IREMAP               ((uint32_t)0x00010000) /* TIM5 Channel4 Internal Remap */
+#define AFIO_PCFR1_ADC1_ETRGINJ_REMAP           ((uint32_t)0x00020000) /* ADC 1 External Trigger Injected Conversion remapping */
+#define AFIO_PCFR1_ADC1_ETRGREG_REMAP           ((uint32_t)0x00040000) /* ADC 1 External Trigger Regular Conversion remapping */
+#define AFIO_PCFR1_ADC2_ETRGINJ_REMAP           ((uint32_t)0x00080000) /* ADC 2 External Trigger Injected Conversion remapping */
+#define AFIO_PCFR1_ADC2_ETRGREG_REMAP           ((uint32_t)0x00100000) /* ADC 2 External Trigger Regular Conversion remapping */
+
+#define AFIO_PCFR1_SWJ_CFG                      ((uint32_t)0x07000000) /* SWJ_CFG[2:0] bits (Serial Wire JTAG configuration) */
+#define AFIO_PCFR1_SWJ_CFG_0                    ((uint32_t)0x01000000) /* Bit 0 */
+#define AFIO_PCFR1_SWJ_CFG_1                    ((uint32_t)0x02000000) /* Bit 1 */
+#define AFIO_PCFR1_SWJ_CFG_2                    ((uint32_t)0x04000000) /* Bit 2 */
+
+#define AFIO_PCFR1_SWJ_CFG_RESET                ((uint32_t)0x00000000) /* Full SWJ (JTAG-DP + SW-DP) : Reset State */
+#define AFIO_PCFR1_SWJ_CFG_NOJNTRST             ((uint32_t)0x01000000) /* Full SWJ (JTAG-DP + SW-DP) but without JNTRST */
+#define AFIO_PCFR1_SWJ_CFG_JTAGDISABLE          ((uint32_t)0x02000000) /* JTAG-DP Disabled and SW-DP Enabled */
+#define AFIO_PCFR1_SWJ_CFG_DISABLE              ((uint32_t)0x04000000) /* JTAG-DP Disabled and SW-DP Disabled */
+
+/*****************  Bit definition for AFIO_EXTICR1 register  *****************/
+#define AFIO_EXTICR1_EXTI0                      ((uint16_t)0x000F) /* EXTI 0 configuration */
+#define AFIO_EXTICR1_EXTI1                      ((uint16_t)0x00F0) /* EXTI 1 configuration */
+#define AFIO_EXTICR1_EXTI2                      ((uint16_t)0x0F00) /* EXTI 2 configuration */
+#define AFIO_EXTICR1_EXTI3                      ((uint16_t)0xF000) /* EXTI 3 configuration */
+
+#define AFIO_EXTICR1_EXTI0_PA                   ((uint16_t)0x0000) /* PA[0] pin */
+#define AFIO_EXTICR1_EXTI0_PB                   ((uint16_t)0x0001) /* PB[0] pin */
+#define AFIO_EXTICR1_EXTI0_PC                   ((uint16_t)0x0002) /* PC[0] pin */
+#define AFIO_EXTICR1_EXTI0_PD                   ((uint16_t)0x0003) /* PD[0] pin */
+#define AFIO_EXTICR1_EXTI0_PE                   ((uint16_t)0x0004) /* PE[0] pin */
+#define AFIO_EXTICR1_EXTI0_PF                   ((uint16_t)0x0005) /* PF[0] pin */
+#define AFIO_EXTICR1_EXTI0_PG                   ((uint16_t)0x0006) /* PG[0] pin */
+
+#define AFIO_EXTICR1_EXTI1_PA                   ((uint16_t)0x0000) /* PA[1] pin */
+#define AFIO_EXTICR1_EXTI1_PB                   ((uint16_t)0x0010) /* PB[1] pin */
+#define AFIO_EXTICR1_EXTI1_PC                   ((uint16_t)0x0020) /* PC[1] pin */
+#define AFIO_EXTICR1_EXTI1_PD                   ((uint16_t)0x0030) /* PD[1] pin */
+#define AFIO_EXTICR1_EXTI1_PE                   ((uint16_t)0x0040) /* PE[1] pin */
+#define AFIO_EXTICR1_EXTI1_PF                   ((uint16_t)0x0050) /* PF[1] pin */
+#define AFIO_EXTICR1_EXTI1_PG                   ((uint16_t)0x0060) /* PG[1] pin */
+
+#define AFIO_EXTICR1_EXTI2_PA                   ((uint16_t)0x0000) /* PA[2] pin */
+#define AFIO_EXTICR1_EXTI2_PB                   ((uint16_t)0x0100) /* PB[2] pin */
+#define AFIO_EXTICR1_EXTI2_PC                   ((uint16_t)0x0200) /* PC[2] pin */
+#define AFIO_EXTICR1_EXTI2_PD                   ((uint16_t)0x0300) /* PD[2] pin */
+#define AFIO_EXTICR1_EXTI2_PE                   ((uint16_t)0x0400) /* PE[2] pin */
+#define AFIO_EXTICR1_EXTI2_PF                   ((uint16_t)0x0500) /* PF[2] pin */
+#define AFIO_EXTICR1_EXTI2_PG                   ((uint16_t)0x0600) /* PG[2] pin */
+
+#define AFIO_EXTICR1_EXTI3_PA                   ((uint16_t)0x0000) /* PA[3] pin */
+#define AFIO_EXTICR1_EXTI3_PB                   ((uint16_t)0x1000) /* PB[3] pin */
+#define AFIO_EXTICR1_EXTI3_PC                   ((uint16_t)0x2000) /* PC[3] pin */
+#define AFIO_EXTICR1_EXTI3_PD                   ((uint16_t)0x3000) /* PD[3] pin */
+#define AFIO_EXTICR1_EXTI3_PE                   ((uint16_t)0x4000) /* PE[3] pin */
+#define AFIO_EXTICR1_EXTI3_PF                   ((uint16_t)0x5000) /* PF[3] pin */
+#define AFIO_EXTICR1_EXTI3_PG                   ((uint16_t)0x6000) /* PG[3] pin */
+
+/*****************  Bit definition for AFIO_EXTICR2 register  *****************/
+#define AFIO_EXTICR2_EXTI4                      ((uint16_t)0x000F) /* EXTI 4 configuration */
+#define AFIO_EXTICR2_EXTI5                      ((uint16_t)0x00F0) /* EXTI 5 configuration */
+#define AFIO_EXTICR2_EXTI6                      ((uint16_t)0x0F00) /* EXTI 6 configuration */
+#define AFIO_EXTICR2_EXTI7                      ((uint16_t)0xF000) /* EXTI 7 configuration */
+
+#define AFIO_EXTICR2_EXTI4_PA                   ((uint16_t)0x0000) /* PA[4] pin */
+#define AFIO_EXTICR2_EXTI4_PB                   ((uint16_t)0x0001) /* PB[4] pin */
+#define AFIO_EXTICR2_EXTI4_PC                   ((uint16_t)0x0002) /* PC[4] pin */
+#define AFIO_EXTICR2_EXTI4_PD                   ((uint16_t)0x0003) /* PD[4] pin */
+#define AFIO_EXTICR2_EXTI4_PE                   ((uint16_t)0x0004) /* PE[4] pin */
+#define AFIO_EXTICR2_EXTI4_PF                   ((uint16_t)0x0005) /* PF[4] pin */
+#define AFIO_EXTICR2_EXTI4_PG                   ((uint16_t)0x0006) /* PG[4] pin */
+
+#define AFIO_EXTICR2_EXTI5_PA                   ((uint16_t)0x0000) /* PA[5] pin */
+#define AFIO_EXTICR2_EXTI5_PB                   ((uint16_t)0x0010) /* PB[5] pin */
+#define AFIO_EXTICR2_EXTI5_PC                   ((uint16_t)0x0020) /* PC[5] pin */
+#define AFIO_EXTICR2_EXTI5_PD                   ((uint16_t)0x0030) /* PD[5] pin */
+#define AFIO_EXTICR2_EXTI5_PE                   ((uint16_t)0x0040) /* PE[5] pin */
+#define AFIO_EXTICR2_EXTI5_PF                   ((uint16_t)0x0050) /* PF[5] pin */
+#define AFIO_EXTICR2_EXTI5_PG                   ((uint16_t)0x0060) /* PG[5] pin */
+
+#define AFIO_EXTICR2_EXTI6_PA                   ((uint16_t)0x0000) /* PA[6] pin */
+#define AFIO_EXTICR2_EXTI6_PB                   ((uint16_t)0x0100) /* PB[6] pin */
+#define AFIO_EXTICR2_EXTI6_PC                   ((uint16_t)0x0200) /* PC[6] pin */
+#define AFIO_EXTICR2_EXTI6_PD                   ((uint16_t)0x0300) /* PD[6] pin */
+#define AFIO_EXTICR2_EXTI6_PE                   ((uint16_t)0x0400) /* PE[6] pin */
+#define AFIO_EXTICR2_EXTI6_PF                   ((uint16_t)0x0500) /* PF[6] pin */
+#define AFIO_EXTICR2_EXTI6_PG                   ((uint16_t)0x0600) /* PG[6] pin */
+
+#define AFIO_EXTICR2_EXTI7_PA                   ((uint16_t)0x0000) /* PA[7] pin */
+#define AFIO_EXTICR2_EXTI7_PB                   ((uint16_t)0x1000) /* PB[7] pin */
+#define AFIO_EXTICR2_EXTI7_PC                   ((uint16_t)0x2000) /* PC[7] pin */
+#define AFIO_EXTICR2_EXTI7_PD                   ((uint16_t)0x3000) /* PD[7] pin */
+#define AFIO_EXTICR2_EXTI7_PE                   ((uint16_t)0x4000) /* PE[7] pin */
+#define AFIO_EXTICR2_EXTI7_PF                   ((uint16_t)0x5000) /* PF[7] pin */
+#define AFIO_EXTICR2_EXTI7_PG                   ((uint16_t)0x6000) /* PG[7] pin */
+
+/*****************  Bit definition for AFIO_EXTICR3 register  *****************/
+#define AFIO_EXTICR3_EXTI8                      ((uint16_t)0x000F) /* EXTI 8 configuration */
+#define AFIO_EXTICR3_EXTI9                      ((uint16_t)0x00F0) /* EXTI 9 configuration */
+#define AFIO_EXTICR3_EXTI10                     ((uint16_t)0x0F00) /* EXTI 10 configuration */
+#define AFIO_EXTICR3_EXTI11                     ((uint16_t)0xF000) /* EXTI 11 configuration */
+
+#define AFIO_EXTICR3_EXTI8_PA                   ((uint16_t)0x0000) /* PA[8] pin */
+#define AFIO_EXTICR3_EXTI8_PB                   ((uint16_t)0x0001) /* PB[8] pin */
+#define AFIO_EXTICR3_EXTI8_PC                   ((uint16_t)0x0002) /* PC[8] pin */
+#define AFIO_EXTICR3_EXTI8_PD                   ((uint16_t)0x0003) /* PD[8] pin */
+#define AFIO_EXTICR3_EXTI8_PE                   ((uint16_t)0x0004) /* PE[8] pin */
+#define AFIO_EXTICR3_EXTI8_PF                   ((uint16_t)0x0005) /* PF[8] pin */
+#define AFIO_EXTICR3_EXTI8_PG                   ((uint16_t)0x0006) /* PG[8] pin */
+
+#define AFIO_EXTICR3_EXTI9_PA                   ((uint16_t)0x0000) /* PA[9] pin */
+#define AFIO_EXTICR3_EXTI9_PB                   ((uint16_t)0x0010) /* PB[9] pin */
+#define AFIO_EXTICR3_EXTI9_PC                   ((uint16_t)0x0020) /* PC[9] pin */
+#define AFIO_EXTICR3_EXTI9_PD                   ((uint16_t)0x0030) /* PD[9] pin */
+#define AFIO_EXTICR3_EXTI9_PE                   ((uint16_t)0x0040) /* PE[9] pin */
+#define AFIO_EXTICR3_EXTI9_PF                   ((uint16_t)0x0050) /* PF[9] pin */
+#define AFIO_EXTICR3_EXTI9_PG                   ((uint16_t)0x0060) /* PG[9] pin */
+
+#define AFIO_EXTICR3_EXTI10_PA                  ((uint16_t)0x0000) /* PA[10] pin */
+#define AFIO_EXTICR3_EXTI10_PB                  ((uint16_t)0x0100) /* PB[10] pin */
+#define AFIO_EXTICR3_EXTI10_PC                  ((uint16_t)0x0200) /* PC[10] pin */
+#define AFIO_EXTICR3_EXTI10_PD                  ((uint16_t)0x0300) /* PD[10] pin */
+#define AFIO_EXTICR3_EXTI10_PE                  ((uint16_t)0x0400) /* PE[10] pin */
+#define AFIO_EXTICR3_EXTI10_PF                  ((uint16_t)0x0500) /* PF[10] pin */
+#define AFIO_EXTICR3_EXTI10_PG                  ((uint16_t)0x0600) /* PG[10] pin */
+
+#define AFIO_EXTICR3_EXTI11_PA                  ((uint16_t)0x0000) /* PA[11] pin */
+#define AFIO_EXTICR3_EXTI11_PB                  ((uint16_t)0x1000) /* PB[11] pin */
+#define AFIO_EXTICR3_EXTI11_PC                  ((uint16_t)0x2000) /* PC[11] pin */
+#define AFIO_EXTICR3_EXTI11_PD                  ((uint16_t)0x3000) /* PD[11] pin */
+#define AFIO_EXTICR3_EXTI11_PE                  ((uint16_t)0x4000) /* PE[11] pin */
+#define AFIO_EXTICR3_EXTI11_PF                  ((uint16_t)0x5000) /* PF[11] pin */
+#define AFIO_EXTICR3_EXTI11_PG                  ((uint16_t)0x6000) /* PG[11] pin */
+
+/*****************  Bit definition for AFIO_EXTICR4 register  *****************/
+#define AFIO_EXTICR4_EXTI12                     ((uint16_t)0x000F) /* EXTI 12 configuration */
+#define AFIO_EXTICR4_EXTI13                     ((uint16_t)0x00F0) /* EXTI 13 configuration */
+#define AFIO_EXTICR4_EXTI14                     ((uint16_t)0x0F00) /* EXTI 14 configuration */
+#define AFIO_EXTICR4_EXTI15                     ((uint16_t)0xF000) /* EXTI 15 configuration */
+
+#define AFIO_EXTICR4_EXTI12_PA                  ((uint16_t)0x0000) /* PA[12] pin */
+#define AFIO_EXTICR4_EXTI12_PB                  ((uint16_t)0x0001) /* PB[12] pin */
+#define AFIO_EXTICR4_EXTI12_PC                  ((uint16_t)0x0002) /* PC[12] pin */
+#define AFIO_EXTICR4_EXTI12_PD                  ((uint16_t)0x0003) /* PD[12] pin */
+#define AFIO_EXTICR4_EXTI12_PE                  ((uint16_t)0x0004) /* PE[12] pin */
+#define AFIO_EXTICR4_EXTI12_PF                  ((uint16_t)0x0005) /* PF[12] pin */
+#define AFIO_EXTICR4_EXTI12_PG                  ((uint16_t)0x0006) /* PG[12] pin */
+
+#define AFIO_EXTICR4_EXTI13_PA                  ((uint16_t)0x0000) /* PA[13] pin */
+#define AFIO_EXTICR4_EXTI13_PB                  ((uint16_t)0x0010) /* PB[13] pin */
+#define AFIO_EXTICR4_EXTI13_PC                  ((uint16_t)0x0020) /* PC[13] pin */
+#define AFIO_EXTICR4_EXTI13_PD                  ((uint16_t)0x0030) /* PD[13] pin */
+#define AFIO_EXTICR4_EXTI13_PE                  ((uint16_t)0x0040) /* PE[13] pin */
+#define AFIO_EXTICR4_EXTI13_PF                  ((uint16_t)0x0050) /* PF[13] pin */
+#define AFIO_EXTICR4_EXTI13_PG                  ((uint16_t)0x0060) /* PG[13] pin */
+
+#define AFIO_EXTICR4_EXTI14_PA                  ((uint16_t)0x0000) /* PA[14] pin */
+#define AFIO_EXTICR4_EXTI14_PB                  ((uint16_t)0x0100) /* PB[14] pin */
+#define AFIO_EXTICR4_EXTI14_PC                  ((uint16_t)0x0200) /* PC[14] pin */
+#define AFIO_EXTICR4_EXTI14_PD                  ((uint16_t)0x0300) /* PD[14] pin */
+#define AFIO_EXTICR4_EXTI14_PE                  ((uint16_t)0x0400) /* PE[14] pin */
+#define AFIO_EXTICR4_EXTI14_PF                  ((uint16_t)0x0500) /* PF[14] pin */
+#define AFIO_EXTICR4_EXTI14_PG                  ((uint16_t)0x0600) /* PG[14] pin */
+
+#define AFIO_EXTICR4_EXTI15_PA                  ((uint16_t)0x0000) /* PA[15] pin */
+#define AFIO_EXTICR4_EXTI15_PB                  ((uint16_t)0x1000) /* PB[15] pin */
+#define AFIO_EXTICR4_EXTI15_PC                  ((uint16_t)0x2000) /* PC[15] pin */
+#define AFIO_EXTICR4_EXTI15_PD                  ((uint16_t)0x3000) /* PD[15] pin */
+#define AFIO_EXTICR4_EXTI15_PE                  ((uint16_t)0x4000) /* PE[15] pin */
+#define AFIO_EXTICR4_EXTI15_PF                  ((uint16_t)0x5000) /* PF[15] pin */
+#define AFIO_EXTICR4_EXTI15_PG                  ((uint16_t)0x6000) /* PG[15] pin */
+
+/******************************************************************************/
+/*                           Independent WATCHDOG                             */
+/******************************************************************************/
+
+/*******************  Bit definition for IWDG_CTLR register  ********************/
+#define IWDG_KEY                                ((uint16_t)0xFFFF) /* Key value (write only, read 0000h) */
+
+/*******************  Bit definition for IWDG_PSCR register  ********************/
+#define IWDG_PR                                 ((uint8_t)0x07) /* PR[2:0] (Prescaler divider) */
+#define IWDG_PR_0                               ((uint8_t)0x01) /* Bit 0 */
+#define IWDG_PR_1                               ((uint8_t)0x02) /* Bit 1 */
+#define IWDG_PR_2                               ((uint8_t)0x04) /* Bit 2 */
+
+/*******************  Bit definition for IWDG_RLDR register  *******************/
+#define IWDG_RL                                 ((uint16_t)0x0FFF) /* Watchdog counter reload value */
+
+/*******************  Bit definition for IWDG_STATR register  ********************/
+#define IWDG_PVU                                ((uint8_t)0x01) /* Watchdog prescaler value update */
+#define IWDG_RVU                                ((uint8_t)0x02) /* Watchdog counter reload value update */
+
+/******************************************************************************/
+/*                      Inter-integrated Circuit Interface                    */
+/******************************************************************************/
+
+/*******************  Bit definition for I2C_CTLR1 register  ********************/
+#define I2C_CTLR1_PE                            ((uint16_t)0x0001) /* Peripheral Enable */
+#define I2C_CTLR1_SMBUS                         ((uint16_t)0x0002) /* SMBus Mode */
+#define I2C_CTLR1_SMBTYPE                       ((uint16_t)0x0008) /* SMBus Type */
+#define I2C_CTLR1_ENARP                         ((uint16_t)0x0010) /* ARP Enable */
+#define I2C_CTLR1_ENPEC                         ((uint16_t)0x0020) /* PEC Enable */
+#define I2C_CTLR1_ENGC                          ((uint16_t)0x0040) /* General Call Enable */
+#define I2C_CTLR1_NOSTRETCH                     ((uint16_t)0x0080) /* Clock Stretching Disable (Slave mode) */
+#define I2C_CTLR1_START                         ((uint16_t)0x0100) /* Start Generation */
+#define I2C_CTLR1_STOP                          ((uint16_t)0x0200) /* Stop Generation */
+#define I2C_CTLR1_ACK                           ((uint16_t)0x0400) /* Acknowledge Enable */
+#define I2C_CTLR1_POS                           ((uint16_t)0x0800) /* Acknowledge/PEC Position (for data reception) */
+#define I2C_CTLR1_PEC                           ((uint16_t)0x1000) /* Packet Error Checking */
+#define I2C_CTLR1_ALERT                         ((uint16_t)0x2000) /* SMBus Alert */
+#define I2C_CTLR1_SWRST                         ((uint16_t)0x8000) /* Software Reset */
+
+/*******************  Bit definition for I2C_CTLR2 register  ********************/
+#define I2C_CTLR2_FREQ                          ((uint16_t)0x003F) /* FREQ[5:0] bits (Peripheral Clock Frequency) */
+#define I2C_CTLR2_FREQ_0                        ((uint16_t)0x0001) /* Bit 0 */
+#define I2C_CTLR2_FREQ_1                        ((uint16_t)0x0002) /* Bit 1 */
+#define I2C_CTLR2_FREQ_2                        ((uint16_t)0x0004) /* Bit 2 */
+#define I2C_CTLR2_FREQ_3                        ((uint16_t)0x0008) /* Bit 3 */
+#define I2C_CTLR2_FREQ_4                        ((uint16_t)0x0010) /* Bit 4 */
+#define I2C_CTLR2_FREQ_5                        ((uint16_t)0x0020) /* Bit 5 */
+
+#define I2C_CTLR2_ITERREN                       ((uint16_t)0x0100) /* Error Interrupt Enable */
+#define I2C_CTLR2_ITEVTEN                       ((uint16_t)0x0200) /* Event Interrupt Enable */
+#define I2C_CTLR2_ITBUFEN                       ((uint16_t)0x0400) /* Buffer Interrupt Enable */
+#define I2C_CTLR2_DMAEN                         ((uint16_t)0x0800) /* DMA Requests Enable */
+#define I2C_CTLR2_LAST                          ((uint16_t)0x1000) /* DMA Last Transfer */
+
+/*******************  Bit definition for I2C_OADDR1 register  *******************/
+#define I2C_OADDR1_ADD1_7                       ((uint16_t)0x00FE) /* Interface Address */
+#define I2C_OADDR1_ADD8_9                       ((uint16_t)0x0300) /* Interface Address */
+
+#define I2C_OADDR1_ADD0                         ((uint16_t)0x0001) /* Bit 0 */
+#define I2C_OADDR1_ADD1                         ((uint16_t)0x0002) /* Bit 1 */
+#define I2C_OADDR1_ADD2                         ((uint16_t)0x0004) /* Bit 2 */
+#define I2C_OADDR1_ADD3                         ((uint16_t)0x0008) /* Bit 3 */
+#define I2C_OADDR1_ADD4                         ((uint16_t)0x0010) /* Bit 4 */
+#define I2C_OADDR1_ADD5                         ((uint16_t)0x0020) /* Bit 5 */
+#define I2C_OADDR1_ADD6                         ((uint16_t)0x0040) /* Bit 6 */
+#define I2C_OADDR1_ADD7                         ((uint16_t)0x0080) /* Bit 7 */
+#define I2C_OADDR1_ADD8                         ((uint16_t)0x0100) /* Bit 8 */
+#define I2C_OADDR1_ADD9                         ((uint16_t)0x0200) /* Bit 9 */
+
+#define I2C_OADDR1_ADDMODE                      ((uint16_t)0x8000) /* Addressing Mode (Slave mode) */
+
+/*******************  Bit definition for I2C_OADDR2 register  *******************/
+#define I2C_OADDR2_ENDUAL                       ((uint8_t)0x01) /* Dual addressing mode enable */
+#define I2C_OADDR2_ADD2                         ((uint8_t)0xFE) /* Interface address */
+
+/********************  Bit definition for I2C_DATAR register  ********************/
+#define I2C_DR_DATAR                            ((uint8_t)0xFF) /* 8-bit Data Register */
+
+/*******************  Bit definition for I2C_STAR1 register  ********************/
+#define I2C_STAR1_SB                            ((uint16_t)0x0001) /* Start Bit (Master mode) */
+#define I2C_STAR1_ADDR                          ((uint16_t)0x0002) /* Address sent (master mode)/matched (slave mode) */
+#define I2C_STAR1_BTF                           ((uint16_t)0x0004) /* Byte Transfer Finished */
+#define I2C_STAR1_ADD10                         ((uint16_t)0x0008) /* 10-bit header sent (Master mode) */
+#define I2C_STAR1_STOPF                         ((uint16_t)0x0010) /* Stop detection (Slave mode) */
+#define I2C_STAR1_RXNE                          ((uint16_t)0x0040) /* Data Register not Empty (receivers) */
+#define I2C_STAR1_TXE                           ((uint16_t)0x0080) /* Data Register Empty (transmitters) */
+#define I2C_STAR1_BERR                          ((uint16_t)0x0100) /* Bus Error */
+#define I2C_STAR1_ARLO                          ((uint16_t)0x0200) /* Arbitration Lost (master mode) */
+#define I2C_STAR1_AF                            ((uint16_t)0x0400) /* Acknowledge Failure */
+#define I2C_STAR1_OVR                           ((uint16_t)0x0800) /* Overrun/Underrun */
+#define I2C_STAR1_PECERR                        ((uint16_t)0x1000) /* PEC Error in reception */
+#define I2C_STAR1_TIMEOUT                       ((uint16_t)0x4000) /* Timeout or Tlow Error */
+#define I2C_STAR1_SMBALERT                      ((uint16_t)0x8000) /* SMBus Alert */
+
+/*******************  Bit definition for I2C_STAR2 register  ********************/
+#define I2C_STAR2_MSL                           ((uint16_t)0x0001) /* Master/Slave */
+#define I2C_STAR2_BUSY                          ((uint16_t)0x0002) /* Bus Busy */
+#define I2C_STAR2_TRA                           ((uint16_t)0x0004) /* Transmitter/Receiver */
+#define I2C_STAR2_GENCALL                       ((uint16_t)0x0010) /* General Call Address (Slave mode) */
+#define I2C_STAR2_SMBDEFAULT                    ((uint16_t)0x0020) /* SMBus Device Default Address (Slave mode) */
+#define I2C_STAR2_SMBHOST                       ((uint16_t)0x0040) /* SMBus Host Header (Slave mode) */
+#define I2C_STAR2_DUALF                         ((uint16_t)0x0080) /* Dual Flag (Slave mode) */
+#define I2C_STAR2_PEC                           ((uint16_t)0xFF00) /* Packet Error Checking Register */
+
+/*******************  Bit definition for I2C_CKCFGR register  ********************/
+#define I2C_CKCFGR_CCR                          ((uint16_t)0x0FFF) /* Clock Control Register in Fast/Standard mode (Master mode) */
+#define I2C_CKCFGR_DUTY                         ((uint16_t)0x4000) /* Fast Mode Duty Cycle */
+#define I2C_CKCFGR_FS                           ((uint16_t)0x8000) /* I2C Master Mode Selection */
+
+/******************  Bit definition for I2C_RTR register  *******************/
+#define I2C_RTR_TRISE                           ((uint8_t)0x3F) /* Maximum Rise Time in Fast/Standard mode (Master mode) */
+
+/******************************************************************************/
+/*                             Power Control                                  */
+/******************************************************************************/
+
+/********************  Bit definition for PWR_CTLR register  ********************/
+#define PWR_CTLR_LPDS                           ((uint16_t)0x0001) /* Low-Power Deepsleep */
+#define PWR_CTLR_PDDS                           ((uint16_t)0x0002) /* Power Down Deepsleep */
+#define PWR_CTLR_CWUF                           ((uint16_t)0x0004) /* Clear Wakeup Flag */
+#define PWR_CTLR_CSBF                           ((uint16_t)0x0008) /* Clear Standby Flag */
+#define PWR_CTLR_PVDE                           ((uint16_t)0x0010) /* Power Voltage Detector Enable */
+
+#define PWR_CTLR_PLS                            ((uint16_t)0x00E0) /* PLS[2:0] bits (PVD Level Selection) */
+#define PWR_CTLR_PLS_0                          ((uint16_t)0x0020) /* Bit 0 */
+#define PWR_CTLR_PLS_1                          ((uint16_t)0x0040) /* Bit 1 */
+#define PWR_CTLR_PLS_2                          ((uint16_t)0x0080) /* Bit 2 */
+
+#define PWR_CTLR_PLS_2V2                        ((uint16_t)0x0000) /* PVD level 2.2V */
+#define PWR_CTLR_PLS_2V3                        ((uint16_t)0x0020) /* PVD level 2.3V */
+#define PWR_CTLR_PLS_2V4                        ((uint16_t)0x0040) /* PVD level 2.4V */
+#define PWR_CTLR_PLS_2V5                        ((uint16_t)0x0060) /* PVD level 2.5V */
+#define PWR_CTLR_PLS_2V6                        ((uint16_t)0x0080) /* PVD level 2.6V */
+#define PWR_CTLR_PLS_2V7                        ((uint16_t)0x00A0) /* PVD level 2.7V */
+#define PWR_CTLR_PLS_2V8                        ((uint16_t)0x00C0) /* PVD level 2.8V */
+#define PWR_CTLR_PLS_2V9                        ((uint16_t)0x00E0) /* PVD level 2.9V */
+
+#define PWR_CTLR_DBP                            ((uint16_t)0x0100) /* Disable Backup Domain write protection */
+
+/*******************  Bit definition for PWR_CSR register  ********************/
+#define PWR_CSR_WUF                             ((uint16_t)0x0001) /* Wakeup Flag */
+#define PWR_CSR_SBF                             ((uint16_t)0x0002) /* Standby Flag */
+#define PWR_CSR_PVDO                            ((uint16_t)0x0004) /* PVD Output */
+#define PWR_CSR_EWUP                            ((uint16_t)0x0100) /* Enable WKUP pin */
+
+/******************************************************************************/
+/*                         Reset and Clock Control                            */
+/******************************************************************************/
+
+/********************  Bit definition for RCC_CTLR register  ********************/
+#define RCC_HSION                               ((uint32_t)0x00000001) /* Internal High Speed clock enable */
+#define RCC_HSIRDY                              ((uint32_t)0x00000002) /* Internal High Speed clock ready flag */
+#define RCC_HSITRIM                             ((uint32_t)0x000000F8) /* Internal High Speed clock trimming */
+#define RCC_HSICAL                              ((uint32_t)0x0000FF00) /* Internal High Speed clock Calibration */
+#define RCC_HSEON                               ((uint32_t)0x00010000) /* External High Speed clock enable */
+#define RCC_HSERDY                              ((uint32_t)0x00020000) /* External High Speed clock ready flag */
+#define RCC_HSEBYP                              ((uint32_t)0x00040000) /* External High Speed clock Bypass */
+#define RCC_CSSON                               ((uint32_t)0x00080000) /* Clock Security System enable */
+#define RCC_PLLON                               ((uint32_t)0x01000000) /* PLL enable */
+#define RCC_PLLRDY                              ((uint32_t)0x02000000) /* PLL clock ready flag */
+
+/*******************  Bit definition for RCC_CFGR0 register  *******************/
+#define RCC_SW                                  ((uint32_t)0x00000003) /* SW[1:0] bits (System clock Switch) */
+#define RCC_SW_0                                ((uint32_t)0x00000001) /* Bit 0 */
+#define RCC_SW_1                                ((uint32_t)0x00000002) /* Bit 1 */
+
+#define RCC_SW_HSI                              ((uint32_t)0x00000000) /* HSI selected as system clock */
+#define RCC_SW_HSE                              ((uint32_t)0x00000001) /* HSE selected as system clock */
+#define RCC_SW_PLL                              ((uint32_t)0x00000002) /* PLL selected as system clock */
+
+#define RCC_SWS                                 ((uint32_t)0x0000000C) /* SWS[1:0] bits (System Clock Switch Status) */
+#define RCC_SWS_0                               ((uint32_t)0x00000004) /* Bit 0 */
+#define RCC_SWS_1                               ((uint32_t)0x00000008) /* Bit 1 */
+
+#define RCC_SWS_HSI                             ((uint32_t)0x00000000) /* HSI oscillator used as system clock */
+#define RCC_SWS_HSE                             ((uint32_t)0x00000004) /* HSE oscillator used as system clock */
+#define RCC_SWS_PLL                             ((uint32_t)0x00000008) /* PLL used as system clock */
+
+#define RCC_HPRE                                ((uint32_t)0x000000F0) /* HPRE[3:0] bits (AHB prescaler) */
+#define RCC_HPRE_0                              ((uint32_t)0x00000010) /* Bit 0 */
+#define RCC_HPRE_1                              ((uint32_t)0x00000020) /* Bit 1 */
+#define RCC_HPRE_2                              ((uint32_t)0x00000040) /* Bit 2 */
+#define RCC_HPRE_3                              ((uint32_t)0x00000080) /* Bit 3 */
+
+#define RCC_HPRE_DIV1                           ((uint32_t)0x00000000) /* SYSCLK not divided */
+#define RCC_HPRE_DIV2                           ((uint32_t)0x00000080) /* SYSCLK divided by 2 */
+#define RCC_HPRE_DIV4                           ((uint32_t)0x00000090) /* SYSCLK divided by 4 */
+#define RCC_HPRE_DIV8                           ((uint32_t)0x000000A0) /* SYSCLK divided by 8 */
+#define RCC_HPRE_DIV16                          ((uint32_t)0x000000B0) /* SYSCLK divided by 16 */
+#define RCC_HPRE_DIV64                          ((uint32_t)0x000000C0) /* SYSCLK divided by 64 */
+#define RCC_HPRE_DIV128                         ((uint32_t)0x000000D0) /* SYSCLK divided by 128 */
+#define RCC_HPRE_DIV256                         ((uint32_t)0x000000E0) /* SYSCLK divided by 256 */
+#define RCC_HPRE_DIV512                         ((uint32_t)0x000000F0) /* SYSCLK divided by 512 */
+
+#define RCC_PPRE1                               ((uint32_t)0x00000700) /* PRE1[2:0] bits (APB1 prescaler) */
+#define RCC_PPRE1_0                             ((uint32_t)0x00000100) /* Bit 0 */
+#define RCC_PPRE1_1                             ((uint32_t)0x00000200) /* Bit 1 */
+#define RCC_PPRE1_2                             ((uint32_t)0x00000400) /* Bit 2 */
+
+#define RCC_PPRE1_DIV1                          ((uint32_t)0x00000000) /* PPRE1 not divided */
+#define RCC_PPRE1_DIV2                          ((uint32_t)0x00000400) /* PPRE1 divided by 2 */
+#define RCC_PPRE1_DIV4                          ((uint32_t)0x00000500) /* PPRE1 divided by 4 */
+#define RCC_PPRE1_DIV8                          ((uint32_t)0x00000600) /* PPRE1 divided by 8 */
+#define RCC_PPRE1_DIV16                         ((uint32_t)0x00000700) /* PPRE1 divided by 16 */
+
+#define RCC_PPRE2                               ((uint32_t)0x00003800) /* PRE2[2:0] bits (APB2 prescaler) */
+#define RCC_PPRE2_0                             ((uint32_t)0x00000800) /* Bit 0 */
+#define RCC_PPRE2_1                             ((uint32_t)0x00001000) /* Bit 1 */
+#define RCC_PPRE2_2                             ((uint32_t)0x00002000) /* Bit 2 */
+
+#define RCC_PPRE2_DIV1                          ((uint32_t)0x00000000) /* PPRE2 not divided */
+#define RCC_PPRE2_DIV2                          ((uint32_t)0x00002000) /* PPRE2 divided by 2 */
+#define RCC_PPRE2_DIV4                          ((uint32_t)0x00002800) /* PPRE2 divided by 4 */
+#define RCC_PPRE2_DIV8                          ((uint32_t)0x00003000) /* PPRE2 divided by 8 */
+#define RCC_PPRE2_DIV16                         ((uint32_t)0x00003800) /* PPRE2 divided by 16 */
+
+#define RCC_ADCPRE                              ((uint32_t)0x0000C000) /* ADCPRE[1:0] bits (ADC prescaler) */
+#define RCC_ADCPRE_0                            ((uint32_t)0x00004000) /* Bit 0 */
+#define RCC_ADCPRE_1                            ((uint32_t)0x00008000) /* Bit 1 */
+
+#define RCC_ADCPRE_DIV2                         ((uint32_t)0x00000000) /* ADCPRE divided by 2 */
+#define RCC_ADCPRE_DIV4                         ((uint32_t)0x00004000) /* ADCPRE divided by 4 */
+#define RCC_ADCPRE_DIV6                         ((uint32_t)0x00008000) /* ADCPRE divided by 6 */
+#define RCC_ADCPRE_DIV8                         ((uint32_t)0x0000C000) /* ADCPRE divided by 8 */
+
+#define RCC_PLLSRC                              ((uint32_t)0x00010000) /* PLL entry clock source */
+
+#define RCC_PLLXTPRE                            ((uint32_t)0x00020000) /* HSE divider for PLL entry */
+
+#define RCC_PLLMULL                             ((uint32_t)0x003C0000) /* PLLMUL[3:0] bits (PLL multiplication factor) */
+#define RCC_PLLMULL_0                           ((uint32_t)0x00040000) /* Bit 0 */
+#define RCC_PLLMULL_1                           ((uint32_t)0x00080000) /* Bit 1 */
+#define RCC_PLLMULL_2                           ((uint32_t)0x00100000) /* Bit 2 */
+#define RCC_PLLMULL_3                           ((uint32_t)0x00200000) /* Bit 3 */
+
+#define RCC_PLLSRC_HSI_Div2                     ((uint32_t)0x00000000) /* HSI clock divided by 2 selected as PLL entry clock source */
+#define RCC_PLLSRC_HSE                          ((uint32_t)0x00010000) /* HSE clock selected as PLL entry clock source */
+
+#define RCC_PLLXTPRE_HSE                        ((uint32_t)0x00000000) /* HSE clock not divided for PLL entry */
+#define RCC_PLLXTPRE_HSE_Div2                   ((uint32_t)0x00020000) /* HSE clock divided by 2 for PLL entry */
+
+/* for other CH32V20x */
+#define RCC_PLLMULL2                            ((uint32_t)0x00000000) /* PLL input clock*2 */
+#define RCC_PLLMULL3                            ((uint32_t)0x00040000) /* PLL input clock*3 */
+#define RCC_PLLMULL4                            ((uint32_t)0x00080000) /* PLL input clock*4 */
+#define RCC_PLLMULL5                            ((uint32_t)0x000C0000) /* PLL input clock*5 */
+#define RCC_PLLMULL6                            ((uint32_t)0x00100000) /* PLL input clock*6 */
+#define RCC_PLLMULL7                            ((uint32_t)0x00140000) /* PLL input clock*7 */
+#define RCC_PLLMULL8                            ((uint32_t)0x00180000) /* PLL input clock*8 */
+#define RCC_PLLMULL9                            ((uint32_t)0x001C0000) /* PLL input clock*9 */
+#define RCC_PLLMULL10                           ((uint32_t)0x00200000) /* PLL input clock10 */
+#define RCC_PLLMULL11                           ((uint32_t)0x00240000) /* PLL input clock*11 */
+#define RCC_PLLMULL12                           ((uint32_t)0x00280000) /* PLL input clock*12 */
+#define RCC_PLLMULL13                           ((uint32_t)0x002C0000) /* PLL input clock*13 */
+#define RCC_PLLMULL14                           ((uint32_t)0x00300000) /* PLL input clock*14 */
+#define RCC_PLLMULL15                           ((uint32_t)0x00340000) /* PLL input clock*15 */
+#define RCC_PLLMULL16                           ((uint32_t)0x00380000) /* PLL input clock*16 */
+#define RCC_PLLMULL18                           ((uint32_t)0x003C0000) /* PLL input clock*18 */
+
+#define RCC_USBPRE                              ((uint32_t)0x00400000) /* USB Device prescaler */
+
+#define RCC_CFGR0_MCO                           ((uint32_t)0x07000000) /* MCO[2:0] bits (Microcontroller Clock Output) */
+#define RCC_MCO_0                               ((uint32_t)0x01000000) /* Bit 0 */
+#define RCC_MCO_1                               ((uint32_t)0x02000000) /* Bit 1 */
+#define RCC_MCO_2                               ((uint32_t)0x04000000) /* Bit 2 */
+
+#define RCC_MCO_NOCLOCK                         ((uint32_t)0x00000000) /* No clock */
+#define RCC_CFGR0_MCO_SYSCLK                    ((uint32_t)0x04000000) /* System clock selected as MCO source */
+#define RCC_CFGR0_MCO_HSI                       ((uint32_t)0x05000000) /* HSI clock selected as MCO source */
+#define RCC_CFGR0_MCO_HSE                       ((uint32_t)0x06000000) /* HSE clock selected as MCO source  */
+#define RCC_CFGR0_MCO_PLL                       ((uint32_t)0x07000000) /* PLL clock divided by 2 selected as MCO source */
+
+/*******************  Bit definition for RCC_INTR register  ********************/
+#define RCC_LSIRDYF                             ((uint32_t)0x00000001) /* LSI Ready Interrupt flag */
+#define RCC_LSERDYF                             ((uint32_t)0x00000002) /* LSE Ready Interrupt flag */
+#define RCC_HSIRDYF                             ((uint32_t)0x00000004) /* HSI Ready Interrupt flag */
+#define RCC_HSERDYF                             ((uint32_t)0x00000008) /* HSE Ready Interrupt flag */
+#define RCC_PLLRDYF                             ((uint32_t)0x00000010) /* PLL Ready Interrupt flag */
+#define RCC_CSSF                                ((uint32_t)0x00000080) /* Clock Security System Interrupt flag */
+#define RCC_LSIRDYIE                            ((uint32_t)0x00000100) /* LSI Ready Interrupt Enable */
+#define RCC_LSERDYIE                            ((uint32_t)0x00000200) /* LSE Ready Interrupt Enable */
+#define RCC_HSIRDYIE                            ((uint32_t)0x00000400) /* HSI Ready Interrupt Enable */
+#define RCC_HSERDYIE                            ((uint32_t)0x00000800) /* HSE Ready Interrupt Enable */
+#define RCC_PLLRDYIE                            ((uint32_t)0x00001000) /* PLL Ready Interrupt Enable */
+#define RCC_LSIRDYC                             ((uint32_t)0x00010000) /* LSI Ready Interrupt Clear */
+#define RCC_LSERDYC                             ((uint32_t)0x00020000) /* LSE Ready Interrupt Clear */
+#define RCC_HSIRDYC                             ((uint32_t)0x00040000) /* HSI Ready Interrupt Clear */
+#define RCC_HSERDYC                             ((uint32_t)0x00080000) /* HSE Ready Interrupt Clear */
+#define RCC_PLLRDYC                             ((uint32_t)0x00100000) /* PLL Ready Interrupt Clear */
+#define RCC_CSSC                                ((uint32_t)0x00800000) /* Clock Security System Interrupt Clear */
+
+/*****************  Bit definition for RCC_APB2PRSTR register  *****************/
+#define RCC_AFIORST                             ((uint32_t)0x00000001) /* Alternate Function I/O reset */
+#define RCC_IOPARST                             ((uint32_t)0x00000004) /* I/O port A reset */
+#define RCC_IOPBRST                             ((uint32_t)0x00000008) /* I/O port B reset */
+#define RCC_IOPCRST                             ((uint32_t)0x00000010) /* I/O port C reset */
+#define RCC_IOPDRST                             ((uint32_t)0x00000020) /* I/O port D reset */
+#define RCC_ADC1RST                             ((uint32_t)0x00000200) /* ADC 1 interface reset */
+
+#define RCC_ADC2RST                             ((uint32_t)0x00000400) /* ADC 2 interface reset */
+
+#define RCC_TIM1RST                             ((uint32_t)0x00000800) /* TIM1 Timer reset */
+#define RCC_SPI1RST                             ((uint32_t)0x00001000) /* SPI 1 reset */
+#define RCC_USART1RST                           ((uint32_t)0x00004000) /* USART1 reset */
+
+#define RCC_IOPERST                             ((uint32_t)0x00000040) /* I/O port E reset */
+
+/*****************  Bit definition for RCC_APB1PRSTR register  *****************/
+#define RCC_TIM2RST                             ((uint32_t)0x00000001) /* Timer 2 reset */
+#define RCC_TIM3RST                             ((uint32_t)0x00000002) /* Timer 3 reset */
+#define RCC_WWDGRST                             ((uint32_t)0x00000800) /* Window Watchdog reset */
+#define RCC_USART2RST                           ((uint32_t)0x00020000) /* USART 2 reset */
+#define RCC_I2C1RST                             ((uint32_t)0x00200000) /* I2C 1 reset */
+
+#define RCC_CAN1RST                             ((uint32_t)0x02000000) /* CAN1 reset */
+
+#define RCC_BKPRST                              ((uint32_t)0x08000000) /* Backup interface reset */
+#define RCC_PWRRST                              ((uint32_t)0x10000000) /* Power interface reset */
+
+#define RCC_TIM4RST                             ((uint32_t)0x00000004) /* Timer 4 reset */
+#define RCC_SPI2RST                             ((uint32_t)0x00004000) /* SPI 2 reset */
+#define RCC_USART3RST                           ((uint32_t)0x00040000) /* USART 3 reset */
+#define RCC_I2C2RST                             ((uint32_t)0x00400000) /* I2C 2 reset */
+
+#define RCC_USBRST                              ((uint32_t)0x00800000) /* USB Device reset */
+
+/******************  Bit definition for RCC_AHBPCENR register  ******************/
+#define RCC_DMA1EN                              ((uint16_t)0x0001) /* DMA1 clock enable */
+#define RCC_SRAMEN                              ((uint16_t)0x0004) /* SRAM interface clock enable */
+#define RCC_FLITFEN                             ((uint16_t)0x0010) /* FLITF clock enable */
+#define RCC_CRCEN                               ((uint16_t)0x0040) /* CRC clock enable */
+#define RCC_USBHD                               ((uint16_t)0x1000)
+
+/******************  Bit definition for RCC_APB2PCENR register  *****************/
+#define RCC_AFIOEN                              ((uint32_t)0x00000001) /* Alternate Function I/O clock enable */
+#define RCC_IOPAEN                              ((uint32_t)0x00000004) /* I/O port A clock enable */
+#define RCC_IOPBEN                              ((uint32_t)0x00000008) /* I/O port B clock enable */
+#define RCC_IOPCEN                              ((uint32_t)0x00000010) /* I/O port C clock enable */
+#define RCC_IOPDEN                              ((uint32_t)0x00000020) /* I/O port D clock enable */
+#define RCC_ADC1EN                              ((uint32_t)0x00000200) /* ADC 1 interface clock enable */
+
+#define RCC_ADC2EN                              ((uint32_t)0x00000400) /* ADC 2 interface clock enable */
+
+#define RCC_TIM1EN                              ((uint32_t)0x00000800) /* TIM1 Timer clock enable */
+#define RCC_SPI1EN                              ((uint32_t)0x00001000) /* SPI 1 clock enable */
+#define RCC_USART1EN                            ((uint32_t)0x00004000) /* USART1 clock enable */
+
+/*****************  Bit definition for RCC_APB1PCENR register  ******************/
+#define RCC_TIM2EN                              ((uint32_t)0x00000001) /* Timer 2 clock enabled*/
+#define RCC_TIM3EN                              ((uint32_t)0x00000002) /* Timer 3 clock enable */
+#define RCC_WWDGEN                              ((uint32_t)0x00000800) /* Window Watchdog clock enable */
+#define RCC_USART2EN                            ((uint32_t)0x00020000) /* USART 2 clock enable */
+#define RCC_I2C1EN                              ((uint32_t)0x00200000) /* I2C 1 clock enable */
+
+#define RCC_BKPEN                               ((uint32_t)0x08000000) /* Backup interface clock enable */
+#define RCC_PWREN                               ((uint32_t)0x10000000) /* Power interface clock enable */
+
+#define RCC_USBEN                               ((uint32_t)0x00800000) /* USB Device clock enable */
+
+/*******************  Bit definition for RCC_BDCTLR register  *******************/
+#define RCC_LSEON                               ((uint32_t)0x00000001) /* External Low Speed oscillator enable */
+#define RCC_LSERDY                              ((uint32_t)0x00000002) /* External Low Speed oscillator Ready */
+#define RCC_LSEBYP                              ((uint32_t)0x00000004) /* External Low Speed oscillator Bypass */
+
+#define RCC_RTCSEL                              ((uint32_t)0x00000300) /* RTCSEL[1:0] bits (RTC clock source selection) */
+#define RCC_RTCSEL_0                            ((uint32_t)0x00000100) /* Bit 0 */
+#define RCC_RTCSEL_1                            ((uint32_t)0x00000200) /* Bit 1 */
+
+#define RCC_RTCSEL_NOCLOCK                      ((uint32_t)0x00000000) /* No clock */
+#define RCC_RTCSEL_LSE                          ((uint32_t)0x00000100) /* LSE oscillator clock used as RTC clock */
+#define RCC_RTCSEL_LSI                          ((uint32_t)0x00000200) /* LSI oscillator clock used as RTC clock */
+#define RCC_RTCSEL_HSE                          ((uint32_t)0x00000300) /* HSE oscillator clock divided by 128 used as RTC clock */
+
+#define RCC_RTCEN                               ((uint32_t)0x00008000) /* RTC clock enable */
+#define RCC_BDRST                               ((uint32_t)0x00010000) /* Backup domain software reset  */
+
+/*******************  Bit definition for RCC_RSTSCKR register  ********************/
+#define RCC_LSION                               ((uint32_t)0x00000001) /* Internal Low Speed oscillator enable */
+#define RCC_LSIRDY                              ((uint32_t)0x00000002) /* Internal Low Speed oscillator Ready */
+#define RCC_RMVF                                ((uint32_t)0x01000000) /* Remove reset flag */
+#define RCC_PINRSTF                             ((uint32_t)0x04000000) /* PIN reset flag */
+#define RCC_PORRSTF                             ((uint32_t)0x08000000) /* POR/PDR reset flag */
+#define RCC_SFTRSTF                             ((uint32_t)0x10000000) /* Software Reset flag */
+#define RCC_IWDGRSTF                            ((uint32_t)0x20000000) /* Independent Watchdog reset flag */
+#define RCC_WWDGRSTF                            ((uint32_t)0x40000000) /* Window watchdog reset flag */
+#define RCC_LPWRRSTF                            ((uint32_t)0x80000000) /* Low-Power reset flag */
+
+/******************************************************************************/
+/*                             Real-Time Clock                                */
+/******************************************************************************/
+
+/*******************  Bit definition for RTC_CTLRH register  ********************/
+#define RTC_CTLRH_SECIE                         ((uint8_t)0x01) /* Second Interrupt Enable */
+#define RTC_CTLRH_ALRIE                         ((uint8_t)0x02) /* Alarm Interrupt Enable */
+#define RTC_CTLRH_OWIE                          ((uint8_t)0x04) /* OverfloW Interrupt Enable */
+
+/*******************  Bit definition for RTC_CTLRL register  ********************/
+#define RTC_CTLRL_SECF                          ((uint8_t)0x01) /* Second Flag */
+#define RTC_CTLRL_ALRF                          ((uint8_t)0x02) /* Alarm Flag */
+#define RTC_CTLRL_OWF                           ((uint8_t)0x04) /* OverfloW Flag */
+#define RTC_CTLRL_RSF                           ((uint8_t)0x08) /* Registers Synchronized Flag */
+#define RTC_CTLRL_CNF                           ((uint8_t)0x10) /* Configuration Flag */
+#define RTC_CTLRL_RTOFF                         ((uint8_t)0x20) /* RTC operation OFF */
+
+/*******************  Bit definition for RTC_PSCH register  *******************/
+#define RTC_PSCH_PRL                            ((uint16_t)0x000F) /* RTC Prescaler Reload Value High */
+
+/*******************  Bit definition for RTC_PRLL register  *******************/
+#define RTC_PSCL_PRL                            ((uint16_t)0xFFFF) /* RTC Prescaler Reload Value Low */
+
+/*******************  Bit definition for RTC_DIVH register  *******************/
+#define RTC_DIVH_RTC_DIV                        ((uint16_t)0x000F) /* RTC Clock Divider High */
+
+/*******************  Bit definition for RTC_DIVL register  *******************/
+#define RTC_DIVL_RTC_DIV                        ((uint16_t)0xFFFF) /* RTC Clock Divider Low */
+
+/*******************  Bit definition for RTC_CNTH register  *******************/
+#define RTC_CNTH_RTC_CNT                        ((uint16_t)0xFFFF) /* RTC Counter High */
+
+/*******************  Bit definition for RTC_CNTL register  *******************/
+#define RTC_CNTL_RTC_CNT                        ((uint16_t)0xFFFF) /* RTC Counter Low */
+
+/*******************  Bit definition for RTC_ALRMH register  *******************/
+#define RTC_ALRMH_RTC_ALRM                      ((uint16_t)0xFFFF) /* RTC Alarm High */
+
+/*******************  Bit definition for RTC_ALRML register  *******************/
+#define RTC_ALRML_RTC_ALRM                      ((uint16_t)0xFFFF) /* RTC Alarm Low */
+
+/******************************************************************************/
+/*                        Serial Peripheral Interface                         */
+/******************************************************************************/
+
+/*******************  Bit definition for SPI_CTLR1 register  ********************/
+#define SPI_CTLR1_CPHA                          ((uint16_t)0x0001) /* Clock Phase */
+#define SPI_CTLR1_CPOL                          ((uint16_t)0x0002) /* Clock Polarity */
+#define SPI_CTLR1_MSTR                          ((uint16_t)0x0004) /* Master Selection */
+
+#define SPI_CTLR1_BR                            ((uint16_t)0x0038) /* BR[2:0] bits (Baud Rate Control) */
+#define SPI_CTLR1_BR_0                          ((uint16_t)0x0008) /* Bit 0 */
+#define SPI_CTLR1_BR_1                          ((uint16_t)0x0010) /* Bit 1 */
+#define SPI_CTLR1_BR_2                          ((uint16_t)0x0020) /* Bit 2 */
+
+#define SPI_CTLR1_SPE                           ((uint16_t)0x0040) /* SPI Enable */
+#define SPI_CTLR1_LSBFIRST                      ((uint16_t)0x0080) /* Frame Format */
+#define SPI_CTLR1_SSI                           ((uint16_t)0x0100) /* Internal slave select */
+#define SPI_CTLR1_SSM                           ((uint16_t)0x0200) /* Software slave management */
+#define SPI_CTLR1_RXONLY                        ((uint16_t)0x0400) /* Receive only */
+#define SPI_CTLR1_DFF                           ((uint16_t)0x0800) /* Data Frame Format */
+#define SPI_CTLR1_CRCNEXT                       ((uint16_t)0x1000) /* Transmit CRC next */
+#define SPI_CTLR1_CRCEN                         ((uint16_t)0x2000) /* Hardware CRC calculation enable */
+#define SPI_CTLR1_BIDIOE                        ((uint16_t)0x4000) /* Output enable in bidirectional mode */
+#define SPI_CTLR1_BIDIMODE                      ((uint16_t)0x8000) /* Bidirectional data mode enable */
+
+/*******************  Bit definition for SPI_CTLR2 register  ********************/
+#define SPI_CTLR2_RXDMAEN                       ((uint8_t)0x01) /* Rx Buffer DMA Enable */
+#define SPI_CTLR2_TXDMAEN                       ((uint8_t)0x02) /* Tx Buffer DMA Enable */
+#define SPI_CTLR2_SSOE                          ((uint8_t)0x04) /* SS Output Enable */
+#define SPI_CTLR2_ERRIE                         ((uint8_t)0x20) /* Error Interrupt Enable */
+#define SPI_CTLR2_RXNEIE                        ((uint8_t)0x40) /* RX buffer Not Empty Interrupt Enable */
+#define SPI_CTLR2_TXEIE                         ((uint8_t)0x80) /* Tx buffer Empty Interrupt Enable */
+
+/********************  Bit definition for SPI_STATR register  ********************/
+#define SPI_STATR_RXNE                          ((uint8_t)0x01) /* Receive buffer Not Empty */
+#define SPI_STATR_TXE                           ((uint8_t)0x02) /* Transmit buffer Empty */
+#define SPI_STATR_CHSIDE                        ((uint8_t)0x04) /* Channel side */
+#define SPI_STATR_UDR                           ((uint8_t)0x08) /* Underrun flag */
+#define SPI_STATR_CRCERR                        ((uint8_t)0x10) /* CRC Error flag */
+#define SPI_STATR_MODF                          ((uint8_t)0x20) /* Mode fault */
+#define SPI_STATR_OVR                           ((uint8_t)0x40) /* Overrun flag */
+#define SPI_STATR_BSY                           ((uint8_t)0x80) /* Busy flag */
+
+/********************  Bit definition for SPI_DATAR register  ********************/
+#define SPI_DATAR_DR                            ((uint16_t)0xFFFF) /* Data Register */
+
+/*******************  Bit definition for SPI_CRCR register  ******************/
+#define SPI_CRCR_CRCPOLY                        ((uint16_t)0xFFFF) /* CRC polynomial register */
+
+/******************  Bit definition for SPI_RCRCR register  ******************/
+#define SPI_RCRCR_RXCRC                         ((uint16_t)0xFFFF) /* Rx CRC Register */
+
+/******************  Bit definition for SPI_TCRCR register  ******************/
+#define SPI_TCRCR_TXCRC                         ((uint16_t)0xFFFF) /* Tx CRC Register */
+
+/******************  Bit definition for SPI_I2SCFGR register  *****************/
+#define SPI_I2SCFGR_CHLEN                       ((uint16_t)0x0001) /* Channel length (number of bits per audio channel) */
+
+#define SPI_I2SCFGR_DATLEN                      ((uint16_t)0x0006) /* DATLEN[1:0] bits (Data length to be transferred) */
+#define SPI_I2SCFGR_DATLEN_0                    ((uint16_t)0x0002) /* Bit 0 */
+#define SPI_I2SCFGR_DATLEN_1                    ((uint16_t)0x0004) /* Bit 1 */
+
+#define SPI_I2SCFGR_CKPOL                       ((uint16_t)0x0008) /* steady state clock polarity */
+
+#define SPI_I2SCFGR_I2SSTD                      ((uint16_t)0x0030) /* I2SSTD[1:0] bits (I2S standard selection) */
+#define SPI_I2SCFGR_I2SSTD_0                    ((uint16_t)0x0010) /* Bit 0 */
+#define SPI_I2SCFGR_I2SSTD_1                    ((uint16_t)0x0020) /* Bit 1 */
+
+#define SPI_I2SCFGR_PCMSYNC                     ((uint16_t)0x0080) /* PCM frame synchronization */
+
+#define SPI_I2SCFGR_I2SCFG                      ((uint16_t)0x0300) /* I2SCFG[1:0] bits (I2S configuration mode) */
+#define SPI_I2SCFGR_I2SCFG_0                    ((uint16_t)0x0100) /* Bit 0 */
+#define SPI_I2SCFGR_I2SCFG_1                    ((uint16_t)0x0200) /* Bit 1 */
+
+#define SPI_I2SCFGR_I2SE                        ((uint16_t)0x0400) /* I2S Enable */
+#define SPI_I2SCFGR_I2SMOD                      ((uint16_t)0x0800) /* I2S mode selection */
+
+/******************  Bit definition for SPI_I2SPR register  *******************/
+#define SPI_I2SPR_I2SDIV                        ((uint16_t)0x00FF) /* I2S Linear prescaler */
+#define SPI_I2SPR_ODD                           ((uint16_t)0x0100) /* Odd factor for the prescaler */
+#define SPI_I2SPR_MCKOE                         ((uint16_t)0x0200) /* Master Clock Output Enable */
+
+/******************************************************************************/
+/*                                    TIM                                     */
+/******************************************************************************/
+
+/*******************  Bit definition for TIM_CTLR1 register  ********************/
+#define TIM_CEN                                 ((uint16_t)0x0001) /* Counter enable */
+#define TIM_UDIS                                ((uint16_t)0x0002) /* Update disable */
+#define TIM_URS                                 ((uint16_t)0x0004) /* Update request source */
+#define TIM_OPM                                 ((uint16_t)0x0008) /* One pulse mode */
+#define TIM_DIR                                 ((uint16_t)0x0010) /* Direction */
+
+#define TIM_CMS                                 ((uint16_t)0x0060) /* CMS[1:0] bits (Center-aligned mode selection) */
+#define TIM_CMS_0                               ((uint16_t)0x0020) /* Bit 0 */
+#define TIM_CMS_1                               ((uint16_t)0x0040) /* Bit 1 */
+
+#define TIM_ARPE                                ((uint16_t)0x0080) /* Auto-reload preload enable */
+
+#define TIM_CTLR1_CKD                           ((uint16_t)0x0300) /* CKD[1:0] bits (clock division) */
+#define TIM_CKD_0                               ((uint16_t)0x0100) /* Bit 0 */
+#define TIM_CKD_1                               ((uint16_t)0x0200) /* Bit 1 */
+
+/*******************  Bit definition for TIM_CTLR2 register  ********************/
+#define TIM_CCPC                                ((uint16_t)0x0001) /* Capture/Compare Preloaded Control */
+#define TIM_CCUS                                ((uint16_t)0x0004) /* Capture/Compare Control Update Selection */
+#define TIM_CCDS                                ((uint16_t)0x0008) /* Capture/Compare DMA Selection */
+
+#define TIM_MMS                                 ((uint16_t)0x0070) /* MMS[2:0] bits (Master Mode Selection) */
+#define TIM_MMS_0                               ((uint16_t)0x0010) /* Bit 0 */
+#define TIM_MMS_1                               ((uint16_t)0x0020) /* Bit 1 */
+#define TIM_MMS_2                               ((uint16_t)0x0040) /* Bit 2 */
+
+#define TIM_TI1S                                ((uint16_t)0x0080) /* TI1 Selection */
+#define TIM_OIS1                                ((uint16_t)0x0100) /* Output Idle state 1 (OC1 output) */
+#define TIM_OIS1N                               ((uint16_t)0x0200) /* Output Idle state 1 (OC1N output) */
+#define TIM_OIS2                                ((uint16_t)0x0400) /* Output Idle state 2 (OC2 output) */
+#define TIM_OIS2N                               ((uint16_t)0x0800) /* Output Idle state 2 (OC2N output) */
+#define TIM_OIS3                                ((uint16_t)0x1000) /* Output Idle state 3 (OC3 output) */
+#define TIM_OIS3N                               ((uint16_t)0x2000) /* Output Idle state 3 (OC3N output) */
+#define TIM_OIS4                                ((uint16_t)0x4000) /* Output Idle state 4 (OC4 output) */
+
+/*******************  Bit definition for TIM_SMCFGR register  *******************/
+#define TIM_SMS                                 ((uint16_t)0x0007) /* SMS[2:0] bits (Slave mode selection) */
+#define TIM_SMS_0                               ((uint16_t)0x0001) /* Bit 0 */
+#define TIM_SMS_1                               ((uint16_t)0x0002) /* Bit 1 */
+#define TIM_SMS_2                               ((uint16_t)0x0004) /* Bit 2 */
+
+#define TIM_TS                                  ((uint16_t)0x0070) /* TS[2:0] bits (Trigger selection) */
+#define TIM_TS_0                                ((uint16_t)0x0010) /* Bit 0 */
+#define TIM_TS_1                                ((uint16_t)0x0020) /* Bit 1 */
+#define TIM_TS_2                                ((uint16_t)0x0040) /* Bit 2 */
+
+#define TIM_MSM                                 ((uint16_t)0x0080) /* Master/slave mode */
+
+#define TIM_ETF                                 ((uint16_t)0x0F00) /* ETF[3:0] bits (External trigger filter) */
+#define TIM_ETF_0                               ((uint16_t)0x0100) /* Bit 0 */
+#define TIM_ETF_1                               ((uint16_t)0x0200) /* Bit 1 */
+#define TIM_ETF_2                               ((uint16_t)0x0400) /* Bit 2 */
+#define TIM_ETF_3                               ((uint16_t)0x0800) /* Bit 3 */
+
+#define TIM_ETPS                                ((uint16_t)0x3000) /* ETPS[1:0] bits (External trigger prescaler) */
+#define TIM_ETPS_0                              ((uint16_t)0x1000) /* Bit 0 */
+#define TIM_ETPS_1                              ((uint16_t)0x2000) /* Bit 1 */
+
+#define TIM_ECE                                 ((uint16_t)0x4000) /* External clock enable */
+#define TIM_ETP                                 ((uint16_t)0x8000) /* External trigger polarity */
+
+/*******************  Bit definition for TIM_DMAINTENR register  *******************/
+#define TIM_UIE                                 ((uint16_t)0x0001) /* Update interrupt enable */
+#define TIM_CC1IE                               ((uint16_t)0x0002) /* Capture/Compare 1 interrupt enable */
+#define TIM_CC2IE                               ((uint16_t)0x0004) /* Capture/Compare 2 interrupt enable */
+#define TIM_CC3IE                               ((uint16_t)0x0008) /* Capture/Compare 3 interrupt enable */
+#define TIM_CC4IE                               ((uint16_t)0x0010) /* Capture/Compare 4 interrupt enable */
+#define TIM_COMIE                               ((uint16_t)0x0020) /* COM interrupt enable */
+#define TIM_TIE                                 ((uint16_t)0x0040) /* Trigger interrupt enable */
+#define TIM_BIE                                 ((uint16_t)0x0080) /* Break interrupt enable */
+#define TIM_UDE                                 ((uint16_t)0x0100) /* Update DMA request enable */
+#define TIM_CC1DE                               ((uint16_t)0x0200) /* Capture/Compare 1 DMA request enable */
+#define TIM_CC2DE                               ((uint16_t)0x0400) /* Capture/Compare 2 DMA request enable */
+#define TIM_CC3DE                               ((uint16_t)0x0800) /* Capture/Compare 3 DMA request enable */
+#define TIM_CC4DE                               ((uint16_t)0x1000) /* Capture/Compare 4 DMA request enable */
+#define TIM_COMDE                               ((uint16_t)0x2000) /* COM DMA request enable */
+#define TIM_TDE                                 ((uint16_t)0x4000) /* Trigger DMA request enable */
+
+/********************  Bit definition for TIM_INTFR register  ********************/
+#define TIM_UIF                                 ((uint16_t)0x0001) /* Update interrupt Flag */
+#define TIM_CC1IF                               ((uint16_t)0x0002) /* Capture/Compare 1 interrupt Flag */
+#define TIM_CC2IF                               ((uint16_t)0x0004) /* Capture/Compare 2 interrupt Flag */
+#define TIM_CC3IF                               ((uint16_t)0x0008) /* Capture/Compare 3 interrupt Flag */
+#define TIM_CC4IF                               ((uint16_t)0x0010) /* Capture/Compare 4 interrupt Flag */
+#define TIM_COMIF                               ((uint16_t)0x0020) /* COM interrupt Flag */
+#define TIM_TIF                                 ((uint16_t)0x0040) /* Trigger interrupt Flag */
+#define TIM_BIF                                 ((uint16_t)0x0080) /* Break interrupt Flag */
+#define TIM_CC1OF                               ((uint16_t)0x0200) /* Capture/Compare 1 Overcapture Flag */
+#define TIM_CC2OF                               ((uint16_t)0x0400) /* Capture/Compare 2 Overcapture Flag */
+#define TIM_CC3OF                               ((uint16_t)0x0800) /* Capture/Compare 3 Overcapture Flag */
+#define TIM_CC4OF                               ((uint16_t)0x1000) /* Capture/Compare 4 Overcapture Flag */
+
+/*******************  Bit definition for TIM_SWEVGR register  ********************/
+#define TIM_UG                                  ((uint8_t)0x01) /* Update Generation */
+#define TIM_CC1G                                ((uint8_t)0x02) /* Capture/Compare 1 Generation */
+#define TIM_CC2G                                ((uint8_t)0x04) /* Capture/Compare 2 Generation */
+#define TIM_CC3G                                ((uint8_t)0x08) /* Capture/Compare 3 Generation */
+#define TIM_CC4G                                ((uint8_t)0x10) /* Capture/Compare 4 Generation */
+#define TIM_COMG                                ((uint8_t)0x20) /* Capture/Compare Control Update Generation */
+#define TIM_TG                                  ((uint8_t)0x40) /* Trigger Generation */
+#define TIM_BG                                  ((uint8_t)0x80) /* Break Generation */
+
+/******************  Bit definition for TIM_CHCTLR1 register  *******************/
+#define TIM_CC1S                                ((uint16_t)0x0003) /* CC1S[1:0] bits (Capture/Compare 1 Selection) */
+#define TIM_CC1S_0                              ((uint16_t)0x0001) /* Bit 0 */
+#define TIM_CC1S_1                              ((uint16_t)0x0002) /* Bit 1 */
+
+#define TIM_OC1FE                               ((uint16_t)0x0004) /* Output Compare 1 Fast enable */
+#define TIM_OC1PE                               ((uint16_t)0x0008) /* Output Compare 1 Preload enable */
+
+#define TIM_OC1M                                ((uint16_t)0x0070) /* OC1M[2:0] bits (Output Compare 1 Mode) */
+#define TIM_OC1M_0                              ((uint16_t)0x0010) /* Bit 0 */
+#define TIM_OC1M_1                              ((uint16_t)0x0020) /* Bit 1 */
+#define TIM_OC1M_2                              ((uint16_t)0x0040) /* Bit 2 */
+
+#define TIM_OC1CE                               ((uint16_t)0x0080) /* Output Compare 1Clear Enable */
+
+#define TIM_CC2S                                ((uint16_t)0x0300) /* CC2S[1:0] bits (Capture/Compare 2 Selection) */
+#define TIM_CC2S_0                              ((uint16_t)0x0100) /* Bit 0 */
+#define TIM_CC2S_1                              ((uint16_t)0x0200) /* Bit 1 */
+
+#define TIM_OC2FE                               ((uint16_t)0x0400) /* Output Compare 2 Fast enable */
+#define TIM_OC2PE                               ((uint16_t)0x0800) /* Output Compare 2 Preload enable */
+
+#define TIM_OC2M                                ((uint16_t)0x7000) /* OC2M[2:0] bits (Output Compare 2 Mode) */
+#define TIM_OC2M_0                              ((uint16_t)0x1000) /* Bit 0 */
+#define TIM_OC2M_1                              ((uint16_t)0x2000) /* Bit 1 */
+#define TIM_OC2M_2                              ((uint16_t)0x4000) /* Bit 2 */
+
+#define TIM_OC2CE                               ((uint16_t)0x8000) /* Output Compare 2 Clear Enable */
+
+#define TIM_IC1PSC                              ((uint16_t)0x000C) /* IC1PSC[1:0] bits (Input Capture 1 Prescaler) */
+#define TIM_IC1PSC_0                            ((uint16_t)0x0004) /* Bit 0 */
+#define TIM_IC1PSC_1                            ((uint16_t)0x0008) /* Bit 1 */
+
+#define TIM_IC1F                                ((uint16_t)0x00F0) /* IC1F[3:0] bits (Input Capture 1 Filter) */
+#define TIM_IC1F_0                              ((uint16_t)0x0010) /* Bit 0 */
+#define TIM_IC1F_1                              ((uint16_t)0x0020) /* Bit 1 */
+#define TIM_IC1F_2                              ((uint16_t)0x0040) /* Bit 2 */
+#define TIM_IC1F_3                              ((uint16_t)0x0080) /* Bit 3 */
+
+#define TIM_IC2PSC                              ((uint16_t)0x0C00) /* IC2PSC[1:0] bits (Input Capture 2 Prescaler) */
+#define TIM_IC2PSC_0                            ((uint16_t)0x0400) /* Bit 0 */
+#define TIM_IC2PSC_1                            ((uint16_t)0x0800) /* Bit 1 */
+
+#define TIM_IC2F                                ((uint16_t)0xF000) /* IC2F[3:0] bits (Input Capture 2 Filter) */
+#define TIM_IC2F_0                              ((uint16_t)0x1000) /* Bit 0 */
+#define TIM_IC2F_1                              ((uint16_t)0x2000) /* Bit 1 */
+#define TIM_IC2F_2                              ((uint16_t)0x4000) /* Bit 2 */
+#define TIM_IC2F_3                              ((uint16_t)0x8000) /* Bit 3 */
+
+/******************  Bit definition for TIM_CHCTLR2 register  *******************/
+#define TIM_CC3S                                ((uint16_t)0x0003) /* CC3S[1:0] bits (Capture/Compare 3 Selection) */
+#define TIM_CC3S_0                              ((uint16_t)0x0001) /* Bit 0 */
+#define TIM_CC3S_1                              ((uint16_t)0x0002) /* Bit 1 */
+
+#define TIM_OC3FE                               ((uint16_t)0x0004) /* Output Compare 3 Fast enable */
+#define TIM_OC3PE                               ((uint16_t)0x0008) /* Output Compare 3 Preload enable */
+
+#define TIM_OC3M                                ((uint16_t)0x0070) /* OC3M[2:0] bits (Output Compare 3 Mode) */
+#define TIM_OC3M_0                              ((uint16_t)0x0010) /* Bit 0 */
+#define TIM_OC3M_1                              ((uint16_t)0x0020) /* Bit 1 */
+#define TIM_OC3M_2                              ((uint16_t)0x0040) /* Bit 2 */
+
+#define TIM_OC3CE                               ((uint16_t)0x0080) /* Output Compare 3 Clear Enable */
+
+#define TIM_CC4S                                ((uint16_t)0x0300) /* CC4S[1:0] bits (Capture/Compare 4 Selection) */
+#define TIM_CC4S_0                              ((uint16_t)0x0100) /* Bit 0 */
+#define TIM_CC4S_1                              ((uint16_t)0x0200) /* Bit 1 */
+
+#define TIM_OC4FE                               ((uint16_t)0x0400) /* Output Compare 4 Fast enable */
+#define TIM_OC4PE                               ((uint16_t)0x0800) /* Output Compare 4 Preload enable */
+
+#define TIM_OC4M                                ((uint16_t)0x7000) /* OC4M[2:0] bits (Output Compare 4 Mode) */
+#define TIM_OC4M_0                              ((uint16_t)0x1000) /* Bit 0 */
+#define TIM_OC4M_1                              ((uint16_t)0x2000) /* Bit 1 */
+#define TIM_OC4M_2                              ((uint16_t)0x4000) /* Bit 2 */
+
+#define TIM_OC4CE                               ((uint16_t)0x8000) /* Output Compare 4 Clear Enable */
+
+#define TIM_IC3PSC                              ((uint16_t)0x000C) /* IC3PSC[1:0] bits (Input Capture 3 Prescaler) */
+#define TIM_IC3PSC_0                            ((uint16_t)0x0004) /* Bit 0 */
+#define TIM_IC3PSC_1                            ((uint16_t)0x0008) /* Bit 1 */
+
+#define TIM_IC3F                                ((uint16_t)0x00F0) /* IC3F[3:0] bits (Input Capture 3 Filter) */
+#define TIM_IC3F_0                              ((uint16_t)0x0010) /* Bit 0 */
+#define TIM_IC3F_1                              ((uint16_t)0x0020) /* Bit 1 */
+#define TIM_IC3F_2                              ((uint16_t)0x0040) /* Bit 2 */
+#define TIM_IC3F_3                              ((uint16_t)0x0080) /* Bit 3 */
+
+#define TIM_IC4PSC                              ((uint16_t)0x0C00) /* IC4PSC[1:0] bits (Input Capture 4 Prescaler) */
+#define TIM_IC4PSC_0                            ((uint16_t)0x0400) /* Bit 0 */
+#define TIM_IC4PSC_1                            ((uint16_t)0x0800) /* Bit 1 */
+
+#define TIM_IC4F                                ((uint16_t)0xF000) /* IC4F[3:0] bits (Input Capture 4 Filter) */
+#define TIM_IC4F_0                              ((uint16_t)0x1000) /* Bit 0 */
+#define TIM_IC4F_1                              ((uint16_t)0x2000) /* Bit 1 */
+#define TIM_IC4F_2                              ((uint16_t)0x4000) /* Bit 2 */
+#define TIM_IC4F_3                              ((uint16_t)0x8000) /* Bit 3 */
+
+/*******************  Bit definition for TIM_CCER register  *******************/
+#define TIM_CC1E                                ((uint16_t)0x0001) /* Capture/Compare 1 output enable */
+#define TIM_CC1P                                ((uint16_t)0x0002) /* Capture/Compare 1 output Polarity */
+#define TIM_CC1NE                               ((uint16_t)0x0004) /* Capture/Compare 1 Complementary output enable */
+#define TIM_CC1NP                               ((uint16_t)0x0008) /* Capture/Compare 1 Complementary output Polarity */
+#define TIM_CC2E                                ((uint16_t)0x0010) /* Capture/Compare 2 output enable */
+#define TIM_CC2P                                ((uint16_t)0x0020) /* Capture/Compare 2 output Polarity */
+#define TIM_CC2NE                               ((uint16_t)0x0040) /* Capture/Compare 2 Complementary output enable */
+#define TIM_CC2NP                               ((uint16_t)0x0080) /* Capture/Compare 2 Complementary output Polarity */
+#define TIM_CC3E                                ((uint16_t)0x0100) /* Capture/Compare 3 output enable */
+#define TIM_CC3P                                ((uint16_t)0x0200) /* Capture/Compare 3 output Polarity */
+#define TIM_CC3NE                               ((uint16_t)0x0400) /* Capture/Compare 3 Complementary output enable */
+#define TIM_CC3NP                               ((uint16_t)0x0800) /* Capture/Compare 3 Complementary output Polarity */
+#define TIM_CC4E                                ((uint16_t)0x1000) /* Capture/Compare 4 output enable */
+#define TIM_CC4P                                ((uint16_t)0x2000) /* Capture/Compare 4 output Polarity */
+#define TIM_CC4NP                               ((uint16_t)0x8000) /* Capture/Compare 4 Complementary output Polarity */
+
+/*******************  Bit definition for TIM_CNT register  ********************/
+#define TIM_CNT                                 ((uint16_t)0xFFFF) /* Counter Value */
+
+/*******************  Bit definition for TIM_PSC register  ********************/
+#define TIM_PSC                                 ((uint16_t)0xFFFF) /* Prescaler Value */
+
+/*******************  Bit definition for TIM_ATRLR register  ********************/
+#define TIM_ARR                                 ((uint16_t)0xFFFF) /* actual auto-reload Value */
+
+/*******************  Bit definition for TIM_RPTCR register  ********************/
+#define TIM_REP                                 ((uint8_t)0xFF) /* Repetition Counter Value */
+
+/*******************  Bit definition for TIM_CH1CVR register  *******************/
+#define TIM_CCR1                                ((uint16_t)0xFFFF) /* Capture/Compare 1 Value */
+
+/*******************  Bit definition for TIM_CH2CVR register  *******************/
+#define TIM_CCR2                                ((uint16_t)0xFFFF) /* Capture/Compare 2 Value */
+
+/*******************  Bit definition for TIM_CH3CVR register  *******************/
+#define TIM_CCR3                                ((uint16_t)0xFFFF) /* Capture/Compare 3 Value */
+
+/*******************  Bit definition for TIM_CH4CVR register  *******************/
+#define TIM_CCR4                                ((uint16_t)0xFFFF) /* Capture/Compare 4 Value */
+
+/*******************  Bit definition for TIM_BDTR register  *******************/
+#define TIM_DTG                                 ((uint16_t)0x00FF) /* DTG[0:7] bits (Dead-Time Generator set-up) */
+#define TIM_DTG_0                               ((uint16_t)0x0001) /* Bit 0 */
+#define TIM_DTG_1                               ((uint16_t)0x0002) /* Bit 1 */
+#define TIM_DTG_2                               ((uint16_t)0x0004) /* Bit 2 */
+#define TIM_DTG_3                               ((uint16_t)0x0008) /* Bit 3 */
+#define TIM_DTG_4                               ((uint16_t)0x0010) /* Bit 4 */
+#define TIM_DTG_5                               ((uint16_t)0x0020) /* Bit 5 */
+#define TIM_DTG_6                               ((uint16_t)0x0040) /* Bit 6 */
+#define TIM_DTG_7                               ((uint16_t)0x0080) /* Bit 7 */
+
+#define TIM_LOCK                                ((uint16_t)0x0300) /* LOCK[1:0] bits (Lock Configuration) */
+#define TIM_LOCK_0                              ((uint16_t)0x0100) /* Bit 0 */
+#define TIM_LOCK_1                              ((uint16_t)0x0200) /* Bit 1 */
+
+#define TIM_OSSI                                ((uint16_t)0x0400) /* Off-State Selection for Idle mode */
+#define TIM_OSSR                                ((uint16_t)0x0800) /* Off-State Selection for Run mode */
+#define TIM_BKE                                 ((uint16_t)0x1000) /* Break enable */
+#define TIM_BKP                                 ((uint16_t)0x2000) /* Break Polarity */
+#define TIM_AOE                                 ((uint16_t)0x4000) /* Automatic Output enable */
+#define TIM_MOE                                 ((uint16_t)0x8000) /* Main Output enable */
+
+/*******************  Bit definition for TIM_DMACFGR register  ********************/
+#define TIM_DBA                                 ((uint16_t)0x001F) /* DBA[4:0] bits (DMA Base Address) */
+#define TIM_DBA_0                               ((uint16_t)0x0001) /* Bit 0 */
+#define TIM_DBA_1                               ((uint16_t)0x0002) /* Bit 1 */
+#define TIM_DBA_2                               ((uint16_t)0x0004) /* Bit 2 */
+#define TIM_DBA_3                               ((uint16_t)0x0008) /* Bit 3 */
+#define TIM_DBA_4                               ((uint16_t)0x0010) /* Bit 4 */
+
+#define TIM_DBL                                 ((uint16_t)0x1F00) /* DBL[4:0] bits (DMA Burst Length) */
+#define TIM_DBL_0                               ((uint16_t)0x0100) /* Bit 0 */
+#define TIM_DBL_1                               ((uint16_t)0x0200) /* Bit 1 */
+#define TIM_DBL_2                               ((uint16_t)0x0400) /* Bit 2 */
+#define TIM_DBL_3                               ((uint16_t)0x0800) /* Bit 3 */
+#define TIM_DBL_4                               ((uint16_t)0x1000) /* Bit 4 */
+
+/*******************  Bit definition for TIM_DMAADR register  *******************/
+#define TIM_DMAR_DMAB                           ((uint16_t)0xFFFF) /* DMA register for burst accesses */
+
+/******************************************************************************/
+/*         Universal Synchronous Asynchronous Receiver Transmitter            */
+/******************************************************************************/
+
+/*******************  Bit definition for USART_STATR register  *******************/
+#define USART_STATR_PE                          ((uint16_t)0x0001) /* Parity Error */
+#define USART_STATR_FE                          ((uint16_t)0x0002) /* Framing Error */
+#define USART_STATR_NE                          ((uint16_t)0x0004) /* Noise Error Flag */
+#define USART_STATR_ORE                         ((uint16_t)0x0008) /* OverRun Error */
+#define USART_STATR_IDLE                        ((uint16_t)0x0010) /* IDLE line detected */
+#define USART_STATR_RXNE                        ((uint16_t)0x0020) /* Read Data Register Not Empty */
+#define USART_STATR_TC                          ((uint16_t)0x0040) /* Transmission Complete */
+#define USART_STATR_TXE                         ((uint16_t)0x0080) /* Transmit Data Register Empty */
+#define USART_STATR_LBD                         ((uint16_t)0x0100) /* LIN Break Detection Flag */
+#define USART_STATR_CTS                         ((uint16_t)0x0200) /* CTS Flag */
+
+/*******************  Bit definition for USART_DATAR register  *******************/
+#define USART_DATAR_DR                          ((uint16_t)0x01FF) /* Data value */
+
+/******************  Bit definition for USART_BRR register  *******************/
+#define USART_BRR_DIV_Fraction                  ((uint16_t)0x000F) /* Fraction of USARTDIV */
+#define USART_BRR_DIV_Mantissa                  ((uint16_t)0xFFF0) /* Mantissa of USARTDIV */
+
+/******************  Bit definition for USART_CTLR1 register  *******************/
+#define USART_CTLR1_SBK                         ((uint16_t)0x0001) /* Send Break */
+#define USART_CTLR1_RWU                         ((uint16_t)0x0002) /* Receiver wakeup */
+#define USART_CTLR1_RE                          ((uint16_t)0x0004) /* Receiver Enable */
+#define USART_CTLR1_TE                          ((uint16_t)0x0008) /* Transmitter Enable */
+#define USART_CTLR1_IDLEIE                      ((uint16_t)0x0010) /* IDLE Interrupt Enable */
+#define USART_CTLR1_RXNEIE                      ((uint16_t)0x0020) /* RXNE Interrupt Enable */
+#define USART_CTLR1_TCIE                        ((uint16_t)0x0040) /* Transmission Complete Interrupt Enable */
+#define USART_CTLR1_TXEIE                       ((uint16_t)0x0080) /* PE Interrupt Enable */
+#define USART_CTLR1_PEIE                        ((uint16_t)0x0100) /* PE Interrupt Enable */
+#define USART_CTLR1_PS                          ((uint16_t)0x0200) /* Parity Selection */
+#define USART_CTLR1_PCE                         ((uint16_t)0x0400) /* Parity Control Enable */
+#define USART_CTLR1_WAKE                        ((uint16_t)0x0800) /* Wakeup method */
+#define USART_CTLR1_M                           ((uint16_t)0x1000) /* Word length */
+#define USART_CTLR1_UE                          ((uint16_t)0x2000) /* USART Enable */
+#define USART_CTLR1_OVER8                       ((uint16_t)0x8000) /* USART Oversmapling 8-bits */
+
+/******************  Bit definition for USART_CTLR2 register  *******************/
+#define USART_CTLR2_ADD                         ((uint16_t)0x000F) /* Address of the USART node */
+#define USART_CTLR2_LBDL                        ((uint16_t)0x0020) /* LIN Break Detection Length */
+#define USART_CTLR2_LBDIE                       ((uint16_t)0x0040) /* LIN Break Detection Interrupt Enable */
+#define USART_CTLR2_LBCL                        ((uint16_t)0x0100) /* Last Bit Clock pulse */
+#define USART_CTLR2_CPHA                        ((uint16_t)0x0200) /* Clock Phase */
+#define USART_CTLR2_CPOL                        ((uint16_t)0x0400) /* Clock Polarity */
+#define USART_CTLR2_CLKEN                       ((uint16_t)0x0800) /* Clock Enable */
+
+#define USART_CTLR2_STOP                        ((uint16_t)0x3000) /* STOP[1:0] bits (STOP bits) */
+#define USART_CTLR2_STOP_0                      ((uint16_t)0x1000) /* Bit 0 */
+#define USART_CTLR2_STOP_1                      ((uint16_t)0x2000) /* Bit 1 */
+
+#define USART_CTLR2_LINEN                       ((uint16_t)0x4000) /* LIN mode enable */
+
+/******************  Bit definition for USART_CTLR3 register  *******************/
+#define USART_CTLR3_EIE                         ((uint16_t)0x0001) /* Error Interrupt Enable */
+#define USART_CTLR3_IREN                        ((uint16_t)0x0002) /* IrDA mode Enable */
+#define USART_CTLR3_IRLP                        ((uint16_t)0x0004) /* IrDA Low-Power */
+#define USART_CTLR3_HDSEL                       ((uint16_t)0x0008) /* Half-Duplex Selection */
+#define USART_CTLR3_NACK                        ((uint16_t)0x0010) /* Smartcard NACK enable */
+#define USART_CTLR3_SCEN                        ((uint16_t)0x0020) /* Smartcard mode enable */
+#define USART_CTLR3_DMAR                        ((uint16_t)0x0040) /* DMA Enable Receiver */
+#define USART_CTLR3_DMAT                        ((uint16_t)0x0080) /* DMA Enable Transmitter */
+#define USART_CTLR3_RTSE                        ((uint16_t)0x0100) /* RTS Enable */
+#define USART_CTLR3_CTSE                        ((uint16_t)0x0200) /* CTS Enable */
+#define USART_CTLR3_CTSIE                       ((uint16_t)0x0400) /* CTS Interrupt Enable */
+#define USART_CTLR3_ONEBIT                      ((uint16_t)0x0800) /* One Bit method */
+
+/******************  Bit definition for USART_GPR register  ******************/
+#define USART_GPR_PSC                           ((uint16_t)0x00FF) /* PSC[7:0] bits (Prescaler value) */
+#define USART_GPR_PSC_0                         ((uint16_t)0x0001) /* Bit 0 */
+#define USART_GPR_PSC_1                         ((uint16_t)0x0002) /* Bit 1 */
+#define USART_GPR_PSC_2                         ((uint16_t)0x0004) /* Bit 2 */
+#define USART_GPR_PSC_3                         ((uint16_t)0x0008) /* Bit 3 */
+#define USART_GPR_PSC_4                         ((uint16_t)0x0010) /* Bit 4 */
+#define USART_GPR_PSC_5                         ((uint16_t)0x0020) /* Bit 5 */
+#define USART_GPR_PSC_6                         ((uint16_t)0x0040) /* Bit 6 */
+#define USART_GPR_PSC_7                         ((uint16_t)0x0080) /* Bit 7 */
+
+#define USART_GPR_GT                            ((uint16_t)0xFF00) /* Guard time value */
+
+/******************************************************************************/
+/*                            Window WATCHDOG                                 */
+/******************************************************************************/
+
+/*******************  Bit definition for WWDG_CTLR register  ********************/
+#define WWDG_CTLR_T                             ((uint8_t)0x7F) /* T[6:0] bits (7-Bit counter (MSB to LSB)) */
+#define WWDG_CTLR_T0                            ((uint8_t)0x01) /* Bit 0 */
+#define WWDG_CTLR_T1                            ((uint8_t)0x02) /* Bit 1 */
+#define WWDG_CTLR_T2                            ((uint8_t)0x04) /* Bit 2 */
+#define WWDG_CTLR_T3                            ((uint8_t)0x08) /* Bit 3 */
+#define WWDG_CTLR_T4                            ((uint8_t)0x10) /* Bit 4 */
+#define WWDG_CTLR_T5                            ((uint8_t)0x20) /* Bit 5 */
+#define WWDG_CTLR_T6                            ((uint8_t)0x40) /* Bit 6 */
+
+#define WWDG_CTLR_WDGA                          ((uint8_t)0x80) /* Activation bit */
+
+/*******************  Bit definition for WWDG_CFGR register  *******************/
+#define WWDG_CFGR_W                             ((uint16_t)0x007F) /* W[6:0] bits (7-bit window value) */
+#define WWDG_CFGR_W0                            ((uint16_t)0x0001) /* Bit 0 */
+#define WWDG_CFGR_W1                            ((uint16_t)0x0002) /* Bit 1 */
+#define WWDG_CFGR_W2                            ((uint16_t)0x0004) /* Bit 2 */
+#define WWDG_CFGR_W3                            ((uint16_t)0x0008) /* Bit 3 */
+#define WWDG_CFGR_W4                            ((uint16_t)0x0010) /* Bit 4 */
+#define WWDG_CFGR_W5                            ((uint16_t)0x0020) /* Bit 5 */
+#define WWDG_CFGR_W6                            ((uint16_t)0x0040) /* Bit 6 */
+
+#define WWDG_CFGR_WDGTB                         ((uint16_t)0x0180) /* WDGTB[1:0] bits (Timer Base) */
+#define WWDG_CFGR_WDGTB0                        ((uint16_t)0x0080) /* Bit 0 */
+#define WWDG_CFGR_WDGTB1                        ((uint16_t)0x0100) /* Bit 1 */
+
+#define WWDG_CFGR_EWI                           ((uint16_t)0x0200) /* Early Wakeup Interrupt */
+
+/*******************  Bit definition for WWDG_STATR register  ********************/
+#define WWDG_STATR_EWIF                         ((uint8_t)0x01) /* Early Wakeup Interrupt Flag */
+
+/******************************************************************************/
+/*                          ENHANCED FUNNCTION                                */
+/******************************************************************************/
+
+/****************************  Enhanced register  *****************************/
+#define EXTEN_USBD_LS                           ((uint32_t)0x00000001) /* Bit 0 */
+#define EXTEN_USBD_PU_EN                        ((uint32_t)0x00000002) /* Bit 1 */
+#define EXTEN_ETH_10M_EN                        ((uint32_t)0x00000004) /* Bit 2 */
+#define EXTEN_PLL_HSI_PRE                       ((uint32_t)0x00000010) /* Bit 4 */
+#define EXTEN_LOCKUP_EN                         ((uint32_t)0x00000040) /* Bit 5 */
+#define EXTEN_LOCKUP_RSTF                       ((uint32_t)0x00000080) /* Bit 7 */
+
+#define EXTEN_ULLDO_TRIM                        ((uint32_t)0x00000300) /* ULLDO_TRIM[1:0] bits */
+#define EXTEN_ULLDO_TRIM0                       ((uint32_t)0x00000100) /* Bit 0 */
+#define EXTEN_ULLDO_TRIM1                       ((uint32_t)0x00000200) /* Bit 1 */
+
+#define EXTEN_LDO_TRIM                          ((uint32_t)0x00000C00) /* LDO_TRIM[1:0] bits */
+#define EXTEN_LDO_TRIM0                         ((uint32_t)0x00000400) /* Bit 0 */
+#define EXTEN_LDO_TRIM1                         ((uint32_t)0x00000800) /* Bit 1 */
+
+/******************************************************************************/
+/*                                  DVP                                       */
+/******************************************************************************/
+
+/*******************  Bit definition for DVP_CR0 register  ********************/
+#define RB_DVP_ENABLE                           0x01  // RW, DVP enable
+#define RB_DVP_V_POLAR                          0x02  // RW, DVP VSYNC polarity control: 1 = invert, 0 = not invert
+#define RB_DVP_H_POLAR                          0x04  // RW, DVP HSYNC polarity control: 1 = invert, 0 = not invert
+#define RB_DVP_P_POLAR                          0x08  // RW, DVP PCLK polarity control: 1 = invert, 0 = not invert
+#define RB_DVP_MSK_DAT_MOD                      0x30
+#define RB_DVP_D8_MOD                           0x00  // RW, DVP 8bits data mode
+#define RB_DVP_D10_MOD                          0x10  // RW, DVP 10bits data mode
+#define RB_DVP_D12_MOD                          0x20  // RW, DVP 12bits data mode
+#define RB_DVP_JPEG                             0x40  // RW, DVP JPEG mode
+
+/*******************  Bit definition for DVP_CR1 register  ********************/
+#define RB_DVP_DMA_EN                           0x01  // RW, DVP dma enable
+#define RB_DVP_ALL_CLR                          0x02  // RW, DVP all clear, high action
+#define RB_DVP_RCV_CLR                          0x04  // RW, DVP receive logic clear, high action
+#define RB_DVP_BUF_TOG                          0x08  // RW, DVP bug toggle by software, write 1 to toggle, ignored writing 0
+#define RB_DVP_CM                               0x10  // RW, DVP capture mode
+#define RB_DVP_CROP                             0x20  // RW, DVP Crop feature enable
+#define RB_DVP_FCRC                             0xC0  // RW, DVP frame capture rate control:
+#define DVP_RATE_100P                           0x00  //00 = every frame captured (100%)
+#define DVP_RATE_50P                            0x40  //01 = every alternate frame captured (50%)
+#define DVP_RATE_25P                            0x80  //10 = one frame in four frame captured (25%)
+
+/*******************  Bit definition for DVP_IER register  ********************/
+#define RB_DVP_IE_STR_FRM                       0x01  // RW, DVP frame start interrupt enable
+#define RB_DVP_IE_ROW_DONE                      0x02  // RW, DVP row received done interrupt enable
+#define RB_DVP_IE_FRM_DONE                      0x04  // RW, DVP frame received done interrupt enable
+#define RB_DVP_IE_FIFO_OV                       0x08  // RW, DVP receive fifo overflow interrupt enable
+#define RB_DVP_IE_STP_FRM                       0x10  // RW, DVP frame stop interrupt enable
+
+/*******************  Bit definition for DVP_IFR register  ********************/
+#define RB_DVP_IF_STR_FRM                       0x01  // RW1, interrupt flag for DVP frame start
+#define RB_DVP_IF_ROW_DONE                      0x02  // RW1, interrupt flag for DVP row receive done
+#define RB_DVP_IF_FRM_DONE                      0x04  // RW1, interrupt flag for DVP frame receive done
+#define RB_DVP_IF_FIFO_OV                       0x08  // RW1, interrupt flag for DVP receive fifo overflow
+#define RB_DVP_IF_STP_FRM                       0x10  // RW1, interrupt flag for DVP frame stop
+
+/*******************  Bit definition for DVP_STATUS register  ********************/
+#define RB_DVP_FIFO_RDY                         0x01  // RO, DVP receive fifo ready
+#define RB_DVP_FIFO_FULL                        0x02  // RO, DVP receive fifo full
+#define RB_DVP_FIFO_OV                          0x04  // RO, DVP receive fifo overflow
+#define RB_DVP_MSK_FIFO_CNT                     0x70  // RO, DVP receive fifo count
+
+
+/******************************************************************************/
+/*                                  ETH10M                                    */
+/******************************************************************************/
+/* ETH register */
+#define R8_ETH_EIE              (*((volatile uint8_t *)(0x40028000+3))) /* Interrupt Enable Register */
+#define  RB_ETH_EIE_INTIE       0x80                  /* RW interrupt enable*/
+#define  RB_ETH_EIE_RXIE        0x40                  /* RW Receive complete interrupt enable */
+#define  RB_ETH_EIE_LINKIE      0x10                  /* RW Link Change Interrupt Enable */
+#define  RB_ETH_EIE_TXIE        0x08                  /* RW send complete interrupt enable */
+#define  RB_ETH_EIE_R_EN50      0x04                  /* RW TX 50�� resistor adjustment. 1: On-chip 50�� connected 0: On-chip 50�� disconnected */
+#define  RB_ETH_EIE_TXERIE      0x02                  /* RW Transmit Error Interrupt Enable */
+#define  RB_ETH_EIE_RXERIE      0x01                  /* RW1 receive error flag */
+#define R8_ETH_EIR              (*((volatile uint8_t *)(0x40028000+4))) /* Interrupt Flag Register */
+#define  RB_ETH_EIR_RXIF        0x40                  /* RW1 Receive complete flag */
+#define  RB_ETH_EIR_LINKIF      0x10                  /* RW1 Link Change Flag */
+#define  RB_ETH_EIR_TXIF        0x08                  /* RW1 Link Change Flag */
+#define  RB_ETH_EIR_TXERIF      0x02                  /* RW1 send error flag */
+#define  RB_ETH_EIR_RXERIF      0x01                  /* RW1 receive error flag */
+#define R8_ETH_ESTAT            (*((volatile uint8_t *)(0x40028000+5))) /* status register */
+#define  RB_ETH_ESTAT_INT       0x80                  /* RW1 interrupt */
+#define  RB_ETH_ESTAT_BUFER     0x40                  /* RW1 Buffer error */
+#define  RB_ETH_ESTAT_RXCRCER   0x20                  /* RO receive crc error */
+#define  RB_ETH_ESTAT_RXNIBBLE  0x10                  /* RO receives nibble error */
+#define  RB_ETH_ESTAT_RXMORE    0x08                  /* RO receives more than maximum packets */
+#define  RB_ETH_ESTAT_RXBUSY    0x04                  /* RO receive busy */
+#define  RB_ETH_ESTAT_TXABRT    0x02                  /* RO send interrupted by mcu */
+#define R8_ETH_ECON2            (*((volatile uint8_t *)(0x40028000+6))) /* ETH PHY Analog Block Control Register */
+#define  RB_ETH_ECON2_RX        0x0E                  /* 011b must be written */
+#define  RB_ETH_ECON2_TX        0x01
+#define  RB_ETH_ECON2_MUST      0x06                  /* 011b must be written */
+#define R8_ETH_ECON1            (*((volatile uint8_t *)(0x40028000+7))) /* Transceiver Control Register */
+#define  RB_ETH_ECON1_TXRST     0x80                  /* RW Send module reset */
+#define  RB_ETH_ECON1_RXRST     0x40                  /* RW Receiver module reset */
+#define  RB_ETH_ECON1_TXRTS     0x08                  /* RW The transmission starts, and it is automatically cleared after the transmission is completed. */
+#define  RB_ETH_ECON1_RXEN      0x04                  /* RW Receive is enabled, when cleared, the error flag RXERIF will change to 1 if it is receiving */
+
+#define R32_ETH_TX              (*((volatile uint32_t *)(0x40028000+8))) /* send control */
+#define R16_ETH_ETXST           (*((volatile uint16_t *)(0x40028000+8))) /* RW Send DMA buffer start address */
+#define R16_ETH_ETXLN           (*((volatile uint16_t *)(0x40028000+0xA))) /* RW send length */
+#define R32_ETH_RX              (*((volatile uint32_t *)(0x40028000+0xC))) /* receive control */
+#define R16_ETH_ERXST           (*((volatile uint16_t *)(0x40028000+0xC))) /* RW Receive DMA buffer start address */
+#define R16_ETH_ERXLN           (*((volatile uint16_t *)(0x40028000+0xE))) /* RO receive length */
+
+#define R32_ETH_HTL             (*((volatile uint32_t *)(0x40028000+0x10)))
+#define R8_ETH_EHT0             (*((volatile uint8_t *)(0x40028000+0x10))) /* RW Hash Table Byte0 */
+#define R8_ETH_EHT1             (*((volatile uint8_t *)(0x40028000+0x11))) /* RW Hash Table Byte1 */
+#define R8_ETH_EHT2             (*((volatile uint8_t *)(0x40028000+0x12))) /* RW Hash Table Byte2 */
+#define R8_ETH_EHT3             (*((volatile uint8_t *)(0x40028000+0x13))) /* RW Hash Table Byte3 */
+#define R32_ETH_HTH             (*((volatile uint32_t *)(0x40028000+0x14)))
+#define R8_ETH_EHT4             (*((volatile uint8_t *)(0x40028000+0x14))) /* RW Hash Table Byte4 */
+#define R8_ETH_EHT5             (*((volatile uint8_t *)(0x40028000+0x15))) /* RW Hash Table Byte5 */
+#define R8_ETH_EHT6             (*((volatile uint8_t *)(0x40028000+0x16))) /* RW Hash Table Byte6 */
+#define R8_ETH_EHT7             (*((volatile uint8_t *)(0x40028000+0x17))) /* RW Hash Table Byte7 */
+
+#define R32_ETH_MACON           (*((volatile uint32_t *)(0x40028000+0x18)))
+#define R8_ETH_ERXFCON          (*((volatile uint8_t *)(0x40028000+0x18))) /* Received Packet Filtering Control Register */
+/* RW 0=Do not enable this filter condition, 1=When ANDOR=1,
+target address mismatch will be filtered, when ANDOR=0, target address match will be accepted */
+#define  RB_ETH_ERXFCON_UCEN    0x80
+#define  RB_ETH_ERXFCON_CRCEN   0x20
+#define  RB_ETH_ERXFCON_EN      0x10
+#define  RB_ETH_ERXFCON_MPEN    0x08
+#define  RB_ETH_ERXFCON_HTEN    0x04
+#define  RB_ETH_ERXFCON_MCEN    0x02
+#define  RB_ETH_ERXFCON_BCEN    0x01
+#define R8_ETH_MACON1           (*((volatile uint8_t *)(0x40028000+0x19))) /* Mac flow control registers */
+/* RW When FULDPX=0 is invalid, when FULDPX=1, 11=send 0 timer pause frame,
+then stop sending, 10=send pause frame periodically, 01=send pause frame once, then stop sending, 00=stop sending pause frame */
+#define  RB_ETH_MACON1_FCEN     0x30
+#define  RB_ETH_MACON1_TXPAUS   0x08                  /* RW Send pause frame enable*/
+#define  RB_ETH_MACON1_RXPAUS   0x04                  /* RW Receive pause frame enable */
+#define  RB_ETH_MACON1_PASSALL  0x02                  /* RW 1=Unfiltered control frames will be written to the buffer, 0=Control frames will be filtered */
+#define  RB_ETH_MACON1_MARXEN   0x01                  /* RW MAC layer receive enable */
+#define R8_ETH_MACON2           (*((volatile uint8_t *)(0x40028000+0x1A))) /* Mac Layer Packet Control Register */
+#define  RB_ETH_MACON2_PADCFG   0xE0                  /* RW Short Packet Padding Settings */
+#define  RB_ETH_MACON2_TXCRCEN  0x10                  /* RW Send to add crc, if you need to add crc in PADCFG, this position is 1 */
+#define  RB_ETH_MACON2_PHDREN   0x08                  /* RW Special 4 bytes do not participate in crc check */
+#define  RB_ETH_MACON2_HFRMEN   0x04                  /* RW Allow jumbo frames */
+#define  RB_ETH_MACON2_FULDPX   0x01                  /* RW full duplex */
+#define R8_ETH_MABBIPG          (*((volatile uint8_t *)(0x40028000+0x1B))) /* Minimum Interpacket Interval Register */
+#define  RB_ETH_MABBIPG_MABBIPG 0x7F                  /* RW Minimum number of bytes between packets */
+
+#define R32_ETH_TIM             (*((volatile uint32_t *)(0x40028000+0x1C)))
+#define R16_ETH_EPAUS           (*((volatile uint16_t *)(0x40028000+0x1C))) /* RW Flow Control Pause Frame Time Register */
+#define R16_ETH_MAMXFL          (*((volatile uint16_t *)(0x40028000+0x1E))) /* RW Maximum Received Packet Length Register */
+#define R16_ETH_MIRD            (*((volatile uint16_t *)(0x40028000+0x20))) /* RW MII read data register */
+
+#define R32_ETH_MIWR            (*((volatile uint32_t *)(0x40028000+0x24)))
+#define R8_ETH_MIREGADR         (*((volatile uint8_t *)(0x40028000+0x24))) /* MII address register*/
+#define  RB_ETH_MIREGADR_MASK   0x1F                  /* RW PHY register address mask */
+#define R8_ETH_MISTAT           (*((volatile uint8_t *)(0x40028000+0x25))) /* RW PHY register address mask */
+//#define  RB_ETH_MIREGADR_MIIWR  0x20                  /* WO MII write command */
+#define R16_ETH_MIWR            (*((volatile uint16_t *)(0x40028000+0x26))) /* WO MII Write Data Register */
+#define R32_ETH_MAADRL          (*((volatile uint32_t *)(0x40028000+0x28))) /* RW MAC 1-4 */
+#define R8_ETH_MAADRL1          (*((volatile uint8_t *)(0x40028000+0x28))) /* RW MAC 1 */
+#define R8_ETH_MAADRL2          (*((volatile uint8_t *)(0x40028000+0x29))) /* RW MAC 2 */
+#define R8_ETH_MAADRL3          (*((volatile uint8_t *)(0x40028000+0x2A))) /* RW MAC 3 */
+#define R8_ETH_MAADRL4          (*((volatile uint8_t *)(0x40028000+0x2B))) /* RW MAC 4 */
+#define R16_ETH_MAADRH          (*((volatile uint16_t *)(0x40028000+0x2C))) /* RW MAC 5-6 */
+#define R8_ETH_MAADRL5          (*((volatile uint8_t *)(0x40028000+0x2C))) /* RW MAC 4 */
+#define R8_ETH_MAADRL6          (*((volatile uint8_t *)(0x40028000+0x2D))) /* RW MAC 4 */
+
+//PHY address
+#define PHY_BMCR                0x00                                            /* Control Register */
+#define PHY_BMSR                0x01                                            /* Status Register */
+#define PHY_ANAR                0x04                                            /* Auto-Negotiation Advertisement Register */
+#define PHY_ANLPAR              0x05                                            /* Auto-Negotiation Link Partner Base  Page Ability Register*/
+#define PHY_ANER                0x06                                            /* Auto-Negotiation Expansion Register */
+#define PHY_MDIX                0x1e                                            /* Custom MDIX Mode Register */
+//Custom MDIX Mode Register  @PHY_MDIX
+#define PN_NORMAL               0x04                                            /* Analog p, n polarity selection */
+#define MDIX_MODE_MASK          0x03                                            /* mdix settings */
+#define MDIX_MODE_AUTO          0x00                                            /*  */
+#define MDIX_MODE_MDIX          0x01
+#define MDIX_MODE_MDI           0x02
+//ECON2 test mode, to be determined
+#define RX_VCM_MODE_0
+#define RX_VCM_MODE_1
+#define RX_VCM_MODE_2
+#define RX_VCM_MODE_3
+//RX reference voltage value setting  @RX_REF
+#define RX_REF_25mV             (0<<2)                                          /* 25mV */
+#define RX_REF_49mV             (1<<2)                                          /* 49mV */
+#define RX_REF_74mV             (2<<2)                                          /* 74mV */
+#define RX_REF_98mV             (3<<2)                                          /* 98mV */
+#define RX_REF_123mV            (4<<2)                                          /* 123mV */
+#define RX_REF_148mV            (5<<2)                                          /* 148mV */
+#define RX_REF_173mV            (6<<2)                                          /* 173mV */
+#define RX_REF_198mV            (7<<2)                                          /* 198mV */
+//TX DRIVER Bias Current  @TX_AMP
+#define TX_AMP_0                (0<<0)                                          /* 43mA   / 14.5mA   (1.4V/0.7V) */
+#define TX_AMP_1                (1<<0)                                          /* 53.1mA / 18mA     (1.8V/0.9V) */
+#define TX_AMP_2                (2<<0)                                          /* 75.6mA / 25.6mA   (2.6V/1.3V) */
+#define TX_AMP_3                (3<<0)                                          /* 122mA  / 41.45mA  (4.1V/2.3V) */
+//FCEN pause frame control      @FCEN
+#define FCEN_0_TIMER            (3<<4)                                          /* Send a 0 timer pause frame, then stop sending */
+#define FCEN_CYCLE              (2<<4)                                          /* Periodically send pause frames */
+#define FCEN_ONCE               (1<<4)                                          /* Send pause frame once, then stop sending */
+#define FCEN_STOP               (0<<4)                                          /* Stop sending pause frames */
+//PADCFG short packet control  @PADCFG
+#define PADCFG_AUTO_0           (7<<5)                                          /* All short packets are filled with 00h to 64 bytes, then 4 bytes crc */
+#define PADCFG_NO_ACT_0         (6<<5)                                          /* No padding for short packets */
+/* The detected VLAN network packet whose field is 8100h is automatically filled
+with 00h to 64 bytes, otherwise the short packet is filled with 60 bytes of 0, and then 4 bytes of crc after filling */
+#define PADCFG_DETE_AUTO        (5<<5)
+#define PADCFG_NO_ACT_1         (4<<5)                                          /* No padding for short packets */
+#define PADCFG_AUTO_1           (3<<5)                                          /* All short packets are filled with 00h to 64 bytes, then 4 bytes crc */
+#define PADCFG_NO_ACT_2         (2<<5)                                          /* No padding for short packets */
+#define PADCFG_AUTO_3           (1<<5)                                          /* All short packets are filled with 00h to 60 bytes, and then 4 bytes crc */
+#define PADCFG_NO_ACT_3         (0<<5)                                          /* No padding for short packets */
+
+/* Bit or field definition for PHY basic status register */
+#define PHY_Linked_Status       ((uint16_t)0x0004)      /* Valid link established */
+
+#define PHY_Reset                               ((uint16_t)0x8000)      /* PHY Reset */
+
+#define PHY_AutoNego_Complete                   ((uint16_t)0x0020)      /* Auto-Negotioation process completed */
+
+//MII control
+#define  RB_ETH_MIREGADR_MIIWR  0x20                                            /* WO MII write command */
+#define  RB_ETH_MIREGADR_MIRDL  0x1f                                            /* RW PHY register address */
+
+
+#include "ch32v20x_conf.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Sources/source/Peripheral/inc/ch32v20x_exti.h
+++ b/Sources/source/Peripheral/inc/ch32v20x_exti.h
@@ -1,0 +1,95 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32v20x_exti.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/06/06
+ * Description        : This file contains all the functions prototypes for the
+ *                      EXTI firmware library.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __CH32V20x_EXTI_H
+#define __CH32V20x_EXTI_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "ch32v20x.h"
+
+/* EXTI mode enumeration */
+typedef enum
+{
+    EXTI_Mode_Interrupt = 0x00,
+    EXTI_Mode_Event = 0x04
+} EXTIMode_TypeDef;
+
+/* EXTI Trigger enumeration */
+typedef enum
+{
+    EXTI_Trigger_Rising = 0x08,
+    EXTI_Trigger_Falling = 0x0C,
+    EXTI_Trigger_Rising_Falling = 0x10
+} EXTITrigger_TypeDef;
+
+/* EXTI Init Structure definition */
+typedef struct
+{
+    uint32_t EXTI_Line; /* Specifies the EXTI lines to be enabled or disabled.
+                           This parameter can be any combination of @ref EXTI_Lines */
+
+    EXTIMode_TypeDef EXTI_Mode; /* Specifies the mode for the EXTI lines.
+                                   This parameter can be a value of @ref EXTIMode_TypeDef */
+
+    EXTITrigger_TypeDef EXTI_Trigger; /* Specifies the trigger signal active edge for the EXTI lines.
+                                         This parameter can be a value of @ref EXTIMode_TypeDef */
+
+    FunctionalState EXTI_LineCmd; /* Specifies the new state of the selected EXTI lines.
+                                     This parameter can be set either to ENABLE or DISABLE */
+} EXTI_InitTypeDef;
+
+/* EXTI_Lines */
+#define EXTI_Line0     ((uint32_t)0x00001)  /* External interrupt line 0 */
+#define EXTI_Line1     ((uint32_t)0x00002)  /* External interrupt line 1 */
+#define EXTI_Line2     ((uint32_t)0x00004)  /* External interrupt line 2 */
+#define EXTI_Line3     ((uint32_t)0x00008)  /* External interrupt line 3 */
+#define EXTI_Line4     ((uint32_t)0x00010)  /* External interrupt line 4 */
+#define EXTI_Line5     ((uint32_t)0x00020)  /* External interrupt line 5 */
+#define EXTI_Line6     ((uint32_t)0x00040)  /* External interrupt line 6 */
+#define EXTI_Line7     ((uint32_t)0x00080)  /* External interrupt line 7 */
+#define EXTI_Line8     ((uint32_t)0x00100)  /* External interrupt line 8 */
+#define EXTI_Line9     ((uint32_t)0x00200)  /* External interrupt line 9 */
+#define EXTI_Line10    ((uint32_t)0x00400)  /* External interrupt line 10 */
+#define EXTI_Line11    ((uint32_t)0x00800)  /* External interrupt line 11 */
+#define EXTI_Line12    ((uint32_t)0x01000)  /* External interrupt line 12 */
+#define EXTI_Line13    ((uint32_t)0x02000)  /* External interrupt line 13 */
+#define EXTI_Line14    ((uint32_t)0x04000)  /* External interrupt line 14 */
+#define EXTI_Line15    ((uint32_t)0x08000)  /* External interrupt line 15 */
+#define EXTI_Line16    ((uint32_t)0x10000)  /* External interrupt line 16 Connected to the PVD Output */
+#define EXTI_Line17    ((uint32_t)0x20000)  /* External interrupt line 17 Connected to the RTC Alarm event */
+#define EXTI_Line18    ((uint32_t)0x40000)  /* External interrupt line 18 Connected to the USBD Device \
+                                               Wakeup from suspend event */
+#define EXTI_Line19    ((uint32_t)0x80000)  /* External interrupt line 19 Connected to the Ethernet Wakeup event */
+#define EXTI_Line20    ((uint32_t)0x100000) /* External interrupt line 20 Connected to the USBFS Wakeup event */
+
+#if defined(CH32V20x_D8) || defined(CH32V20x_D8W)
+  #define EXTI_Line21    ((uint32_t)0x200000) /* External interrupt line 21 Connected to the OSCCAL Wakeup event */
+
+#endif
+
+void       EXTI_DeInit(void);
+void       EXTI_Init(EXTI_InitTypeDef *EXTI_InitStruct);
+void       EXTI_StructInit(EXTI_InitTypeDef *EXTI_InitStruct);
+void       EXTI_GenerateSWInterrupt(uint32_t EXTI_Line);
+FlagStatus EXTI_GetFlagStatus(uint32_t EXTI_Line);
+void       EXTI_ClearFlag(uint32_t EXTI_Line);
+ITStatus   EXTI_GetITStatus(uint32_t EXTI_Line);
+void       EXTI_ClearITPendingBit(uint32_t EXTI_Line);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Sources/source/Peripheral/inc/ch32v20x_gpio.h
+++ b/Sources/source/Peripheral/inc/ch32v20x_gpio.h
@@ -1,0 +1,189 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32v20x_gpio.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/06/06
+ * Description        : This file contains all the functions prototypes for the
+ *                      GPIO firmware library.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __CH32V20x_GPIO_H
+#define __CH32V20x_GPIO_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "ch32v20x.h"
+
+/* Output Maximum frequency selection */
+typedef enum
+{
+    GPIO_Speed_10MHz = 1,
+    GPIO_Speed_2MHz,
+    GPIO_Speed_50MHz
+} GPIOSpeed_TypeDef;
+
+/* Configuration Mode enumeration */
+typedef enum
+{
+    GPIO_Mode_AIN = 0x0,
+    GPIO_Mode_IN_FLOATING = 0x04,
+    GPIO_Mode_IPD = 0x28,
+    GPIO_Mode_IPU = 0x48,
+    GPIO_Mode_Out_OD = 0x14,
+    GPIO_Mode_Out_PP = 0x10,
+    GPIO_Mode_AF_OD = 0x1C,
+    GPIO_Mode_AF_PP = 0x18
+} GPIOMode_TypeDef;
+
+/* GPIO Init structure definition */
+typedef struct
+{
+    uint16_t GPIO_Pin; /* Specifies the GPIO pins to be configured.
+                          This parameter can be any value of @ref GPIO_pins_define */
+
+    GPIOSpeed_TypeDef GPIO_Speed; /* Specifies the speed for the selected pins.
+                                     This parameter can be a value of @ref GPIOSpeed_TypeDef */
+
+    GPIOMode_TypeDef GPIO_Mode; /* Specifies the operating mode for the selected pins.
+                                   This parameter can be a value of @ref GPIOMode_TypeDef */
+} GPIO_InitTypeDef;
+
+/* Bit_SET and Bit_RESET enumeration */
+typedef enum
+{
+    Bit_RESET = 0,
+    Bit_SET
+} BitAction;
+
+/* GPIO_pins_define */
+#define GPIO_Pin_0                      ((uint16_t)0x0001) /* Pin 0 selected */
+#define GPIO_Pin_1                      ((uint16_t)0x0002) /* Pin 1 selected */
+#define GPIO_Pin_2                      ((uint16_t)0x0004) /* Pin 2 selected */
+#define GPIO_Pin_3                      ((uint16_t)0x0008) /* Pin 3 selected */
+#define GPIO_Pin_4                      ((uint16_t)0x0010) /* Pin 4 selected */
+#define GPIO_Pin_5                      ((uint16_t)0x0020) /* Pin 5 selected */
+#define GPIO_Pin_6                      ((uint16_t)0x0040) /* Pin 6 selected */
+#define GPIO_Pin_7                      ((uint16_t)0x0080) /* Pin 7 selected */
+#define GPIO_Pin_8                      ((uint16_t)0x0100) /* Pin 8 selected */
+#define GPIO_Pin_9                      ((uint16_t)0x0200) /* Pin 9 selected */
+#define GPIO_Pin_10                     ((uint16_t)0x0400) /* Pin 10 selected */
+#define GPIO_Pin_11                     ((uint16_t)0x0800) /* Pin 11 selected */
+#define GPIO_Pin_12                     ((uint16_t)0x1000) /* Pin 12 selected */
+#define GPIO_Pin_13                     ((uint16_t)0x2000) /* Pin 13 selected */
+#define GPIO_Pin_14                     ((uint16_t)0x4000) /* Pin 14 selected */
+#define GPIO_Pin_15                     ((uint16_t)0x8000) /* Pin 15 selected */
+#define GPIO_Pin_All                    ((uint16_t)0xFFFF) /* All pins selected */
+
+/* GPIO_Remap_define */
+/* PCFR1 */
+#define GPIO_Remap_SPI1                 ((uint32_t)0x00000001) /* SPI1 Alternate Function mapping */
+#define GPIO_Remap_I2C1                 ((uint32_t)0x00000002) /* I2C1 Alternate Function mapping */
+#define GPIO_Remap_USART1               ((uint32_t)0x00000004) /* USART1 Alternate Function mapping low bit */
+#define GPIO_Remap_USART2               ((uint32_t)0x00000008) /* USART2 Alternate Function mapping */
+#define GPIO_PartialRemap_USART3        ((uint32_t)0x00140010) /* USART3 Partial Alternate Function mapping */
+#define GPIO_FullRemap_USART3           ((uint32_t)0x00140030) /* USART3 Full Alternate Function mapping */
+#define GPIO_PartialRemap_TIM1          ((uint32_t)0x00160040) /* TIM1 Partial Alternate Function mapping */
+#define GPIO_FullRemap_TIM1             ((uint32_t)0x001600C0) /* TIM1 Full Alternate Function mapping */
+#define GPIO_PartialRemap1_TIM2         ((uint32_t)0x00180100) /* TIM2 Partial1 Alternate Function mapping */
+#define GPIO_PartialRemap2_TIM2         ((uint32_t)0x00180200) /* TIM2 Partial2 Alternate Function mapping */
+#define GPIO_FullRemap_TIM2             ((uint32_t)0x00180300) /* TIM2 Full Alternate Function mapping */
+#define GPIO_PartialRemap_TIM3          ((uint32_t)0x001A0800) /* TIM3 Partial Alternate Function mapping */
+#define GPIO_FullRemap_TIM3             ((uint32_t)0x001A0C00) /* TIM3 Full Alternate Function mapping */
+#define GPIO_Remap_TIM4                 ((uint32_t)0x00001000) /* TIM4 Alternate Function mapping */
+#define GPIO_Remap1_CAN1                ((uint32_t)0x001D4000) /* CAN1 Alternate Function mapping */
+#define GPIO_Remap2_CAN1                ((uint32_t)0x001D6000) /* CAN1 Alternate Function mapping */
+#define GPIO_Remap_PD01                 ((uint32_t)0x00008000) /* PD01 Alternate Function mapping */
+#define GPIO_Remap_TIM5CH4_LSI          ((uint32_t)0x00200001) /* LSI connected to TIM5 Channel4 input capture for calibration */
+#define GPIO_Remap_ADC1_ETRGINJ         ((uint32_t)0x00200002) /* ADC1 External Trigger Injected Conversion remapping */
+#define GPIO_Remap_ADC1_ETRGREG         ((uint32_t)0x00200004) /* ADC1 External Trigger Regular Conversion remapping */
+#define GPIO_Remap_ADC2_ETRGINJ         ((uint32_t)0x00200008) /* ADC2 External Trigger Injected Conversion remapping */
+#define GPIO_Remap_ADC2_ETRGREG         ((uint32_t)0x00200010) /* ADC2 External Trigger Regular Conversion remapping */
+#define GPIO_Remap_ETH                  ((uint32_t)0x00200020) /* Ethernet remapping (only for Connectivity line devices) */
+#define GPIO_Remap_CAN2                 ((uint32_t)0x00200040) /* CAN2 remapping (only for Connectivity line devices) */
+#define GPIO_Remap_MII_RMII_SEL         ((uint32_t)0x00200080) /* MII or RMII selection */
+#define GPIO_Remap_SWJ_Disable          ((uint32_t)0x00300400) /* Full SWJ Disabled (JTAG-DP + SW-DP) */
+#define GPIO_Remap_SPI3                 ((uint32_t)0x00201000) /* SPI3/I2S3 Alternate Function mapping (only for Connectivity line devices) */
+#define GPIO_Remap_TIM2ITR1_PTP_SOF     ((uint32_t)0x00202000) /* Ethernet PTP output or USB OTG SOF (Start of Frame) connected \
+                                                                  to TIM2 Internal Trigger 1 for calibration                    \
+                                                                  (only for Connectivity line devices) */
+#define GPIO_Remap_PTP_PPS              ((uint32_t)0x00204000) /* Ethernet MAC PPS_PTS output on PB05 (only for Connectivity line devices) */
+
+/* PCFR2 */
+#define GPIO_Remap_TIM8                 ((uint32_t)0x80000004) /* TIM8 Alternate Function mapping */
+#define GPIO_PartialRemap_TIM9          ((uint32_t)0x80130008) /* TIM9 Partial Alternate Function mapping */
+#define GPIO_FullRemap_TIM9             ((uint32_t)0x80130010) /* TIM9 Full Alternate Function mapping */
+#define GPIO_PartialRemap_TIM10         ((uint32_t)0x80150020) /* TIM10 Partial Alternate Function mapping */
+#define GPIO_FullRemap_TIM10            ((uint32_t)0x80150040) /* TIM10 Full Alternate Function mapping */
+#define GPIO_Remap_FSMC_NADV            ((uint32_t)0x80000400) /* FSMC_NADV Alternate Function mapping */
+#define GPIO_PartialRemap_USART4        ((uint32_t)0x80300001) /* USART4 Partial Alternate Function mapping */
+#define GPIO_FullRemap_USART4           ((uint32_t)0x80300002) /* USART4 Full Alternate Function mapping */
+#define GPIO_PartialRemap_USART5        ((uint32_t)0x80320004) /* USART5 Partial Alternate Function mapping */
+#define GPIO_FullRemap_USART5           ((uint32_t)0x80320008) /* USART5 Full Alternate Function mapping */
+#define GPIO_PartialRemap_USART6        ((uint32_t)0x80340010) /* USART6 Partial Alternate Function mapping */
+#define GPIO_FullRemap_USART6           ((uint32_t)0x80340020) /* USART6 Full Alternate Function mapping */
+#define GPIO_PartialRemap_USART7        ((uint32_t)0x80360040) /* USART7 Partial Alternate Function mapping */
+#define GPIO_FullRemap_USART7           ((uint32_t)0x80360080) /* USART7 Full Alternate Function mapping */
+#define GPIO_PartialRemap_USART8        ((uint32_t)0x80380100) /* USART8 Partial Alternate Function mapping */
+#define GPIO_FullRemap_USART8           ((uint32_t)0x80380200) /* USART8 Full Alternate Function mapping */
+#define GPIO_Remap_USART1_HighBit       ((uint32_t)0x80200400) /* USART1 Alternate Function mapping high bit */
+
+/* GPIO_Port_Sources */
+#define GPIO_PortSourceGPIOA            ((uint8_t)0x00)
+#define GPIO_PortSourceGPIOB            ((uint8_t)0x01)
+#define GPIO_PortSourceGPIOC            ((uint8_t)0x02)
+#define GPIO_PortSourceGPIOD            ((uint8_t)0x03)
+#define GPIO_PortSourceGPIOE            ((uint8_t)0x04)
+#define GPIO_PortSourceGPIOF            ((uint8_t)0x05)
+#define GPIO_PortSourceGPIOG            ((uint8_t)0x06)
+
+/* GPIO_Pin_sources */
+#define GPIO_PinSource0                 ((uint8_t)0x00)
+#define GPIO_PinSource1                 ((uint8_t)0x01)
+#define GPIO_PinSource2                 ((uint8_t)0x02)
+#define GPIO_PinSource3                 ((uint8_t)0x03)
+#define GPIO_PinSource4                 ((uint8_t)0x04)
+#define GPIO_PinSource5                 ((uint8_t)0x05)
+#define GPIO_PinSource6                 ((uint8_t)0x06)
+#define GPIO_PinSource7                 ((uint8_t)0x07)
+#define GPIO_PinSource8                 ((uint8_t)0x08)
+#define GPIO_PinSource9                 ((uint8_t)0x09)
+#define GPIO_PinSource10                ((uint8_t)0x0A)
+#define GPIO_PinSource11                ((uint8_t)0x0B)
+#define GPIO_PinSource12                ((uint8_t)0x0C)
+#define GPIO_PinSource13                ((uint8_t)0x0D)
+#define GPIO_PinSource14                ((uint8_t)0x0E)
+#define GPIO_PinSource15                ((uint8_t)0x0F)
+
+/* Ethernet_Media_Interface */
+#define GPIO_ETH_MediaInterface_MII     ((u32)0x00000000)
+#define GPIO_ETH_MediaInterface_RMII    ((u32)0x00000001)
+
+void     GPIO_DeInit(GPIO_TypeDef *GPIOx);
+void     GPIO_AFIODeInit(void);
+void     GPIO_Init(GPIO_TypeDef *GPIOx, GPIO_InitTypeDef *GPIO_InitStruct);
+void     GPIO_StructInit(GPIO_InitTypeDef *GPIO_InitStruct);
+uint8_t  GPIO_ReadInputDataBit(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin);
+uint16_t GPIO_ReadInputData(GPIO_TypeDef *GPIOx);
+uint8_t  GPIO_ReadOutputDataBit(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin);
+uint16_t GPIO_ReadOutputData(GPIO_TypeDef *GPIOx);
+void     GPIO_SetBits(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin);
+void     GPIO_ResetBits(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin);
+void     GPIO_WriteBit(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin, BitAction BitVal);
+void     GPIO_Write(GPIO_TypeDef *GPIOx, uint16_t PortVal);
+void     GPIO_PinLockConfig(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin);
+void     GPIO_EventOutputConfig(uint8_t GPIO_PortSource, uint8_t GPIO_PinSource);
+void     GPIO_EventOutputCmd(FunctionalState NewState);
+void     GPIO_PinRemapConfig(uint32_t GPIO_Remap, FunctionalState NewState);
+void     GPIO_EXTILineConfig(uint8_t GPIO_PortSource, uint8_t GPIO_PinSource);
+void     GPIO_ETH_MediaInterfaceConfig(uint32_t GPIO_ETH_MediaInterface);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Sources/source/Peripheral/inc/ch32v20x_i2c.h
+++ b/Sources/source/Peripheral/inc/ch32v20x_i2c.h
@@ -1,0 +1,429 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32v20x_i2c.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/06/06
+ * Description        : This file contains all the functions prototypes for the
+ *                      I2C firmware library.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __CH32V20x_I2C_H
+#define __CH32V20x_I2C_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "ch32v20x.h"
+
+/* I2C Init structure definition  */
+typedef struct
+{
+    uint32_t I2C_ClockSpeed; /* Specifies the clock frequency.
+                                This parameter must be set to a value lower than 400kHz */
+
+    uint16_t I2C_Mode; /* Specifies the I2C mode.
+                          This parameter can be a value of @ref I2C_mode */
+
+    uint16_t I2C_DutyCycle; /* Specifies the I2C fast mode duty cycle.
+                               This parameter can be a value of @ref I2C_duty_cycle_in_fast_mode */
+
+    uint16_t I2C_OwnAddress1; /* Specifies the first device own address.
+                                 This parameter can be a 7-bit or 10-bit address. */
+
+    uint16_t I2C_Ack; /* Enables or disables the acknowledgement.
+                         This parameter can be a value of @ref I2C_acknowledgement */
+
+    uint16_t I2C_AcknowledgedAddress; /* Specifies if 7-bit or 10-bit address is acknowledged.
+                                         This parameter can be a value of @ref I2C_acknowledged_address */
+} I2C_InitTypeDef;
+
+/* I2C_mode */
+#define I2C_Mode_I2C                                         ((uint16_t)0x0000)
+#define I2C_Mode_SMBusDevice                                 ((uint16_t)0x0002)
+#define I2C_Mode_SMBusHost                                   ((uint16_t)0x000A)
+
+/* I2C_duty_cycle_in_fast_mode */
+#define I2C_DutyCycle_16_9                                   ((uint16_t)0x4000) /* I2C fast mode Tlow/Thigh = 16/9 */
+#define I2C_DutyCycle_2                                      ((uint16_t)0xBFFF) /* I2C fast mode Tlow/Thigh = 2 */
+
+/* I2C_acknowledgement */
+#define I2C_Ack_Enable                                       ((uint16_t)0x0400)
+#define I2C_Ack_Disable                                      ((uint16_t)0x0000)
+
+/* I2C_transfer_direction */
+#define I2C_Direction_Transmitter                            ((uint8_t)0x00)
+#define I2C_Direction_Receiver                               ((uint8_t)0x01)
+
+/* I2C_acknowledged_address */
+#define I2C_AcknowledgedAddress_7bit                         ((uint16_t)0x4000)
+#define I2C_AcknowledgedAddress_10bit                        ((uint16_t)0xC000)
+
+/* I2C_registers */
+#define I2C_Register_CTLR1                                   ((uint8_t)0x00)
+#define I2C_Register_CTLR2                                   ((uint8_t)0x04)
+#define I2C_Register_OADDR1                                  ((uint8_t)0x08)
+#define I2C_Register_OADDR2                                  ((uint8_t)0x0C)
+#define I2C_Register_DATAR                                   ((uint8_t)0x10)
+#define I2C_Register_STAR1                                   ((uint8_t)0x14)
+#define I2C_Register_STAR2                                   ((uint8_t)0x18)
+#define I2C_Register_CKCFGR                                  ((uint8_t)0x1C)
+#define I2C_Register_RTR                                     ((uint8_t)0x20)
+
+/* I2C_SMBus_alert_pin_level */
+#define I2C_SMBusAlert_Low                                   ((uint16_t)0x2000)
+#define I2C_SMBusAlert_High                                  ((uint16_t)0xDFFF)
+
+/* I2C_PEC_position */
+#define I2C_PECPosition_Next                                 ((uint16_t)0x0800)
+#define I2C_PECPosition_Current                              ((uint16_t)0xF7FF)
+
+/* I2C_NACK_position */
+#define I2C_NACKPosition_Next                                ((uint16_t)0x0800)
+#define I2C_NACKPosition_Current                             ((uint16_t)0xF7FF)
+
+/* I2C_interrupts_definition */
+#define I2C_IT_BUF                                           ((uint16_t)0x0400)
+#define I2C_IT_EVT                                           ((uint16_t)0x0200)
+#define I2C_IT_ERR                                           ((uint16_t)0x0100)
+
+/* I2C_interrupts_definition */
+#define I2C_IT_SMBALERT                                      ((uint32_t)0x01008000)
+#define I2C_IT_TIMEOUT                                       ((uint32_t)0x01004000)
+#define I2C_IT_PECERR                                        ((uint32_t)0x01001000)
+#define I2C_IT_OVR                                           ((uint32_t)0x01000800)
+#define I2C_IT_AF                                            ((uint32_t)0x01000400)
+#define I2C_IT_ARLO                                          ((uint32_t)0x01000200)
+#define I2C_IT_BERR                                          ((uint32_t)0x01000100)
+#define I2C_IT_TXE                                           ((uint32_t)0x06000080)
+#define I2C_IT_RXNE                                          ((uint32_t)0x06000040)
+#define I2C_IT_STOPF                                         ((uint32_t)0x02000010)
+#define I2C_IT_ADD10                                         ((uint32_t)0x02000008)
+#define I2C_IT_BTF                                           ((uint32_t)0x02000004)
+#define I2C_IT_ADDR                                          ((uint32_t)0x02000002)
+#define I2C_IT_SB                                            ((uint32_t)0x02000001)
+
+/* SR2 register flags  */
+#define I2C_FLAG_DUALF                                       ((uint32_t)0x00800000)
+#define I2C_FLAG_SMBHOST                                     ((uint32_t)0x00400000)
+#define I2C_FLAG_SMBDEFAULT                                  ((uint32_t)0x00200000)
+#define I2C_FLAG_GENCALL                                     ((uint32_t)0x00100000)
+#define I2C_FLAG_TRA                                         ((uint32_t)0x00040000)
+#define I2C_FLAG_BUSY                                        ((uint32_t)0x00020000)
+#define I2C_FLAG_MSL                                         ((uint32_t)0x00010000)
+
+/* SR1 register flags */
+#define I2C_FLAG_SMBALERT                                    ((uint32_t)0x10008000)
+#define I2C_FLAG_TIMEOUT                                     ((uint32_t)0x10004000)
+#define I2C_FLAG_PECERR                                      ((uint32_t)0x10001000)
+#define I2C_FLAG_OVR                                         ((uint32_t)0x10000800)
+#define I2C_FLAG_AF                                          ((uint32_t)0x10000400)
+#define I2C_FLAG_ARLO                                        ((uint32_t)0x10000200)
+#define I2C_FLAG_BERR                                        ((uint32_t)0x10000100)
+#define I2C_FLAG_TXE                                         ((uint32_t)0x10000080)
+#define I2C_FLAG_RXNE                                        ((uint32_t)0x10000040)
+#define I2C_FLAG_STOPF                                       ((uint32_t)0x10000010)
+#define I2C_FLAG_ADD10                                       ((uint32_t)0x10000008)
+#define I2C_FLAG_BTF                                         ((uint32_t)0x10000004)
+#define I2C_FLAG_ADDR                                        ((uint32_t)0x10000002)
+#define I2C_FLAG_SB                                          ((uint32_t)0x10000001)
+
+/****************I2C Master Events (Events grouped in order of communication)********************/
+
+/******************************************************************************************************************** 
+  * @brief  Start communicate
+  * 
+  * After master use I2C_GenerateSTART() function sending the START condition,the master 
+  * has to wait for event 5(the Start condition has been correctly 
+  * released on the I2C bus ).
+  * 
+  */
+/* EVT5 */
+#define  I2C_EVENT_MASTER_MODE_SELECT                      ((uint32_t)0x00030001)  /* BUSY, MSL and SB flag */
+
+/********************************************************************************************************************
+  * @brief  Address Acknowledge
+  * 
+  * When start condition correctly released on the bus(check EVT5), the 
+  * master use I2C_Send7bitAddress() function sends the address of the slave(s) with which it will communicate 
+  * it also determines master as transmitter or Receiver. Then the master has to wait that a slave acknowledges 
+  * his address. If an acknowledge is sent on the bus, one of the following events will be set:
+  * 
+  *
+  * 
+  *  1) In case of Master Receiver (7-bit addressing): the I2C_EVENT_MASTER_RECEIVER_MODE_SELECTED 
+  *     event is set.
+  *  
+  *  2) In case of Master Transmitter (7-bit addressing): the I2C_EVENT_MASTER_TRANSMITTER_MODE_SELECTED 
+  *     is set
+  *  
+  *  3) In case of 10-Bit addressing mode, the master (after generating the START 
+  *  and checking on EVT5) use I2C_SendData() function send the header of 10-bit addressing mode.  
+  *  Then master wait EVT9. EVT9 means that the 10-bit addressing header has been correctly sent 
+  *  on the bus. Then master should use the function I2C_Send7bitAddress() to send the second part 
+  *  of the 10-bit address (LSB) . Then master should wait for event 6. 
+  *
+  *     
+  */
+
+/* EVT6 */
+#define  I2C_EVENT_MASTER_TRANSMITTER_MODE_SELECTED        ((uint32_t)0x00070082)  /* BUSY, MSL, ADDR, TXE and TRA flags */
+#define  I2C_EVENT_MASTER_RECEIVER_MODE_SELECTED           ((uint32_t)0x00030002)  /* BUSY, MSL and ADDR flags */
+/*EVT9 */
+#define  I2C_EVENT_MASTER_MODE_ADDRESS10                   ((uint32_t)0x00030008)  /* BUSY, MSL and ADD10 flags */
+
+/******************************************************************************************************************** 
+  * @brief Communication events
+  * 
+  * If START condition has generated and slave address 
+  * been acknowledged. then the master has to check one of the following events for 
+  * communication procedures:
+  *  
+  * 1) Master Receiver mode: The master has to wait on the event EVT7 then use  
+  *   I2C_ReceiveData() function to read the data received from the slave .
+  * 
+  * 2) Master Transmitter mode: The master use I2C_SendData() function to send data  
+  *     then to wait on event EVT8 or EVT8_2.
+  *    These two events are similar: 
+  *     - EVT8 means that the data has been written in the data register and is 
+  *       being shifted out.
+  *     - EVT8_2 means that the data has been physically shifted out and output 
+  *       on the bus.
+  *     In most cases, using EVT8 is sufficient for the application.
+  *     Using EVT8_2  will leads to a slower communication  speed but will more reliable .
+  *     EVT8_2 is also more suitable than EVT8 for testing on the last data transmission 
+  *    
+  *     
+  *  Note:
+  *  In case the  user software does not guarantee that this event EVT7 is managed before 
+  *  the current byte end of transfer, then user may check on I2C_EVENT_MASTER_BYTE_RECEIVED 
+  *  and I2C_FLAG_BTF flag at the same time .But in this case the communication may be slower.
+  *
+  * 
+  */
+
+/* Master Receive mode */ 
+/* EVT7 */
+#define  I2C_EVENT_MASTER_BYTE_RECEIVED                    ((uint32_t)0x00030040)  /* BUSY, MSL and RXNE flags */
+
+/* Master Transmitter mode*/
+/* EVT8 */
+#define I2C_EVENT_MASTER_BYTE_TRANSMITTING                 ((uint32_t)0x00070080) /* TRA, BUSY, MSL, TXE flags */
+/* EVT8_2 */
+#define  I2C_EVENT_MASTER_BYTE_TRANSMITTED                 ((uint32_t)0x00070084)  /* TRA, BUSY, MSL, TXE and BTF flags */
+
+/******************I2C Slave Events (Events grouped in order of communication)******************/
+
+/******************************************************************************************************************** 
+  * @brief  Start Communicate events
+  * 
+  * Wait on one of these events at the start of the communication. It means that 
+  * the I2C peripheral detected a start condition of master device generate on the bus.  
+  * If the acknowledge feature is enabled through function I2C_AcknowledgeConfig()),The peripheral generates an ACK condition on the bus. 
+  *    
+  *
+  *
+  * a) In normal case (only one address managed by the slave), when the address 
+  *   sent by the master matches the own address of the peripheral (configured by 
+  *   I2C_OwnAddress1 field) the I2C_EVENT_SLAVE_XXX_ADDRESS_MATCHED event is set 
+  *   (where XXX could be TRANSMITTER or RECEIVER).
+  *    
+  * b) In case the address sent by the master matches the second address of the 
+  *   peripheral (configured by the function I2C_OwnAddress2Config() and enabled 
+  *   by the function I2C_DualAddressCmd()) the events I2C_EVENT_SLAVE_XXX_SECONDADDRESS_MATCHED 
+  *   (where XXX could be TRANSMITTER or RECEIVER) are set.
+  *   
+  * c) In case the address sent by the master is General Call (address 0x00) and 
+  *   if the General Call is enabled for the peripheral (using function I2C_GeneralCallCmd()) 
+  *   the following event is set I2C_EVENT_SLAVE_GENERALCALLADDRESS_MATCHED.   
+  * 
+  */
+
+/* EVT1 */   
+/* a) Case of One Single Address managed by the slave */
+#define  I2C_EVENT_SLAVE_RECEIVER_ADDRESS_MATCHED          ((uint32_t)0x00020002) /* BUSY and ADDR flags */
+#define  I2C_EVENT_SLAVE_TRANSMITTER_ADDRESS_MATCHED       ((uint32_t)0x00060082) /* TRA, BUSY, TXE and ADDR flags */
+
+/* b) Case of Dual address managed by the slave */
+#define  I2C_EVENT_SLAVE_RECEIVER_SECONDADDRESS_MATCHED    ((uint32_t)0x00820000)  /* DUALF and BUSY flags */
+#define  I2C_EVENT_SLAVE_TRANSMITTER_SECONDADDRESS_MATCHED ((uint32_t)0x00860080)  /* DUALF, TRA, BUSY and TXE flags */
+
+/* c) Case of General Call enabled for the slave */
+#define  I2C_EVENT_SLAVE_GENERALCALLADDRESS_MATCHED        ((uint32_t)0x00120000)  /* GENCALL and BUSY flags */
+
+/******************************************************************************************************************** 
+  * @brief  Communication events
+  * 
+  * Wait on one of these events when EVT1 has already been checked : 
+  * 
+  * - Slave Receiver mode:
+  *     - EVT2--The device is expecting to receive a data byte . 
+  *     - EVT4--The device is expecting the end of the communication: master 
+  *       sends a stop condition and data transmission is stopped.
+  *    
+  * - Slave Transmitter mode:
+  *    - EVT3--When a byte has been transmitted by the slave and the Master is expecting 
+  *      the end of the byte transmission. The two events I2C_EVENT_SLAVE_BYTE_TRANSMITTED and
+  *      I2C_EVENT_SLAVE_BYTE_TRANSMITTING are similar. If the user software doesn't guarantee 
+  *      the EVT3 is managed before the current byte end of transfer The second one can optionally
+  *      be used. 
+  *    - EVT3_2--When the master sends a NACK  to tell slave device that data transmission 
+  *      shall end . The slave device has to stop sending 
+  *      data bytes and wait a Stop condition from bus.
+  *      
+  *  Note:
+  *  If the  user software does not guarantee that the event 2 is 
+  *  managed before the current byte end of transfer, User may check on I2C_EVENT_SLAVE_BYTE_RECEIVED 
+  *  and I2C_FLAG_BTF flag at the same time .
+  *  In this case the communication will be slower.
+  *
+  */
+
+/* Slave Receiver mode*/ 
+/* EVT2 */
+#define  I2C_EVENT_SLAVE_BYTE_RECEIVED                     ((uint32_t)0x00020040)  /* BUSY and RXNE flags */
+/* EVT4  */
+#define  I2C_EVENT_SLAVE_STOP_DETECTED                     ((uint32_t)0x00000010)  /* STOPF flag */
+
+/* Slave Transmitter mode*/
+/* EVT3 */
+#define  I2C_EVENT_SLAVE_BYTE_TRANSMITTED                  ((uint32_t)0x00060084)  /* TRA, BUSY, TXE and BTF flags */
+#define  I2C_EVENT_SLAVE_BYTE_TRANSMITTING                 ((uint32_t)0x00060080)  /* TRA, BUSY and TXE flags */
+/*EVT3_2 */
+#define  I2C_EVENT_SLAVE_ACK_FAILURE                       ((uint32_t)0x00000400)  /* AF flag */
+
+
+void     I2C_DeInit(I2C_TypeDef *I2Cx);
+void     I2C_Init(I2C_TypeDef *I2Cx, I2C_InitTypeDef *I2C_InitStruct);
+void     I2C_StructInit(I2C_InitTypeDef *I2C_InitStruct);
+void     I2C_Cmd(I2C_TypeDef *I2Cx, FunctionalState NewState);
+void     I2C_DMACmd(I2C_TypeDef *I2Cx, FunctionalState NewState);
+void     I2C_DMALastTransferCmd(I2C_TypeDef *I2Cx, FunctionalState NewState);
+void     I2C_GenerateSTART(I2C_TypeDef *I2Cx, FunctionalState NewState);
+void     I2C_GenerateSTOP(I2C_TypeDef *I2Cx, FunctionalState NewState);
+void     I2C_AcknowledgeConfig(I2C_TypeDef *I2Cx, FunctionalState NewState);
+void     I2C_OwnAddress2Config(I2C_TypeDef *I2Cx, uint8_t Address);
+void     I2C_DualAddressCmd(I2C_TypeDef *I2Cx, FunctionalState NewState);
+void     I2C_GeneralCallCmd(I2C_TypeDef *I2Cx, FunctionalState NewState);
+void     I2C_ITConfig(I2C_TypeDef *I2Cx, uint16_t I2C_IT, FunctionalState NewState);
+void     I2C_SendData(I2C_TypeDef *I2Cx, uint8_t Data);
+uint8_t  I2C_ReceiveData(I2C_TypeDef *I2Cx);
+void     I2C_Send7bitAddress(I2C_TypeDef *I2Cx, uint8_t Address, uint8_t I2C_Direction);
+uint16_t I2C_ReadRegister(I2C_TypeDef *I2Cx, uint8_t I2C_Register);
+void     I2C_SoftwareResetCmd(I2C_TypeDef *I2Cx, FunctionalState NewState);
+void     I2C_NACKPositionConfig(I2C_TypeDef *I2Cx, uint16_t I2C_NACKPosition);
+void     I2C_SMBusAlertConfig(I2C_TypeDef *I2Cx, uint16_t I2C_SMBusAlert);
+void     I2C_TransmitPEC(I2C_TypeDef *I2Cx, FunctionalState NewState);
+void     I2C_PECPositionConfig(I2C_TypeDef *I2Cx, uint16_t I2C_PECPosition);
+void     I2C_CalculatePEC(I2C_TypeDef *I2Cx, FunctionalState NewState);
+uint8_t  I2C_GetPEC(I2C_TypeDef *I2Cx);
+void     I2C_ARPCmd(I2C_TypeDef *I2Cx, FunctionalState NewState);
+void     I2C_StretchClockCmd(I2C_TypeDef *I2Cx, FunctionalState NewState);
+void     I2C_FastModeDutyCycleConfig(I2C_TypeDef *I2Cx, uint16_t I2C_DutyCycle);
+
+
+/*****************************************************************************************
+ *
+ *                         I2C State Monitoring Functions
+ *                       
+ ****************************************************************************************   
+ * This I2C driver provides three different ways for I2C state monitoring
+ *  profit the application requirements and constraints:
+ *        
+ *  
+ * a) First way:
+ *    Using I2C_CheckEvent() function:
+ *    It compares the status registers (STARR1 and STAR2) content to a given event
+ *    (can be the combination of more flags).
+ *    If the current status registers includes the given flags  will return SUCCESS.
+ *    and  if the current status registers miss flags will returns ERROR.
+ *    - When to use:
+ *      - This function is suitable for most applications as well as for startup 
+ *      activity since the events are fully described in the product reference manual 
+ *      (CH32FV2x-V3xRM).
+ *      - It is also suitable for users who need to define their own events.
+ *    - Limitations:
+ *      - If an error occurs besides to the monitored error,
+ *        the I2C_CheckEvent() function may return SUCCESS despite the communication
+ *       in corrupted state.  it is suggeted to use error interrupts to monitor the error
+ *        events and handle them in IRQ handler.
+ *
+ *        
+ *        Note: 
+ *        The following functions are recommended for error management: :
+ *          - I2C_ITConfig() main function of configure and enable the error interrupts.
+ *          - I2Cx_ER_IRQHandler() will be called when the error interrupt happen.
+ *            Where x is the peripheral instance (I2C1, I2C2 ...)
+ *          -  I2Cx_ER_IRQHandler() will call I2C_GetFlagStatus() or I2C_GetITStatus() functions
+ *            to determine which error occurred.
+ *          - I2C_ClearFlag() \ I2C_ClearITPendingBit() \ I2C_SoftwareResetCmd()
+ *            \ I2C_GenerateStop() will be use to clear the error flag and source,
+ *            and return to correct communication status.
+ *            
+ *
+ *  b) Second way:
+ *     Using the function to get a single word(uint32_t) composed of status register 1 and register 2. 
+ *     (Status Register 2 value is shifted left by 16 bits and concatenated to Status Register 1).
+ *     - When to use:
+ *
+ *       - This function is suitable for the same applications above but it 
+ *         don't have the limitations of I2C_GetFlagStatus() function .
+ *         The returned value could be compared to events already defined in the 
+ *         library (CH32V20x_i2c.h) or to custom values defined by user.
+ *       - This function can be used to monitor the status of multiple flags simultaneously.
+ *       - Contrary to the I2C_CheckEvent () function, this function can choose the time to
+ *         accept the event according to the user's needs (when all event flags are set and  
+ *         no other flags are set, or only when the required flags are set) 
+ *     
+ *     - Limitations:
+ *       - User may need to define his own events.
+ *       - Same remark concerning the error management is applicable for this 
+ *         function if user decides to check only regular communication flags (and 
+ *         ignores error flags).
+ *     
+ *
+ *  c) Third way:
+ *     Using the function I2C_GetFlagStatus() get the status of 
+ *     one single flag . 
+ *     - When to use:
+ *        - This function could be used for specific applications or in debug phase.
+ *        - It is suitable when only one flag checking is needed . 
+ *          
+ *     - Limitations: 
+ *        - Call this function to access the status register. Some flag bits may be cleared.           
+ *       - Function may need to be called twice or more in order to monitor one single event. 
+ */
+            
+ 
+
+/*********************************************************
+ * 
+ *  a) Basic state monitoring(First way)
+ ********************************************************
+ */
+ErrorStatus I2C_CheckEvent(I2C_TypeDef* I2Cx, uint32_t I2C_EVENT);
+/*********************************************************
+ * 
+ *  b) Advanced state monitoring(Second way:)
+ ********************************************************
+ */
+uint32_t I2C_GetLastEvent(I2C_TypeDef* I2Cx);
+/*********************************************************
+ * 
+ *  c) Flag-based state monitoring(Third way)
+ *********************************************************
+ */
+FlagStatus I2C_GetFlagStatus(I2C_TypeDef* I2Cx, uint32_t I2C_FLAG);
+
+void     I2C_ClearFlag(I2C_TypeDef *I2Cx, uint32_t I2C_FLAG);
+ITStatus I2C_GetITStatus(I2C_TypeDef *I2Cx, uint32_t I2C_IT);
+void     I2C_ClearITPendingBit(I2C_TypeDef *I2Cx, uint32_t I2C_IT);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Sources/source/Peripheral/inc/ch32v20x_misc.h
+++ b/Sources/source/Peripheral/inc/ch32v20x_misc.h
@@ -1,0 +1,45 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32v20x_misc.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/06/06
+ * Description        : This file contains all the functions prototypes for the
+ *                      miscellaneous firmware library functions.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __CH32V20x_MISC_H
+#define __CH32V20x_MISC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "ch32v20x.h"
+
+/* NVIC Init Structure definition */
+typedef struct
+{
+    uint8_t         NVIC_IRQChannel;
+    uint8_t         NVIC_IRQChannelPreemptionPriority;
+    uint8_t         NVIC_IRQChannelSubPriority;
+    FunctionalState NVIC_IRQChannelCmd;
+} NVIC_InitTypeDef;
+
+/* Preemption_Priority_Group */
+#define NVIC_PriorityGroup_0    ((uint32_t)0x00)
+#define NVIC_PriorityGroup_1    ((uint32_t)0x01)
+#define NVIC_PriorityGroup_2    ((uint32_t)0x02)
+#define NVIC_PriorityGroup_3    ((uint32_t)0x03)
+#define NVIC_PriorityGroup_4    ((uint32_t)0x04)
+
+void NVIC_PriorityGroupConfig(uint32_t NVIC_PriorityGroup);
+void NVIC_Init(NVIC_InitTypeDef *NVIC_InitStruct);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Sources/source/Peripheral/inc/ch32v20x_rcc.h
+++ b/Sources/source/Peripheral/inc/ch32v20x_rcc.h
@@ -1,0 +1,257 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32v20x_rcc.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/06/06
+ * Description        : This file provides all the RCC firmware functions.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __CH32V20x_RCC_H
+#define __CH32V20x_RCC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "ch32v20x.h"
+
+/* RCC_Exported_Types */
+typedef struct
+{
+    uint32_t SYSCLK_Frequency; /* returns SYSCLK clock frequency expressed in Hz */
+    uint32_t HCLK_Frequency;   /* returns HCLK clock frequency expressed in Hz */
+    uint32_t PCLK1_Frequency;  /* returns PCLK1 clock frequency expressed in Hz */
+    uint32_t PCLK2_Frequency;  /* returns PCLK2 clock frequency expressed in Hz */
+    uint32_t ADCCLK_Frequency; /* returns ADCCLK clock frequency expressed in Hz */
+} RCC_ClocksTypeDef;
+
+/* HSE_configuration */
+#define RCC_HSE_OFF                     ((uint32_t)0x00000000)
+#define RCC_HSE_ON                      ((uint32_t)0x00010000)
+#define RCC_HSE_Bypass                  ((uint32_t)0x00040000)
+
+/* PLL_entry_clock_source */
+#define RCC_PLLSource_HSI_Div2          ((uint32_t)0x00000000)
+#define RCC_PLLSource_HSE_Div1          ((uint32_t)0x00010000)
+#define RCC_PLLSource_HSE_Div2          ((uint32_t)0x00030000)
+
+/* PLL_multiplication_factor for other CH32V20x  */
+#define RCC_PLLMul_2                    ((uint32_t)0x00000000)
+#define RCC_PLLMul_3                    ((uint32_t)0x00040000)
+#define RCC_PLLMul_4                    ((uint32_t)0x00080000)
+#define RCC_PLLMul_5                    ((uint32_t)0x000C0000)
+#define RCC_PLLMul_6                    ((uint32_t)0x00100000)
+#define RCC_PLLMul_7                    ((uint32_t)0x00140000)
+#define RCC_PLLMul_8                    ((uint32_t)0x00180000)
+#define RCC_PLLMul_9                    ((uint32_t)0x001C0000)
+#define RCC_PLLMul_10                   ((uint32_t)0x00200000)
+#define RCC_PLLMul_11                   ((uint32_t)0x00240000)
+#define RCC_PLLMul_12                   ((uint32_t)0x00280000)
+#define RCC_PLLMul_13                   ((uint32_t)0x002C0000)
+#define RCC_PLLMul_14                   ((uint32_t)0x00300000)
+#define RCC_PLLMul_15                   ((uint32_t)0x00340000)
+#define RCC_PLLMul_16                   ((uint32_t)0x00380000)
+#define RCC_PLLMul_18                   ((uint32_t)0x003C0000)
+
+/* System_clock_source */
+#define RCC_SYSCLKSource_HSI            ((uint32_t)0x00000000)
+#define RCC_SYSCLKSource_HSE            ((uint32_t)0x00000001)
+#define RCC_SYSCLKSource_PLLCLK         ((uint32_t)0x00000002)
+
+/* AHB_clock_source */
+#define RCC_SYSCLK_Div1                 ((uint32_t)0x00000000)
+#define RCC_SYSCLK_Div2                 ((uint32_t)0x00000080)
+#define RCC_SYSCLK_Div4                 ((uint32_t)0x00000090)
+#define RCC_SYSCLK_Div8                 ((uint32_t)0x000000A0)
+#define RCC_SYSCLK_Div16                ((uint32_t)0x000000B0)
+#define RCC_SYSCLK_Div64                ((uint32_t)0x000000C0)
+#define RCC_SYSCLK_Div128               ((uint32_t)0x000000D0)
+#define RCC_SYSCLK_Div256               ((uint32_t)0x000000E0)
+#define RCC_SYSCLK_Div512               ((uint32_t)0x000000F0)
+
+/* APB1_APB2_clock_source */
+#define RCC_HCLK_Div1                   ((uint32_t)0x00000000)
+#define RCC_HCLK_Div2                   ((uint32_t)0x00000400)
+#define RCC_HCLK_Div4                   ((uint32_t)0x00000500)
+#define RCC_HCLK_Div8                   ((uint32_t)0x00000600)
+#define RCC_HCLK_Div16                  ((uint32_t)0x00000700)
+
+/* RCC_Interrupt_source */
+#define RCC_IT_LSIRDY                   ((uint8_t)0x01)
+#define RCC_IT_LSERDY                   ((uint8_t)0x02)
+#define RCC_IT_HSIRDY                   ((uint8_t)0x04)
+#define RCC_IT_HSERDY                   ((uint8_t)0x08)
+#define RCC_IT_PLLRDY                   ((uint8_t)0x10)
+#define RCC_IT_CSS                      ((uint8_t)0x80)
+
+/* USB_Device_clock_source */
+#define RCC_USBCLKSource_PLLCLK_Div1    ((uint8_t)0x00)
+#define RCC_USBCLKSource_PLLCLK_Div2    ((uint8_t)0x01)
+#define RCC_USBCLKSource_PLLCLK_Div3    ((uint8_t)0x02)
+
+#ifdef CH32V20x_D8W
+  #define RCC_USBCLKSource_PLLCLK_Div5    ((uint8_t)0x03)
+
+#endif
+
+/* ADC_clock_source */
+#define RCC_PCLK2_Div2                 ((uint32_t)0x00000000)
+#define RCC_PCLK2_Div4                 ((uint32_t)0x00004000)
+#define RCC_PCLK2_Div6                 ((uint32_t)0x00008000)
+#define RCC_PCLK2_Div8                 ((uint32_t)0x0000C000)
+
+/* LSE_configuration */
+#define RCC_LSE_OFF                    ((uint8_t)0x00)
+#define RCC_LSE_ON                     ((uint8_t)0x01)
+#define RCC_LSE_Bypass                 ((uint8_t)0x04)
+
+/* RTC_clock_source */
+#define RCC_RTCCLKSource_LSE           ((uint32_t)0x00000100)
+#define RCC_RTCCLKSource_LSI           ((uint32_t)0x00000200)
+#define RCC_RTCCLKSource_HSE_Div128    ((uint32_t)0x00000300)
+
+/* AHB_peripheral */
+#define RCC_AHBPeriph_DMA1             ((uint32_t)0x00000001)
+#define RCC_AHBPeriph_DMA2             ((uint32_t)0x00000002)
+#define RCC_AHBPeriph_SRAM             ((uint32_t)0x00000004)
+#define RCC_AHBPeriph_CRC              ((uint32_t)0x00000040)
+#define RCC_AHBPeriph_FSMC             ((uint32_t)0x00000100)
+#define RCC_AHBPeriph_RNG              ((uint32_t)0x00000200)
+#define RCC_AHBPeriph_SDIO             ((uint32_t)0x00000400)
+#define RCC_AHBPeriph_USBHS            ((uint32_t)0x00000800)
+#define RCC_AHBPeriph_OTG_FS           ((uint32_t)0x00001000)
+
+#ifdef CH32V20x_D8W
+#define RCC_AHBPeriph_BLE_CRC          ((uint32_t)0x00030040)
+#endif
+
+/* APB2_peripheral */
+#define RCC_APB2Periph_AFIO            ((uint32_t)0x00000001)
+#define RCC_APB2Periph_GPIOA           ((uint32_t)0x00000004)
+#define RCC_APB2Periph_GPIOB           ((uint32_t)0x00000008)
+#define RCC_APB2Periph_GPIOC           ((uint32_t)0x00000010)
+#define RCC_APB2Periph_GPIOD           ((uint32_t)0x00000020)
+#define RCC_APB2Periph_GPIOE           ((uint32_t)0x00000040)
+#define RCC_APB2Periph_ADC1            ((uint32_t)0x00000200)
+#define RCC_APB2Periph_ADC2            ((uint32_t)0x00000400)
+#define RCC_APB2Periph_TIM1            ((uint32_t)0x00000800)
+#define RCC_APB2Periph_SPI1            ((uint32_t)0x00001000)
+#define RCC_APB2Periph_TIM8            ((uint32_t)0x00002000)
+#define RCC_APB2Periph_USART1          ((uint32_t)0x00004000)
+#define RCC_APB2Periph_TIM9            ((uint32_t)0x00080000)
+#define RCC_APB2Periph_TIM10           ((uint32_t)0x00100000)
+
+/* APB1_peripheral */
+#define RCC_APB1Periph_TIM2            ((uint32_t)0x00000001)
+#define RCC_APB1Periph_TIM3            ((uint32_t)0x00000002)
+#define RCC_APB1Periph_TIM4            ((uint32_t)0x00000004)
+#define RCC_APB1Periph_TIM5            ((uint32_t)0x00000008)
+#define RCC_APB1Periph_TIM6            ((uint32_t)0x00000010)
+#define RCC_APB1Periph_TIM7            ((uint32_t)0x00000020)
+#define RCC_APB1Periph_UART6           ((uint32_t)0x00000040)
+#define RCC_APB1Periph_UART7           ((uint32_t)0x00000080)
+#define RCC_APB1Periph_UART8           ((uint32_t)0x00000100)
+#define RCC_APB1Periph_WWDG            ((uint32_t)0x00000800)
+#define RCC_APB1Periph_SPI2            ((uint32_t)0x00004000)
+#define RCC_APB1Periph_SPI3            ((uint32_t)0x00008000)
+#define RCC_APB1Periph_USART2          ((uint32_t)0x00020000)
+#define RCC_APB1Periph_USART3          ((uint32_t)0x00040000)
+#define RCC_APB1Periph_UART4           ((uint32_t)0x00080000)
+#define RCC_APB1Periph_UART5           ((uint32_t)0x00100000)
+#define RCC_APB1Periph_I2C1            ((uint32_t)0x00200000)
+#define RCC_APB1Periph_I2C2            ((uint32_t)0x00400000)
+#define RCC_APB1Periph_USB             ((uint32_t)0x00800000)
+#define RCC_APB1Periph_CAN1            ((uint32_t)0x02000000)
+#define RCC_APB1Periph_CAN2            ((uint32_t)0x04000000)
+#define RCC_APB1Periph_BKP             ((uint32_t)0x08000000)
+#define RCC_APB1Periph_PWR             ((uint32_t)0x10000000)
+#define RCC_APB1Periph_DAC             ((uint32_t)0x20000000)
+
+/* Clock_source_to_output_on_MCO_pin */
+#define RCC_MCO_NoClock                ((uint8_t)0x00)
+#define RCC_MCO_SYSCLK                 ((uint8_t)0x04)
+#define RCC_MCO_HSI                    ((uint8_t)0x05)
+#define RCC_MCO_HSE                    ((uint8_t)0x06)
+#define RCC_MCO_PLLCLK_Div2            ((uint8_t)0x07)
+
+/* RCC_Flag */
+#define RCC_FLAG_HSIRDY                ((uint8_t)0x21)
+#define RCC_FLAG_HSERDY                ((uint8_t)0x31)
+#define RCC_FLAG_PLLRDY                ((uint8_t)0x39)
+#define RCC_FLAG_LSERDY                ((uint8_t)0x41)
+#define RCC_FLAG_LSIRDY                ((uint8_t)0x61)
+#define RCC_FLAG_PINRST                ((uint8_t)0x7A)
+#define RCC_FLAG_PORRST                ((uint8_t)0x7B)
+#define RCC_FLAG_SFTRST                ((uint8_t)0x7C)
+#define RCC_FLAG_IWDGRST               ((uint8_t)0x7D)
+#define RCC_FLAG_WWDGRST               ((uint8_t)0x7E)
+#define RCC_FLAG_LPWRRST               ((uint8_t)0x7F)
+
+/* SysTick_clock_source */
+#define SysTick_CLKSource_HCLK_Div8    ((uint32_t)0xFFFFFFFB)
+#define SysTick_CLKSource_HCLK         ((uint32_t)0x00000004)
+
+/* USBFS_clock_source */
+#define RCC_USBPLL_Div1                ((uint32_t)0x00)
+#define RCC_USBPLL_Div2                ((uint32_t)0x01)
+#define RCC_USBPLL_Div3                ((uint32_t)0x02)
+#define RCC_USBPLL_Div4                ((uint32_t)0x03)
+#define RCC_USBPLL_Div5                ((uint32_t)0x04)
+#define RCC_USBPLL_Div6                ((uint32_t)0x05)
+#define RCC_USBPLL_Div7                ((uint32_t)0x06)
+#define RCC_USBPLL_Div8                ((uint32_t)0x07)
+
+/* ETH_clock_source */
+#if defined(CH32V20x_D8) || defined(CH32V20x_D8W)
+  #define RCC_ETHCLK_Div1    ((uint32_t)0x00)
+  #define RCC_ETHCLK_Div2    ((uint32_t)0x01)
+
+#endif
+
+void        RCC_DeInit(void);
+void        RCC_HSEConfig(uint32_t RCC_HSE);
+ErrorStatus RCC_WaitForHSEStartUp(void);
+void        RCC_AdjustHSICalibrationValue(uint8_t HSICalibrationValue);
+void        RCC_HSICmd(FunctionalState NewState);
+void        RCC_PLLConfig(uint32_t RCC_PLLSource, uint32_t RCC_PLLMul);
+void        RCC_PLLCmd(FunctionalState NewState);
+void        RCC_SYSCLKConfig(uint32_t RCC_SYSCLKSource);
+uint8_t     RCC_GetSYSCLKSource(void);
+void        RCC_HCLKConfig(uint32_t RCC_SYSCLK);
+void        RCC_PCLK1Config(uint32_t RCC_HCLK);
+void        RCC_PCLK2Config(uint32_t RCC_HCLK);
+void        RCC_ITConfig(uint8_t RCC_IT, FunctionalState NewState);
+void        RCC_USBCLKConfig(uint32_t RCC_USBCLKSource);
+void        RCC_ADCCLKConfig(uint32_t RCC_PCLK2);
+void        RCC_LSEConfig(uint8_t RCC_LSE);
+void        RCC_LSICmd(FunctionalState NewState);
+void        RCC_RTCCLKConfig(uint32_t RCC_RTCCLKSource);
+void        RCC_RTCCLKCmd(FunctionalState NewState);
+void        RCC_GetClocksFreq(RCC_ClocksTypeDef *RCC_Clocks);
+void        RCC_AHBPeriphClockCmd(uint32_t RCC_AHBPeriph, FunctionalState NewState);
+void        RCC_APB2PeriphClockCmd(uint32_t RCC_APB2Periph, FunctionalState NewState);
+void        RCC_APB1PeriphClockCmd(uint32_t RCC_APB1Periph, FunctionalState NewState);
+void        RCC_APB2PeriphResetCmd(uint32_t RCC_APB2Periph, FunctionalState NewState);
+void        RCC_APB1PeriphResetCmd(uint32_t RCC_APB1Periph, FunctionalState NewState);
+void        RCC_BackupResetCmd(FunctionalState NewState);
+void        RCC_ClockSecuritySystemCmd(FunctionalState NewState);
+void        RCC_MCOConfig(uint8_t RCC_MCO);
+FlagStatus  RCC_GetFlagStatus(uint8_t RCC_FLAG);
+void        RCC_ClearFlag(void);
+ITStatus    RCC_GetITStatus(uint8_t RCC_IT);
+void        RCC_ClearITPendingBit(uint8_t RCC_IT);
+void        RCC_ADCCLKADJcmd(FunctionalState NewState);
+
+#if defined(CH32V20x_D8) || defined(CH32V20x_D8W)
+void RCC_ETHDIVConfig(uint32_t RCC_ETHPRE_Div);
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Sources/source/Peripheral/inc/ch32v20x_tim.h
+++ b/Sources/source/Peripheral/inc/ch32v20x_tim.h
@@ -1,0 +1,508 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32v20x_tim.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/06/06
+ * Description        : This file contains all the functions prototypes for the
+ *                      TIM firmware library.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __CH32V20x_TIM_H
+#define __CH32V20x_TIM_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "ch32v20x.h"
+
+/* TIM Time Base Init structure definition */
+typedef struct
+{
+    uint16_t TIM_Prescaler; /* Specifies the prescaler value used to divide the TIM clock.
+                               This parameter can be a number between 0x0000 and 0xFFFF */
+
+    uint16_t TIM_CounterMode; /* Specifies the counter mode.
+                                 This parameter can be a value of @ref TIM_Counter_Mode */
+
+    uint16_t TIM_Period; /* Specifies the period value to be loaded into the active
+                            Auto-Reload Register at the next update event.
+                            This parameter must be a number between 0x0000 and 0xFFFF.  */
+
+    uint16_t TIM_ClockDivision; /* Specifies the clock division.
+                                  This parameter can be a value of @ref TIM_Clock_Division_CKD */
+
+    uint8_t TIM_RepetitionCounter; /* Specifies the repetition counter value. Each time the RCR downcounter
+                                      reaches zero, an update event is generated and counting restarts
+                                      from the RCR value (N).
+                                      This means in PWM mode that (N+1) corresponds to:
+                                         - the number of PWM periods in edge-aligned mode
+                                         - the number of half PWM period in center-aligned mode
+                                      This parameter must be a number between 0x00 and 0xFF.
+                                      @note This parameter is valid only for TIM1 and TIM8. */
+} TIM_TimeBaseInitTypeDef;
+
+/* TIM Output Compare Init structure definition */
+typedef struct
+{
+    uint16_t TIM_OCMode; /* Specifies the TIM mode.
+                            This parameter can be a value of @ref TIM_Output_Compare_and_PWM_modes */
+
+    uint16_t TIM_OutputState; /* Specifies the TIM Output Compare state.
+                                 This parameter can be a value of @ref TIM_Output_Compare_state */
+
+    uint16_t TIM_OutputNState; /* Specifies the TIM complementary Output Compare state.
+                                  This parameter can be a value of @ref TIM_Output_Compare_N_state
+                                  @note This parameter is valid only for TIM1 and TIM8. */
+
+    uint16_t TIM_Pulse; /* Specifies the pulse value to be loaded into the Capture Compare Register.
+                           This parameter can be a number between 0x0000 and 0xFFFF */
+
+    uint16_t TIM_OCPolarity; /* Specifies the output polarity.
+                                This parameter can be a value of @ref TIM_Output_Compare_Polarity */
+
+    uint16_t TIM_OCNPolarity; /* Specifies the complementary output polarity.
+                                 This parameter can be a value of @ref TIM_Output_Compare_N_Polarity
+                                 @note This parameter is valid only for TIM1 and TIM8. */
+
+    uint16_t TIM_OCIdleState; /* Specifies the TIM Output Compare pin state during Idle state.
+                                 This parameter can be a value of @ref TIM_Output_Compare_Idle_State
+                                 @note This parameter is valid only for TIM1 and TIM8. */
+
+    uint16_t TIM_OCNIdleState; /* Specifies the TIM Output Compare pin state during Idle state.
+                                  This parameter can be a value of @ref TIM_Output_Compare_N_Idle_State
+                                  @note This parameter is valid only for TIM1 and TIM8. */
+} TIM_OCInitTypeDef;
+
+/* TIM Input Capture Init structure definition */
+typedef struct
+{
+    uint16_t TIM_Channel; /* Specifies the TIM channel.
+                             This parameter can be a value of @ref TIM_Channel */
+
+    uint16_t TIM_ICPolarity; /* Specifies the active edge of the input signal.
+                                This parameter can be a value of @ref TIM_Input_Capture_Polarity */
+
+    uint16_t TIM_ICSelection; /* Specifies the input.
+                                 This parameter can be a value of @ref TIM_Input_Capture_Selection */
+
+    uint16_t TIM_ICPrescaler; /* Specifies the Input Capture Prescaler.
+                                 This parameter can be a value of @ref TIM_Input_Capture_Prescaler */
+
+    uint16_t TIM_ICFilter; /* Specifies the input capture filter.
+                              This parameter can be a number between 0x0 and 0xF */
+} TIM_ICInitTypeDef;
+
+/* BDTR structure definition */
+typedef struct
+{
+    uint16_t TIM_OSSRState; /* Specifies the Off-State selection used in Run mode.
+                               This parameter can be a value of @ref OSSR_Off_State_Selection_for_Run_mode_state */
+
+    uint16_t TIM_OSSIState; /* Specifies the Off-State used in Idle state.
+                               This parameter can be a value of @ref OSSI_Off_State_Selection_for_Idle_mode_state */
+
+    uint16_t TIM_LOCKLevel; /* Specifies the LOCK level parameters.
+                               This parameter can be a value of @ref Lock_level */
+
+    uint16_t TIM_DeadTime; /* Specifies the delay time between the switching-off and the
+                              switching-on of the outputs.
+                              This parameter can be a number between 0x00 and 0xFF  */
+
+    uint16_t TIM_Break; /* Specifies whether the TIM Break input is enabled or not.
+                           This parameter can be a value of @ref Break_Input_enable_disable */
+
+    uint16_t TIM_BreakPolarity; /* Specifies the TIM Break Input pin polarity.
+                                   This parameter can be a value of @ref Break_Polarity */
+
+    uint16_t TIM_AutomaticOutput; /* Specifies whether the TIM Automatic Output feature is enabled or not.
+                                     This parameter can be a value of @ref TIM_AOE_Bit_Set_Reset */
+} TIM_BDTRInitTypeDef;
+
+/* TIM_Output_Compare_and_PWM_modes */
+#define TIM_OCMode_Timing                  ((uint16_t)0x0000)
+#define TIM_OCMode_Active                  ((uint16_t)0x0010)
+#define TIM_OCMode_Inactive                ((uint16_t)0x0020)
+#define TIM_OCMode_Toggle                  ((uint16_t)0x0030)
+#define TIM_OCMode_PWM1                    ((uint16_t)0x0060)
+#define TIM_OCMode_PWM2                    ((uint16_t)0x0070)
+
+/* TIM_One_Pulse_Mode */
+#define TIM_OPMode_Single                  ((uint16_t)0x0008)
+#define TIM_OPMode_Repetitive              ((uint16_t)0x0000)
+
+/* TIM_Channel */
+#define TIM_Channel_1                      ((uint16_t)0x0000)
+#define TIM_Channel_2                      ((uint16_t)0x0004)
+#define TIM_Channel_3                      ((uint16_t)0x0008)
+#define TIM_Channel_4                      ((uint16_t)0x000C)
+
+/* TIM_Clock_Division_CKD */
+#define TIM_CKD_DIV1                       ((uint16_t)0x0000)
+#define TIM_CKD_DIV2                       ((uint16_t)0x0100)
+#define TIM_CKD_DIV4                       ((uint16_t)0x0200)
+
+/* TIM_Counter_Mode */
+#define TIM_CounterMode_Up                 ((uint16_t)0x0000)
+#define TIM_CounterMode_Down               ((uint16_t)0x0010)
+#define TIM_CounterMode_CenterAligned1     ((uint16_t)0x0020)
+#define TIM_CounterMode_CenterAligned2     ((uint16_t)0x0040)
+#define TIM_CounterMode_CenterAligned3     ((uint16_t)0x0060)
+
+/* TIM_Output_Compare_Polarity */
+#define TIM_OCPolarity_High                ((uint16_t)0x0000)
+#define TIM_OCPolarity_Low                 ((uint16_t)0x0002)
+
+/* TIM_Output_Compare_N_Polarity */
+#define TIM_OCNPolarity_High               ((uint16_t)0x0000)
+#define TIM_OCNPolarity_Low                ((uint16_t)0x0008)
+
+/* TIM_Output_Compare_state */
+#define TIM_OutputState_Disable            ((uint16_t)0x0000)
+#define TIM_OutputState_Enable             ((uint16_t)0x0001)
+
+/* TIM_Output_Compare_N_state */
+#define TIM_OutputNState_Disable           ((uint16_t)0x0000)
+#define TIM_OutputNState_Enable            ((uint16_t)0x0004)
+
+/* TIM_Capture_Compare_state */
+#define TIM_CCx_Enable                     ((uint16_t)0x0001)
+#define TIM_CCx_Disable                    ((uint16_t)0x0000)
+
+/* TIM_Capture_Compare_N_state */
+#define TIM_CCxN_Enable                    ((uint16_t)0x0004)
+#define TIM_CCxN_Disable                   ((uint16_t)0x0000)
+
+/* Break_Input_enable_disable */
+#define TIM_Break_Enable                   ((uint16_t)0x1000)
+#define TIM_Break_Disable                  ((uint16_t)0x0000)
+
+/* Break_Polarity */
+#define TIM_BreakPolarity_Low              ((uint16_t)0x0000)
+#define TIM_BreakPolarity_High             ((uint16_t)0x2000)
+
+/* TIM_AOE_Bit_Set_Reset */
+#define TIM_AutomaticOutput_Enable         ((uint16_t)0x4000)
+#define TIM_AutomaticOutput_Disable        ((uint16_t)0x0000)
+
+/* Lock_level */
+#define TIM_LOCKLevel_OFF                  ((uint16_t)0x0000)
+#define TIM_LOCKLevel_1                    ((uint16_t)0x0100)
+#define TIM_LOCKLevel_2                    ((uint16_t)0x0200)
+#define TIM_LOCKLevel_3                    ((uint16_t)0x0300)
+
+/* OSSI_Off_State_Selection_for_Idle_mode_state */
+#define TIM_OSSIState_Enable               ((uint16_t)0x0400)
+#define TIM_OSSIState_Disable              ((uint16_t)0x0000)
+
+/* OSSR_Off_State_Selection_for_Run_mode_state */
+#define TIM_OSSRState_Enable               ((uint16_t)0x0800)
+#define TIM_OSSRState_Disable              ((uint16_t)0x0000)
+
+/* TIM_Output_Compare_Idle_State */
+#define TIM_OCIdleState_Set                ((uint16_t)0x0100)
+#define TIM_OCIdleState_Reset              ((uint16_t)0x0000)
+
+/* TIM_Output_Compare_N_Idle_State */
+#define TIM_OCNIdleState_Set               ((uint16_t)0x0200)
+#define TIM_OCNIdleState_Reset             ((uint16_t)0x0000)
+
+/* TIM_Input_Capture_Polarity */
+#define TIM_ICPolarity_Rising              ((uint16_t)0x0000)
+#define TIM_ICPolarity_Falling             ((uint16_t)0x0002)
+#define TIM_ICPolarity_BothEdge            ((uint16_t)0x000A)
+
+/* TIM_Input_Capture_Selection */
+#define TIM_ICSelection_DirectTI           ((uint16_t)0x0001) /* TIM Input 1, 2, 3 or 4 is selected to be \
+                                                                 connected to IC1, IC2, IC3 or IC4, respectively */
+#define TIM_ICSelection_IndirectTI         ((uint16_t)0x0002) /* TIM Input 1, 2, 3 or 4 is selected to be \
+                                                                 connected to IC2, IC1, IC4 or IC3, respectively. */
+#define TIM_ICSelection_TRC                ((uint16_t)0x0003) /* TIM Input 1, 2, 3 or 4 is selected to be connected to TRC. */
+
+/* TIM_Input_Capture_Prescaler */
+#define TIM_ICPSC_DIV1                     ((uint16_t)0x0000) /* Capture performed each time an edge is detected on the capture input. */
+#define TIM_ICPSC_DIV2                     ((uint16_t)0x0004) /* Capture performed once every 2 events. */
+#define TIM_ICPSC_DIV4                     ((uint16_t)0x0008) /* Capture performed once every 4 events. */
+#define TIM_ICPSC_DIV8                     ((uint16_t)0x000C) /* Capture performed once every 8 events. */
+
+/* TIM_interrupt_sources */
+#define TIM_IT_Update                      ((uint16_t)0x0001)
+#define TIM_IT_CC1                         ((uint16_t)0x0002)
+#define TIM_IT_CC2                         ((uint16_t)0x0004)
+#define TIM_IT_CC3                         ((uint16_t)0x0008)
+#define TIM_IT_CC4                         ((uint16_t)0x0010)
+#define TIM_IT_COM                         ((uint16_t)0x0020)
+#define TIM_IT_Trigger                     ((uint16_t)0x0040)
+#define TIM_IT_Break                       ((uint16_t)0x0080)
+
+/* TIM_DMA_Base_address */
+#define TIM_DMABase_CR1                    ((uint16_t)0x0000)
+#define TIM_DMABase_CR2                    ((uint16_t)0x0001)
+#define TIM_DMABase_SMCR                   ((uint16_t)0x0002)
+#define TIM_DMABase_DIER                   ((uint16_t)0x0003)
+#define TIM_DMABase_SR                     ((uint16_t)0x0004)
+#define TIM_DMABase_EGR                    ((uint16_t)0x0005)
+#define TIM_DMABase_CCMR1                  ((uint16_t)0x0006)
+#define TIM_DMABase_CCMR2                  ((uint16_t)0x0007)
+#define TIM_DMABase_CCER                   ((uint16_t)0x0008)
+#define TIM_DMABase_CNT                    ((uint16_t)0x0009)
+#define TIM_DMABase_PSC                    ((uint16_t)0x000A)
+#define TIM_DMABase_ARR                    ((uint16_t)0x000B)
+#define TIM_DMABase_RCR                    ((uint16_t)0x000C)
+#define TIM_DMABase_CCR1                   ((uint16_t)0x000D)
+#define TIM_DMABase_CCR2                   ((uint16_t)0x000E)
+#define TIM_DMABase_CCR3                   ((uint16_t)0x000F)
+#define TIM_DMABase_CCR4                   ((uint16_t)0x0010)
+#define TIM_DMABase_BDTR                   ((uint16_t)0x0011)
+#define TIM_DMABase_DCR                    ((uint16_t)0x0012)
+
+/* TIM_DMA_Burst_Length */
+#define TIM_DMABurstLength_1Transfer       ((uint16_t)0x0000)
+#define TIM_DMABurstLength_2Transfers      ((uint16_t)0x0100)
+#define TIM_DMABurstLength_3Transfers      ((uint16_t)0x0200)
+#define TIM_DMABurstLength_4Transfers      ((uint16_t)0x0300)
+#define TIM_DMABurstLength_5Transfers      ((uint16_t)0x0400)
+#define TIM_DMABurstLength_6Transfers      ((uint16_t)0x0500)
+#define TIM_DMABurstLength_7Transfers      ((uint16_t)0x0600)
+#define TIM_DMABurstLength_8Transfers      ((uint16_t)0x0700)
+#define TIM_DMABurstLength_9Transfers      ((uint16_t)0x0800)
+#define TIM_DMABurstLength_10Transfers     ((uint16_t)0x0900)
+#define TIM_DMABurstLength_11Transfers     ((uint16_t)0x0A00)
+#define TIM_DMABurstLength_12Transfers     ((uint16_t)0x0B00)
+#define TIM_DMABurstLength_13Transfers     ((uint16_t)0x0C00)
+#define TIM_DMABurstLength_14Transfers     ((uint16_t)0x0D00)
+#define TIM_DMABurstLength_15Transfers     ((uint16_t)0x0E00)
+#define TIM_DMABurstLength_16Transfers     ((uint16_t)0x0F00)
+#define TIM_DMABurstLength_17Transfers     ((uint16_t)0x1000)
+#define TIM_DMABurstLength_18Transfers     ((uint16_t)0x1100)
+
+/* TIM_DMA_sources */
+#define TIM_DMA_Update                     ((uint16_t)0x0100)
+#define TIM_DMA_CC1                        ((uint16_t)0x0200)
+#define TIM_DMA_CC2                        ((uint16_t)0x0400)
+#define TIM_DMA_CC3                        ((uint16_t)0x0800)
+#define TIM_DMA_CC4                        ((uint16_t)0x1000)
+#define TIM_DMA_COM                        ((uint16_t)0x2000)
+#define TIM_DMA_Trigger                    ((uint16_t)0x4000)
+
+/* TIM_External_Trigger_Prescaler */
+#define TIM_ExtTRGPSC_OFF                  ((uint16_t)0x0000)
+#define TIM_ExtTRGPSC_DIV2                 ((uint16_t)0x1000)
+#define TIM_ExtTRGPSC_DIV4                 ((uint16_t)0x2000)
+#define TIM_ExtTRGPSC_DIV8                 ((uint16_t)0x3000)
+
+/* TIM_Internal_Trigger_Selection */
+#define TIM_TS_ITR0                        ((uint16_t)0x0000)
+#define TIM_TS_ITR1                        ((uint16_t)0x0010)
+#define TIM_TS_ITR2                        ((uint16_t)0x0020)
+#define TIM_TS_ITR3                        ((uint16_t)0x0030)
+#define TIM_TS_TI1F_ED                     ((uint16_t)0x0040)
+#define TIM_TS_TI1FP1                      ((uint16_t)0x0050)
+#define TIM_TS_TI2FP2                      ((uint16_t)0x0060)
+#define TIM_TS_ETRF                        ((uint16_t)0x0070)
+
+/* TIM_TIx_External_Clock_Source */
+#define TIM_TIxExternalCLK1Source_TI1      ((uint16_t)0x0050)
+#define TIM_TIxExternalCLK1Source_TI2      ((uint16_t)0x0060)
+#define TIM_TIxExternalCLK1Source_TI1ED    ((uint16_t)0x0040)
+
+/* TIM_External_Trigger_Polarity */
+#define TIM_ExtTRGPolarity_Inverted        ((uint16_t)0x8000)
+#define TIM_ExtTRGPolarity_NonInverted     ((uint16_t)0x0000)
+
+/* TIM_Prescaler_Reload_Mode */
+#define TIM_PSCReloadMode_Update           ((uint16_t)0x0000)
+#define TIM_PSCReloadMode_Immediate        ((uint16_t)0x0001)
+
+/* TIM_Forced_Action */
+#define TIM_ForcedAction_Active            ((uint16_t)0x0050)
+#define TIM_ForcedAction_InActive          ((uint16_t)0x0040)
+
+/* TIM_Encoder_Mode */
+#define TIM_EncoderMode_TI1                ((uint16_t)0x0001)
+#define TIM_EncoderMode_TI2                ((uint16_t)0x0002)
+#define TIM_EncoderMode_TI12               ((uint16_t)0x0003)
+
+/* TIM_Event_Source */
+#define TIM_EventSource_Update             ((uint16_t)0x0001)
+#define TIM_EventSource_CC1                ((uint16_t)0x0002)
+#define TIM_EventSource_CC2                ((uint16_t)0x0004)
+#define TIM_EventSource_CC3                ((uint16_t)0x0008)
+#define TIM_EventSource_CC4                ((uint16_t)0x0010)
+#define TIM_EventSource_COM                ((uint16_t)0x0020)
+#define TIM_EventSource_Trigger            ((uint16_t)0x0040)
+#define TIM_EventSource_Break              ((uint16_t)0x0080)
+
+/* TIM_Update_Source */
+#define TIM_UpdateSource_Global            ((uint16_t)0x0000) /* Source of update is the counter overflow/underflow \
+                                                                 or the setting of UG bit, or an update generation  \
+                                                                 through the slave mode controller. */
+#define TIM_UpdateSource_Regular           ((uint16_t)0x0001) /* Source of update is counter overflow/underflow. */
+
+/* TIM_Output_Compare_Preload_State */
+#define TIM_OCPreload_Enable               ((uint16_t)0x0008)
+#define TIM_OCPreload_Disable              ((uint16_t)0x0000)
+
+/* TIM_Output_Compare_Fast_State */
+#define TIM_OCFast_Enable                  ((uint16_t)0x0004)
+#define TIM_OCFast_Disable                 ((uint16_t)0x0000)
+
+/* TIM_Output_Compare_Clear_State */
+#define TIM_OCClear_Enable                 ((uint16_t)0x0080)
+#define TIM_OCClear_Disable                ((uint16_t)0x0000)
+
+/* TIM_Trigger_Output_Source */
+#define TIM_TRGOSource_Reset               ((uint16_t)0x0000)
+#define TIM_TRGOSource_Enable              ((uint16_t)0x0010)
+#define TIM_TRGOSource_Update              ((uint16_t)0x0020)
+#define TIM_TRGOSource_OC1                 ((uint16_t)0x0030)
+#define TIM_TRGOSource_OC1Ref              ((uint16_t)0x0040)
+#define TIM_TRGOSource_OC2Ref              ((uint16_t)0x0050)
+#define TIM_TRGOSource_OC3Ref              ((uint16_t)0x0060)
+#define TIM_TRGOSource_OC4Ref              ((uint16_t)0x0070)
+
+/* TIM_Slave_Mode */
+#define TIM_SlaveMode_Reset                ((uint16_t)0x0004)
+#define TIM_SlaveMode_Gated                ((uint16_t)0x0005)
+#define TIM_SlaveMode_Trigger              ((uint16_t)0x0006)
+#define TIM_SlaveMode_External1            ((uint16_t)0x0007)
+
+/* TIM_Master_Slave_Mode */
+#define TIM_MasterSlaveMode_Enable         ((uint16_t)0x0080)
+#define TIM_MasterSlaveMode_Disable        ((uint16_t)0x0000)
+
+/* TIM_Flags */
+#define TIM_FLAG_Update                    ((uint16_t)0x0001)
+#define TIM_FLAG_CC1                       ((uint16_t)0x0002)
+#define TIM_FLAG_CC2                       ((uint16_t)0x0004)
+#define TIM_FLAG_CC3                       ((uint16_t)0x0008)
+#define TIM_FLAG_CC4                       ((uint16_t)0x0010)
+#define TIM_FLAG_COM                       ((uint16_t)0x0020)
+#define TIM_FLAG_Trigger                   ((uint16_t)0x0040)
+#define TIM_FLAG_Break                     ((uint16_t)0x0080)
+#define TIM_FLAG_CC1OF                     ((uint16_t)0x0200)
+#define TIM_FLAG_CC2OF                     ((uint16_t)0x0400)
+#define TIM_FLAG_CC3OF                     ((uint16_t)0x0800)
+#define TIM_FLAG_CC4OF                     ((uint16_t)0x1000)
+
+/* TIM_Legacy */
+#define TIM_DMABurstLength_1Byte           TIM_DMABurstLength_1Transfer
+#define TIM_DMABurstLength_2Bytes          TIM_DMABurstLength_2Transfers
+#define TIM_DMABurstLength_3Bytes          TIM_DMABurstLength_3Transfers
+#define TIM_DMABurstLength_4Bytes          TIM_DMABurstLength_4Transfers
+#define TIM_DMABurstLength_5Bytes          TIM_DMABurstLength_5Transfers
+#define TIM_DMABurstLength_6Bytes          TIM_DMABurstLength_6Transfers
+#define TIM_DMABurstLength_7Bytes          TIM_DMABurstLength_7Transfers
+#define TIM_DMABurstLength_8Bytes          TIM_DMABurstLength_8Transfers
+#define TIM_DMABurstLength_9Bytes          TIM_DMABurstLength_9Transfers
+#define TIM_DMABurstLength_10Bytes         TIM_DMABurstLength_10Transfers
+#define TIM_DMABurstLength_11Bytes         TIM_DMABurstLength_11Transfers
+#define TIM_DMABurstLength_12Bytes         TIM_DMABurstLength_12Transfers
+#define TIM_DMABurstLength_13Bytes         TIM_DMABurstLength_13Transfers
+#define TIM_DMABurstLength_14Bytes         TIM_DMABurstLength_14Transfers
+#define TIM_DMABurstLength_15Bytes         TIM_DMABurstLength_15Transfers
+#define TIM_DMABurstLength_16Bytes         TIM_DMABurstLength_16Transfers
+#define TIM_DMABurstLength_17Bytes         TIM_DMABurstLength_17Transfers
+#define TIM_DMABurstLength_18Bytes         TIM_DMABurstLength_18Transfers
+
+void       TIM_DeInit(TIM_TypeDef *TIMx);
+void       TIM_TimeBaseInit(TIM_TypeDef *TIMx, TIM_TimeBaseInitTypeDef *TIM_TimeBaseInitStruct);
+void       TIM_OC1Init(TIM_TypeDef *TIMx, TIM_OCInitTypeDef *TIM_OCInitStruct);
+void       TIM_OC2Init(TIM_TypeDef *TIMx, TIM_OCInitTypeDef *TIM_OCInitStruct);
+void       TIM_OC3Init(TIM_TypeDef *TIMx, TIM_OCInitTypeDef *TIM_OCInitStruct);
+void       TIM_OC4Init(TIM_TypeDef *TIMx, TIM_OCInitTypeDef *TIM_OCInitStruct);
+void       TIM_ICInit(TIM_TypeDef *TIMx, TIM_ICInitTypeDef *TIM_ICInitStruct);
+void       TIM_PWMIConfig(TIM_TypeDef *TIMx, TIM_ICInitTypeDef *TIM_ICInitStruct);
+void       TIM_BDTRConfig(TIM_TypeDef *TIMx, TIM_BDTRInitTypeDef *TIM_BDTRInitStruct);
+void       TIM_TimeBaseStructInit(TIM_TimeBaseInitTypeDef *TIM_TimeBaseInitStruct);
+void       TIM_OCStructInit(TIM_OCInitTypeDef *TIM_OCInitStruct);
+void       TIM_ICStructInit(TIM_ICInitTypeDef *TIM_ICInitStruct);
+void       TIM_BDTRStructInit(TIM_BDTRInitTypeDef *TIM_BDTRInitStruct);
+void       TIM_Cmd(TIM_TypeDef *TIMx, FunctionalState NewState);
+void       TIM_CtrlPWMOutputs(TIM_TypeDef *TIMx, FunctionalState NewState);
+void       TIM_ITConfig(TIM_TypeDef *TIMx, uint16_t TIM_IT, FunctionalState NewState);
+void       TIM_GenerateEvent(TIM_TypeDef *TIMx, uint16_t TIM_EventSource);
+void       TIM_DMAConfig(TIM_TypeDef *TIMx, uint16_t TIM_DMABase, uint16_t TIM_DMABurstLength);
+void       TIM_DMACmd(TIM_TypeDef *TIMx, uint16_t TIM_DMASource, FunctionalState NewState);
+void       TIM_InternalClockConfig(TIM_TypeDef *TIMx);
+void       TIM_ITRxExternalClockConfig(TIM_TypeDef *TIMx, uint16_t TIM_InputTriggerSource);
+void       TIM_TIxExternalClockConfig(TIM_TypeDef *TIMx, uint16_t TIM_TIxExternalCLKSource,
+                                      uint16_t TIM_ICPolarity, uint16_t ICFilter);
+void       TIM_ETRClockMode1Config(TIM_TypeDef *TIMx, uint16_t TIM_ExtTRGPrescaler, uint16_t TIM_ExtTRGPolarity,
+                                   uint16_t ExtTRGFilter);
+void       TIM_ETRClockMode2Config(TIM_TypeDef *TIMx, uint16_t TIM_ExtTRGPrescaler,
+                                   uint16_t TIM_ExtTRGPolarity, uint16_t ExtTRGFilter);
+void       TIM_ETRConfig(TIM_TypeDef *TIMx, uint16_t TIM_ExtTRGPrescaler, uint16_t TIM_ExtTRGPolarity,
+                         uint16_t ExtTRGFilter);
+void       TIM_PrescalerConfig(TIM_TypeDef *TIMx, uint16_t Prescaler, uint16_t TIM_PSCReloadMode);
+void       TIM_CounterModeConfig(TIM_TypeDef *TIMx, uint16_t TIM_CounterMode);
+void       TIM_SelectInputTrigger(TIM_TypeDef *TIMx, uint16_t TIM_InputTriggerSource);
+void       TIM_EncoderInterfaceConfig(TIM_TypeDef *TIMx, uint16_t TIM_EncoderMode,
+                                      uint16_t TIM_IC1Polarity, uint16_t TIM_IC2Polarity);
+void       TIM_ForcedOC1Config(TIM_TypeDef *TIMx, uint16_t TIM_ForcedAction);
+void       TIM_ForcedOC2Config(TIM_TypeDef *TIMx, uint16_t TIM_ForcedAction);
+void       TIM_ForcedOC3Config(TIM_TypeDef *TIMx, uint16_t TIM_ForcedAction);
+void       TIM_ForcedOC4Config(TIM_TypeDef *TIMx, uint16_t TIM_ForcedAction);
+void       TIM_ARRPreloadConfig(TIM_TypeDef *TIMx, FunctionalState NewState);
+void       TIM_SelectCOM(TIM_TypeDef *TIMx, FunctionalState NewState);
+void       TIM_SelectCCDMA(TIM_TypeDef *TIMx, FunctionalState NewState);
+void       TIM_CCPreloadControl(TIM_TypeDef *TIMx, FunctionalState NewState);
+void       TIM_OC1PreloadConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCPreload);
+void       TIM_OC2PreloadConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCPreload);
+void       TIM_OC3PreloadConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCPreload);
+void       TIM_OC4PreloadConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCPreload);
+void       TIM_OC1FastConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCFast);
+void       TIM_OC2FastConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCFast);
+void       TIM_OC3FastConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCFast);
+void       TIM_OC4FastConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCFast);
+void       TIM_ClearOC1Ref(TIM_TypeDef *TIMx, uint16_t TIM_OCClear);
+void       TIM_ClearOC2Ref(TIM_TypeDef *TIMx, uint16_t TIM_OCClear);
+void       TIM_ClearOC3Ref(TIM_TypeDef *TIMx, uint16_t TIM_OCClear);
+void       TIM_ClearOC4Ref(TIM_TypeDef *TIMx, uint16_t TIM_OCClear);
+void       TIM_OC1PolarityConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCPolarity);
+void       TIM_OC1NPolarityConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCNPolarity);
+void       TIM_OC2PolarityConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCPolarity);
+void       TIM_OC2NPolarityConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCNPolarity);
+void       TIM_OC3PolarityConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCPolarity);
+void       TIM_OC3NPolarityConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCNPolarity);
+void       TIM_OC4PolarityConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCPolarity);
+void       TIM_CCxCmd(TIM_TypeDef *TIMx, uint16_t TIM_Channel, uint16_t TIM_CCx);
+void       TIM_CCxNCmd(TIM_TypeDef *TIMx, uint16_t TIM_Channel, uint16_t TIM_CCxN);
+void       TIM_SelectOCxM(TIM_TypeDef *TIMx, uint16_t TIM_Channel, uint16_t TIM_OCMode);
+void       TIM_UpdateDisableConfig(TIM_TypeDef *TIMx, FunctionalState NewState);
+void       TIM_UpdateRequestConfig(TIM_TypeDef *TIMx, uint16_t TIM_UpdateSource);
+void       TIM_SelectHallSensor(TIM_TypeDef *TIMx, FunctionalState NewState);
+void       TIM_SelectOnePulseMode(TIM_TypeDef *TIMx, uint16_t TIM_OPMode);
+void       TIM_SelectOutputTrigger(TIM_TypeDef *TIMx, uint16_t TIM_TRGOSource);
+void       TIM_SelectSlaveMode(TIM_TypeDef *TIMx, uint16_t TIM_SlaveMode);
+void       TIM_SelectMasterSlaveMode(TIM_TypeDef *TIMx, uint16_t TIM_MasterSlaveMode);
+void       TIM_SetCounter(TIM_TypeDef *TIMx, uint16_t Counter);
+void       TIM_SetAutoreload(TIM_TypeDef *TIMx, uint16_t Autoreload);
+void       TIM_SetCompare1(TIM_TypeDef *TIMx, uint16_t Compare1);
+void       TIM_SetCompare2(TIM_TypeDef *TIMx, uint16_t Compare2);
+void       TIM_SetCompare3(TIM_TypeDef *TIMx, uint16_t Compare3);
+void       TIM_SetCompare4(TIM_TypeDef *TIMx, uint16_t Compare4);
+void       TIM_SetIC1Prescaler(TIM_TypeDef *TIMx, uint16_t TIM_ICPSC);
+void       TIM_SetIC2Prescaler(TIM_TypeDef *TIMx, uint16_t TIM_ICPSC);
+void       TIM_SetIC3Prescaler(TIM_TypeDef *TIMx, uint16_t TIM_ICPSC);
+void       TIM_SetIC4Prescaler(TIM_TypeDef *TIMx, uint16_t TIM_ICPSC);
+void       TIM_SetClockDivision(TIM_TypeDef *TIMx, uint16_t TIM_CKD);
+uint16_t   TIM_GetCapture1(TIM_TypeDef *TIMx);
+uint16_t   TIM_GetCapture2(TIM_TypeDef *TIMx);
+uint16_t   TIM_GetCapture3(TIM_TypeDef *TIMx);
+uint16_t   TIM_GetCapture4(TIM_TypeDef *TIMx);
+uint16_t   TIM_GetCounter(TIM_TypeDef *TIMx);
+uint16_t   TIM_GetPrescaler(TIM_TypeDef *TIMx);
+FlagStatus TIM_GetFlagStatus(TIM_TypeDef *TIMx, uint16_t TIM_FLAG);
+void       TIM_ClearFlag(TIM_TypeDef *TIMx, uint16_t TIM_FLAG);
+ITStatus   TIM_GetITStatus(TIM_TypeDef *TIMx, uint16_t TIM_IT);
+void       TIM_ClearITPendingBit(TIM_TypeDef *TIMx, uint16_t TIM_IT);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Sources/source/Peripheral/inc/ch32v20x_usart.h
+++ b/Sources/source/Peripheral/inc/ch32v20x_usart.h
@@ -1,0 +1,187 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32v20x_usart.h
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/06/06
+ * Description        : This file contains all the functions prototypes for the
+ *                      USART firmware library.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#ifndef __CH32V20x_USART_H
+#define __CH32V20x_USART_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "ch32v20x.h"
+
+/* USART Init Structure definition */
+typedef struct
+{
+    uint32_t USART_BaudRate; /* This member configures the USART communication baud rate.
+                                The baud rate is computed using the following formula:
+                                 - IntegerDivider = ((PCLKx) / (16 * (USART_InitStruct->USART_BaudRate)))
+                                 - FractionalDivider = ((IntegerDivider - ((u32) IntegerDivider)) * 16) + 0.5 */
+
+    uint16_t USART_WordLength; /* Specifies the number of data bits transmitted or received in a frame.
+                                  This parameter can be a value of @ref USART_Word_Length */
+
+    uint16_t USART_StopBits; /* Specifies the number of stop bits transmitted.
+                                This parameter can be a value of @ref USART_Stop_Bits */
+
+    uint16_t USART_Parity; /* Specifies the parity mode.
+                              This parameter can be a value of @ref USART_Parity
+                              @note When parity is enabled, the computed parity is inserted
+                                    at the MSB position of the transmitted data (9th bit when
+                                    the word length is set to 9 data bits; 8th bit when the
+                                    word length is set to 8 data bits). */
+
+    uint16_t USART_Mode; /* Specifies wether the Receive or Transmit mode is enabled or disabled.
+                            This parameter can be a value of @ref USART_Mode */
+
+    uint16_t USART_HardwareFlowControl; /* Specifies wether the hardware flow control mode is enabled
+                                           or disabled.
+                                           This parameter can be a value of @ref USART_Hardware_Flow_Control */
+} USART_InitTypeDef;
+
+/* USART Clock Init Structure definition */
+typedef struct
+{
+    uint16_t USART_Clock; /* Specifies whether the USART clock is enabled or disabled.
+                             This parameter can be a value of @ref USART_Clock */
+
+    uint16_t USART_CPOL; /* Specifies the steady state value of the serial clock.
+                            This parameter can be a value of @ref USART_Clock_Polarity */
+
+    uint16_t USART_CPHA; /* Specifies the clock transition on which the bit capture is made.
+                            This parameter can be a value of @ref USART_Clock_Phase */
+
+    uint16_t USART_LastBit; /* Specifies whether the clock pulse corresponding to the last transmitted
+                               data bit (MSB) has to be output on the SCLK pin in synchronous mode.
+                               This parameter can be a value of @ref USART_Last_Bit */
+} USART_ClockInitTypeDef;
+
+/* USART_Word_Length */
+#define USART_WordLength_8b                  ((uint16_t)0x0000)
+#define USART_WordLength_9b                  ((uint16_t)0x1000)
+
+/* USART_Stop_Bits */
+#define USART_StopBits_1                     ((uint16_t)0x0000)
+#define USART_StopBits_0_5                   ((uint16_t)0x1000)
+#define USART_StopBits_2                     ((uint16_t)0x2000)
+#define USART_StopBits_1_5                   ((uint16_t)0x3000)
+
+/* USART_Parity */
+#define USART_Parity_No                      ((uint16_t)0x0000)
+#define USART_Parity_Even                    ((uint16_t)0x0400)
+#define USART_Parity_Odd                     ((uint16_t)0x0600)
+
+/* USART_Mode */
+#define USART_Mode_Rx                        ((uint16_t)0x0004)
+#define USART_Mode_Tx                        ((uint16_t)0x0008)
+
+/* USART_Hardware_Flow_Control */
+#define USART_HardwareFlowControl_None       ((uint16_t)0x0000)
+#define USART_HardwareFlowControl_RTS        ((uint16_t)0x0100)
+#define USART_HardwareFlowControl_CTS        ((uint16_t)0x0200)
+#define USART_HardwareFlowControl_RTS_CTS    ((uint16_t)0x0300)
+
+/* USART_Clock */
+#define USART_Clock_Disable                  ((uint16_t)0x0000)
+#define USART_Clock_Enable                   ((uint16_t)0x0800)
+
+/* USART_Clock_Polarity */
+#define USART_CPOL_Low                       ((uint16_t)0x0000)
+#define USART_CPOL_High                      ((uint16_t)0x0400)
+
+/* USART_Clock_Phase */
+#define USART_CPHA_1Edge                     ((uint16_t)0x0000)
+#define USART_CPHA_2Edge                     ((uint16_t)0x0200)
+
+/* USART_Last_Bit */
+#define USART_LastBit_Disable                ((uint16_t)0x0000)
+#define USART_LastBit_Enable                 ((uint16_t)0x0100)
+
+/* USART_Interrupt_definition */
+#define USART_IT_PE                          ((uint16_t)0x0028)
+#define USART_IT_TXE                         ((uint16_t)0x0727)
+#define USART_IT_TC                          ((uint16_t)0x0626)
+#define USART_IT_RXNE                        ((uint16_t)0x0525)
+#define USART_IT_ORE_RX                      ((uint16_t)0x0325)
+#define USART_IT_IDLE                        ((uint16_t)0x0424)
+#define USART_IT_LBD                         ((uint16_t)0x0846)
+#define USART_IT_CTS                         ((uint16_t)0x096A)
+#define USART_IT_ERR                         ((uint16_t)0x0060)
+#define USART_IT_ORE_ER                      ((uint16_t)0x0360)
+#define USART_IT_NE                          ((uint16_t)0x0260)
+#define USART_IT_FE                          ((uint16_t)0x0160)
+
+#define USART_IT_ORE                         USART_IT_ORE_ER
+
+/* USART_DMA_Requests */
+#define USART_DMAReq_Tx                      ((uint16_t)0x0080)
+#define USART_DMAReq_Rx                      ((uint16_t)0x0040)
+
+/* USART_WakeUp_methods */
+#define USART_WakeUp_IdleLine                ((uint16_t)0x0000)
+#define USART_WakeUp_AddressMark             ((uint16_t)0x0800)
+
+/* USART_LIN_Break_Detection_Length */
+#define USART_LINBreakDetectLength_10b       ((uint16_t)0x0000)
+#define USART_LINBreakDetectLength_11b       ((uint16_t)0x0020)
+
+/* USART_IrDA_Low_Power */
+#define USART_IrDAMode_LowPower              ((uint16_t)0x0004)
+#define USART_IrDAMode_Normal                ((uint16_t)0x0000)
+
+/* USART_Flags */
+#define USART_FLAG_CTS                       ((uint16_t)0x0200)
+#define USART_FLAG_LBD                       ((uint16_t)0x0100)
+#define USART_FLAG_TXE                       ((uint16_t)0x0080)
+#define USART_FLAG_TC                        ((uint16_t)0x0040)
+#define USART_FLAG_RXNE                      ((uint16_t)0x0020)
+#define USART_FLAG_IDLE                      ((uint16_t)0x0010)
+#define USART_FLAG_ORE                       ((uint16_t)0x0008)
+#define USART_FLAG_NE                        ((uint16_t)0x0004)
+#define USART_FLAG_FE                        ((uint16_t)0x0002)
+#define USART_FLAG_PE                        ((uint16_t)0x0001)
+
+void       USART_DeInit(USART_TypeDef *USARTx);
+void       USART_Init(USART_TypeDef *USARTx, USART_InitTypeDef *USART_InitStruct);
+void       USART_StructInit(USART_InitTypeDef *USART_InitStruct);
+void       USART_ClockInit(USART_TypeDef *USARTx, USART_ClockInitTypeDef *USART_ClockInitStruct);
+void       USART_ClockStructInit(USART_ClockInitTypeDef *USART_ClockInitStruct);
+void       USART_Cmd(USART_TypeDef *USARTx, FunctionalState NewState);
+void       USART_ITConfig(USART_TypeDef *USARTx, uint16_t USART_IT, FunctionalState NewState);
+void       USART_DMACmd(USART_TypeDef *USARTx, uint16_t USART_DMAReq, FunctionalState NewState);
+void       USART_SetAddress(USART_TypeDef *USARTx, uint8_t USART_Address);
+void       USART_WakeUpConfig(USART_TypeDef *USARTx, uint16_t USART_WakeUp);
+void       USART_ReceiverWakeUpCmd(USART_TypeDef *USARTx, FunctionalState NewState);
+void       USART_LINBreakDetectLengthConfig(USART_TypeDef *USARTx, uint16_t USART_LINBreakDetectLength);
+void       USART_LINCmd(USART_TypeDef *USARTx, FunctionalState NewState);
+void       USART_SendData(USART_TypeDef *USARTx, uint16_t Data);
+uint16_t   USART_ReceiveData(USART_TypeDef *USARTx);
+void       USART_SendBreak(USART_TypeDef *USARTx);
+void       USART_SetGuardTime(USART_TypeDef *USARTx, uint8_t USART_GuardTime);
+void       USART_SetPrescaler(USART_TypeDef *USARTx, uint8_t USART_Prescaler);
+void       USART_SmartCardCmd(USART_TypeDef *USARTx, FunctionalState NewState);
+void       USART_SmartCardNACKCmd(USART_TypeDef *USARTx, FunctionalState NewState);
+void       USART_HalfDuplexCmd(USART_TypeDef *USARTx, FunctionalState NewState);
+void       USART_OverSampling8Cmd(USART_TypeDef *USARTx, FunctionalState NewState);
+void       USART_OneBitMethodCmd(USART_TypeDef *USARTx, FunctionalState NewState);
+void       USART_IrDAConfig(USART_TypeDef *USARTx, uint16_t USART_IrDAMode);
+void       USART_IrDACmd(USART_TypeDef *USARTx, FunctionalState NewState);
+FlagStatus USART_GetFlagStatus(USART_TypeDef *USARTx, uint16_t USART_FLAG);
+void       USART_ClearFlag(USART_TypeDef *USARTx, uint16_t USART_FLAG);
+ITStatus   USART_GetITStatus(USART_TypeDef *USARTx, uint16_t USART_IT);
+void       USART_ClearITPendingBit(USART_TypeDef *USARTx, uint16_t USART_IT);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Sources/source/Peripheral/src/ch32v20x_exti.c
+++ b/Sources/source/Peripheral/src/ch32v20x_exti.c
@@ -1,0 +1,182 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32v20x_exti.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/06/06
+ * Description        : This file provides all the EXTI firmware functions.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#include "ch32v20x_exti.h"
+
+/* No interrupt selected */
+#define EXTI_LINENONE    ((uint32_t)0x00000)
+
+/*********************************************************************
+ * @fn      EXTI_DeInit
+ *
+ * @brief   Deinitializes the EXTI peripheral registers to their default
+ *        reset values.
+ *
+ * @return  none.
+ */
+void EXTI_DeInit(void)
+{
+    EXTI->INTENR = 0x00000000;
+    EXTI->EVENR = 0x00000000;
+    EXTI->RTENR = 0x00000000;
+    EXTI->FTENR = 0x00000000;
+    EXTI->INTFR = 0x000FFFFF;
+}
+
+/*********************************************************************
+ * @fn      EXTI_Init
+ *
+ * @brief   Initializes the EXTI peripheral according to the specified
+ *        parameters in the EXTI_InitStruct.
+ *
+ * @param   EXTI_InitStruct: pointer to a EXTI_InitTypeDef structure
+ *
+ * @return  none.
+ */
+void EXTI_Init(EXTI_InitTypeDef *EXTI_InitStruct)
+{
+    uint32_t tmp = 0;
+
+    tmp = (uint32_t)EXTI_BASE;
+    if(EXTI_InitStruct->EXTI_LineCmd != DISABLE)
+    {
+        EXTI->INTENR &= ~EXTI_InitStruct->EXTI_Line;
+        EXTI->EVENR &= ~EXTI_InitStruct->EXTI_Line;
+        tmp += EXTI_InitStruct->EXTI_Mode;
+        *(__IO uint32_t *)tmp |= EXTI_InitStruct->EXTI_Line;
+        EXTI->RTENR &= ~EXTI_InitStruct->EXTI_Line;
+        EXTI->FTENR &= ~EXTI_InitStruct->EXTI_Line;
+        if(EXTI_InitStruct->EXTI_Trigger == EXTI_Trigger_Rising_Falling)
+        {
+            EXTI->RTENR |= EXTI_InitStruct->EXTI_Line;
+            EXTI->FTENR |= EXTI_InitStruct->EXTI_Line;
+        }
+        else
+        {
+            tmp = (uint32_t)EXTI_BASE;
+            tmp += EXTI_InitStruct->EXTI_Trigger;
+            *(__IO uint32_t *)tmp |= EXTI_InitStruct->EXTI_Line;
+        }
+    }
+    else
+    {
+        tmp += EXTI_InitStruct->EXTI_Mode;
+        *(__IO uint32_t *)tmp &= ~EXTI_InitStruct->EXTI_Line;
+    }
+}
+
+/*********************************************************************
+ * @fn      EXTI_StructInit
+ *
+ * @brief   Fills each EXTI_InitStruct member with its reset value.
+ *
+ * @param   EXTI_InitStruct - pointer to a EXTI_InitTypeDef structure
+ *
+ * @return  none.
+ */
+void EXTI_StructInit(EXTI_InitTypeDef *EXTI_InitStruct)
+{
+    EXTI_InitStruct->EXTI_Line = EXTI_LINENONE;
+    EXTI_InitStruct->EXTI_Mode = EXTI_Mode_Interrupt;
+    EXTI_InitStruct->EXTI_Trigger = EXTI_Trigger_Falling;
+    EXTI_InitStruct->EXTI_LineCmd = DISABLE;
+}
+
+/*********************************************************************
+ * @fn      EXTI_GenerateSWInterrupt
+ *
+ * @brief   Generates a Software interrupt.
+ *
+ * @param   EXTI_Line - specifies the EXTI lines to be enabled or disabled.
+ *
+ * @return  none.
+ */
+void EXTI_GenerateSWInterrupt(uint32_t EXTI_Line)
+{
+    EXTI->SWIEVR |= EXTI_Line;
+}
+
+/*********************************************************************
+ * @fn      EXTI_GetFlagStatus
+ *
+ * @brief   Checks whether the specified EXTI line flag is set or not.
+ *
+ * @param   EXTI_Line - specifies the EXTI lines to be enabled or disabled.
+ *
+ * @return  The new state of EXTI_Line (SET or RESET).
+ */
+FlagStatus EXTI_GetFlagStatus(uint32_t EXTI_Line)
+{
+    FlagStatus bitstatus = RESET;
+    if((EXTI->INTFR & EXTI_Line) != (uint32_t)RESET)
+    {
+        bitstatus = SET;
+    }
+    else
+    {
+        bitstatus = RESET;
+    }
+    return bitstatus;
+}
+
+/*********************************************************************
+ * @fn      EXTI_ClearFlag
+ *
+ * @brief   Clears the EXTI's line pending flags.
+ *
+ * @param   EXTI_Line - specifies the EXTI lines to be enabled or disabled.
+ *
+ * @return  None
+ */
+void EXTI_ClearFlag(uint32_t EXTI_Line)
+{
+    EXTI->INTFR = EXTI_Line;
+}
+
+/*********************************************************************
+ * @fn      EXTI_GetITStatus
+ *
+ * @brief   Checks whether the specified EXTI line is asserted or not.
+ *
+ * @param   EXTI_Line - specifies the EXTI lines to be enabled or disabled.
+ *
+ * @return  The new state of EXTI_Line (SET or RESET).
+ */
+ITStatus EXTI_GetITStatus(uint32_t EXTI_Line)
+{
+    ITStatus bitstatus = RESET;
+    uint32_t enablestatus = 0;
+
+    enablestatus = EXTI->INTENR & EXTI_Line;
+    if(((EXTI->INTFR & EXTI_Line) != (uint32_t)RESET) && (enablestatus != (uint32_t)RESET))
+    {
+        bitstatus = SET;
+    }
+    else
+    {
+        bitstatus = RESET;
+    }
+    return bitstatus;
+}
+
+/*********************************************************************
+ * @fn      EXTI_ClearITPendingBit
+ *
+ * @brief   Clears the EXTI's line pending bits.
+ *
+ * @param   EXTI_Line - specifies the EXTI lines to be enabled or disabled.
+ *
+ * @return  none
+ */
+void EXTI_ClearITPendingBit(uint32_t EXTI_Line)
+{
+    EXTI->INTFR = EXTI_Line;
+}

--- a/Sources/source/Peripheral/src/ch32v20x_gpio.c
+++ b/Sources/source/Peripheral/src/ch32v20x_gpio.c
@@ -1,0 +1,666 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32v20x_gpio.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/06/06
+ * Description        : This file provides all the GPIO firmware functions.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#include "ch32v20x_gpio.h"
+#include "ch32v20x_rcc.h"
+
+/* MASK */
+#define ECR_PORTPINCONFIG_MASK    ((uint16_t)0xFF80)
+#define LSB_MASK                  ((uint16_t)0xFFFF)
+#define DBGAFR_POSITION_MASK      ((uint32_t)0x000F0000)
+#define DBGAFR_SWJCFG_MASK        ((uint32_t)0xF0FFFFFF)
+#define DBGAFR_LOCATION_MASK      ((uint32_t)0x00200000)
+#define DBGAFR_NUMBITS_MASK       ((uint32_t)0x00100000)
+
+#if defined (CH32V20x_D6)
+uint8_t MCU_Version = 0;
+#endif
+
+/*********************************************************************
+ * @fn      GPIO_DeInit
+ *
+ * @brief   Deinitializes the GPIOx peripheral registers to their default
+ *        reset values.
+ *
+ * @param   GPIOx - where x can be (A..G) to select the GPIO peripheral.
+ *
+ * @return  none
+ */
+void GPIO_DeInit(GPIO_TypeDef *GPIOx)
+{
+    if(GPIOx == GPIOA)
+    {
+        RCC_APB2PeriphResetCmd(RCC_APB2Periph_GPIOA, ENABLE);
+        RCC_APB2PeriphResetCmd(RCC_APB2Periph_GPIOA, DISABLE);
+    }
+    else if(GPIOx == GPIOB)
+    {
+        RCC_APB2PeriphResetCmd(RCC_APB2Periph_GPIOB, ENABLE);
+        RCC_APB2PeriphResetCmd(RCC_APB2Periph_GPIOB, DISABLE);
+    }
+    else if(GPIOx == GPIOC)
+    {
+        RCC_APB2PeriphResetCmd(RCC_APB2Periph_GPIOC, ENABLE);
+        RCC_APB2PeriphResetCmd(RCC_APB2Periph_GPIOC, DISABLE);
+    }
+    else if(GPIOx == GPIOD)
+    {
+        RCC_APB2PeriphResetCmd(RCC_APB2Periph_GPIOD, ENABLE);
+        RCC_APB2PeriphResetCmd(RCC_APB2Periph_GPIOD, DISABLE);
+    }
+    else if(GPIOx == GPIOE)
+    {
+        RCC_APB2PeriphResetCmd(RCC_APB2Periph_GPIOE, ENABLE);
+        RCC_APB2PeriphResetCmd(RCC_APB2Periph_GPIOE, DISABLE);
+    }
+}
+
+/*********************************************************************
+ * @fn      GPIO_AFIODeInit
+ *
+ * @brief   Deinitializes the Alternate Functions (remap, event control
+ *        and EXTI configuration) registers to their default reset values.
+ *
+ * @return  none
+ */
+void GPIO_AFIODeInit(void)
+{
+    RCC_APB2PeriphResetCmd(RCC_APB2Periph_AFIO, ENABLE);
+    RCC_APB2PeriphResetCmd(RCC_APB2Periph_AFIO, DISABLE);
+}
+
+/*********************************************************************
+ * @fn      GPIO_Init
+ *
+ * @brief   GPIOx - where x can be (A..G) to select the GPIO peripheral.
+ *
+ * @param   GPIO_InitStruct - pointer to a GPIO_InitTypeDef structure that
+ *        contains the configuration information for the specified GPIO peripheral.
+ *
+ * @return  none
+ */
+void GPIO_Init(GPIO_TypeDef *GPIOx, GPIO_InitTypeDef *GPIO_InitStruct)
+{
+    uint32_t currentmode = 0x00, currentpin = 0x00, pinpos = 0x00, pos = 0x00;
+    uint32_t tmpreg = 0x00, pinmask = 0x00;
+
+    currentmode = ((uint32_t)GPIO_InitStruct->GPIO_Mode) & ((uint32_t)0x0F);
+
+    if((((uint32_t)GPIO_InitStruct->GPIO_Mode) & ((uint32_t)0x10)) != 0x00)
+    {
+        currentmode |= (uint32_t)GPIO_InitStruct->GPIO_Speed;
+    }
+#if defined (CH32V20x_D6)
+    if(((*(uint32_t *) 0x40022030) & 0x0F000000) == 0)
+    {
+        MCU_Version = 1;
+    }
+
+    if((GPIOx == GPIOC) && MCU_Version){
+        GPIO_InitStruct->GPIO_Pin = GPIO_InitStruct->GPIO_Pin >> 13;
+    }
+
+#endif
+    if(((uint32_t)GPIO_InitStruct->GPIO_Pin & ((uint32_t)0x00FF)) != 0x00)
+    {
+        tmpreg = GPIOx->CFGLR;
+
+        for(pinpos = 0x00; pinpos < 0x08; pinpos++)
+        {
+            pos = ((uint32_t)0x01) << pinpos;
+            currentpin = (GPIO_InitStruct->GPIO_Pin) & pos;
+
+            if(currentpin == pos)
+            {
+                pos = pinpos << 2;
+                pinmask = ((uint32_t)0x0F) << pos;
+                tmpreg &= ~pinmask;
+                tmpreg |= (currentmode << pos);
+
+                if(GPIO_InitStruct->GPIO_Mode == GPIO_Mode_IPD)
+                {
+                    GPIOx->BCR = (((uint32_t)0x01) << pinpos);
+                }
+                else
+                {
+                    if(GPIO_InitStruct->GPIO_Mode == GPIO_Mode_IPU)
+                    {
+                        GPIOx->BSHR = (((uint32_t)0x01) << pinpos);
+                    }
+                }
+            }
+        }
+        GPIOx->CFGLR = tmpreg;
+    }
+
+    if(GPIO_InitStruct->GPIO_Pin > 0x00FF)
+    {
+        tmpreg = GPIOx->CFGHR;
+
+        for(pinpos = 0x00; pinpos < 0x08; pinpos++)
+        {
+            pos = (((uint32_t)0x01) << (pinpos + 0x08));
+            currentpin = ((GPIO_InitStruct->GPIO_Pin) & pos);
+
+            if(currentpin == pos)
+            {
+                pos = pinpos << 2;
+                pinmask = ((uint32_t)0x0F) << pos;
+                tmpreg &= ~pinmask;
+                tmpreg |= (currentmode << pos);
+
+                if(GPIO_InitStruct->GPIO_Mode == GPIO_Mode_IPD)
+                {
+                    GPIOx->BCR = (((uint32_t)0x01) << (pinpos + 0x08));
+                }
+
+                if(GPIO_InitStruct->GPIO_Mode == GPIO_Mode_IPU)
+                {
+                    GPIOx->BSHR = (((uint32_t)0x01) << (pinpos + 0x08));
+                }
+            }
+        }
+        GPIOx->CFGHR = tmpreg;
+    }
+}
+
+/*********************************************************************
+ * @fn      GPIO_StructInit
+ *
+ * @brief   Fills each GPIO_InitStruct member with its default
+ *
+ * @param   GPIO_InitStruct - pointer to a GPIO_InitTypeDef structure
+ *      which will be initialized.
+ *
+ * @return  none
+ */
+void GPIO_StructInit(GPIO_InitTypeDef *GPIO_InitStruct)
+{
+    GPIO_InitStruct->GPIO_Pin = GPIO_Pin_All;
+    GPIO_InitStruct->GPIO_Speed = GPIO_Speed_2MHz;
+    GPIO_InitStruct->GPIO_Mode = GPIO_Mode_IN_FLOATING;
+}
+
+/*********************************************************************
+ * @fn      GPIO_ReadInputDataBit
+ *
+ * @brief   GPIOx - where x can be (A..G) to select the GPIO peripheral.
+ *
+ * @param    GPIO_Pin - specifies the port bit to read.
+ *             This parameter can be GPIO_Pin_x where x can be (0..15).
+ *
+ * @return  The input port pin value.
+ */
+uint8_t GPIO_ReadInputDataBit(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin)
+{
+    uint8_t bitstatus = 0x00;
+
+#if defined (CH32V20x_D6)
+    if((GPIOx == GPIOC) && MCU_Version){
+        GPIO_Pin = GPIO_Pin >> 13;
+    }
+
+#endif
+
+    if((GPIOx->INDR & GPIO_Pin) != (uint32_t)Bit_RESET)
+    {
+        bitstatus = (uint8_t)Bit_SET;
+    }
+    else
+    {
+        bitstatus = (uint8_t)Bit_RESET;
+    }
+
+    return bitstatus;
+}
+
+/*********************************************************************
+ * @fn      GPIO_ReadInputData
+ *
+ * @brief   Reads the specified GPIO input data port.
+ *
+ * @param   GPIOx - where x can be (A..G) to select the GPIO peripheral.
+ *
+ * @return  The output port pin value.
+ */
+uint16_t GPIO_ReadInputData(GPIO_TypeDef *GPIOx)
+{
+    uint16_t val;
+
+#if defined (CH32V20x_D6)
+    if((GPIOx == GPIOC) && MCU_Version){
+        val = ( uint16_t )(GPIOx->INDR << 13);
+    }
+    else{
+        val = ( uint16_t )GPIOx->INDR;
+    }
+
+#else
+    val = ( uint16_t )GPIOx->INDR;
+#endif
+
+return ( val );
+}
+
+/*********************************************************************
+ * @fn      GPIO_ReadOutputDataBit
+ *
+ * @brief   Reads the specified output data port bit.
+ *
+ * @param   GPIOx - where x can be (A..G) to select the GPIO peripheral.
+ *          GPIO_Pin - specifies the port bit to read.
+ *            This parameter can be GPIO_Pin_x where x can be (0..15).
+ *
+ * @return  none
+ */
+uint8_t GPIO_ReadOutputDataBit(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin)
+{
+    uint8_t bitstatus = 0x00;
+
+#if defined (CH32V20x_D6)
+    if((GPIOx == GPIOC) && MCU_Version){
+        GPIO_Pin = GPIO_Pin >> 13;
+    }
+
+#endif
+
+    if((GPIOx->OUTDR & GPIO_Pin) != (uint32_t)Bit_RESET)
+    {
+        bitstatus = (uint8_t)Bit_SET;
+    }
+    else
+    {
+        bitstatus = (uint8_t)Bit_RESET;
+    }
+
+    return bitstatus;
+}
+
+/*********************************************************************
+ * @fn      GPIO_ReadOutputData
+ *
+ * @brief   Reads the specified GPIO output data port.
+ *
+ * @param   GPIOx - where x can be (A..G) to select the GPIO peripheral.
+ *
+ * @return  GPIO output port pin value.
+ */
+uint16_t GPIO_ReadOutputData(GPIO_TypeDef *GPIOx)
+{
+    uint16_t val;
+
+#if defined (CH32V20x_D6)
+    if((GPIOx == GPIOC) && MCU_Version){
+        val = ( uint16_t )(GPIOx->OUTDR << 13);
+    }
+    else{
+        val = ( uint16_t )GPIOx->OUTDR;
+    }
+
+#else
+    val = ( uint16_t )GPIOx->OUTDR;
+#endif
+
+    return ( val );
+}
+
+/*********************************************************************
+ * @fn      GPIO_SetBits
+ *
+ * @brief   Sets the selected data port bits.
+ *
+ * @param   GPIOx - where x can be (A..G) to select the GPIO peripheral.
+ *          GPIO_Pin - specifies the port bits to be written.
+ *            This parameter can be any combination of GPIO_Pin_x where x can be (0..15).
+ *
+ * @return  none
+ */
+void GPIO_SetBits(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin)
+{
+#if defined (CH32V20x_D6)
+    if((GPIOx == GPIOC) && MCU_Version){
+        GPIO_Pin = GPIO_Pin >> 13;
+    }
+
+#endif
+
+    GPIOx->BSHR = GPIO_Pin;
+}
+
+/*********************************************************************
+ * @fn      GPIO_ResetBits
+ *
+ * @brief   Clears the selected data port bits.
+ *
+ * @param   GPIOx - where x can be (A..G) to select the GPIO peripheral.
+ *          GPIO_Pin - specifies the port bits to be written.
+ *            This parameter can be any combination of GPIO_Pin_x where x can be (0..15).
+ *
+ * @return  none
+ */
+void GPIO_ResetBits(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin)
+{
+#if defined (CH32V20x_D6)
+    if((GPIOx == GPIOC) && MCU_Version){
+        GPIO_Pin = GPIO_Pin >> 13;
+    }
+
+#endif
+
+    GPIOx->BCR = GPIO_Pin;
+}
+
+/*********************************************************************
+ * @fn      GPIO_WriteBit
+ *
+ * @brief   Sets or clears the selected data port bit.
+ *
+ * @param   GPIO_Pin - specifies the port bit to be written.
+ *            This parameter can be one of GPIO_Pin_x where x can be (0..15).
+ *          BitVal - specifies the value to be written to the selected bit.
+ *            Bit_SetL - to clear the port pin.
+ *            Bit_SetH - to set the port pin.
+ *
+ * @return  none
+ */
+void GPIO_WriteBit(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin, BitAction BitVal)
+{
+#if defined (CH32V20x_D6)
+    if((GPIOx == GPIOC) && MCU_Version){
+        GPIO_Pin = GPIO_Pin >> 13;
+    }
+
+#endif
+
+    if(BitVal != Bit_RESET)
+    {
+        GPIOx->BSHR = GPIO_Pin;
+    }
+    else
+    {
+        GPIOx->BCR = GPIO_Pin;
+    }
+}
+
+/*********************************************************************
+ * @fn      GPIO_Write
+ *
+ * @brief   Writes data to the specified GPIO data port.
+ *
+ * @param   GPIOx - where x can be (A..G) to select the GPIO peripheral.
+ *          PortVal - specifies the value to be written to the port output data register.
+ *
+ * @return  none
+ */
+void GPIO_Write(GPIO_TypeDef *GPIOx, uint16_t PortVal)
+{
+#if defined (CH32V20x_D6)
+    if((GPIOx == GPIOC) && MCU_Version){
+        PortVal = PortVal >> 13;
+    }
+
+#endif
+
+    GPIOx->OUTDR = PortVal;
+}
+
+/*********************************************************************
+ * @fn      GPIO_PinLockConfig
+ *
+ * @brief   Locks GPIO Pins configuration registers.
+ *
+ * @param   GPIOx - where x can be (A..G) to select the GPIO peripheral.
+ *          GPIO_Pin - specifies the port bit to be written.
+ *            This parameter can be any combination of GPIO_Pin_x where x can be (0..15).
+ *
+ * @return  none
+ */
+void GPIO_PinLockConfig(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin)
+{
+    uint32_t tmp = 0x00010000;
+
+#if defined (CH32V20x_D6)
+    if((GPIOx == GPIOC) && MCU_Version){
+        GPIO_Pin = GPIO_Pin >> 13;
+    }
+
+#endif
+
+    tmp |= GPIO_Pin;
+    GPIOx->LCKR = tmp;
+    GPIOx->LCKR = GPIO_Pin;
+    GPIOx->LCKR = tmp;
+    tmp = GPIOx->LCKR;
+    tmp = GPIOx->LCKR;
+}
+
+/*********************************************************************
+ * @fn      GPIO_EventOutputConfig
+ *
+ * @brief   Selects the GPIO pin used as Event output.
+ *
+ * @param   GPIO_PortSource - selects the GPIO port to be used as source
+ *        for Event output.
+ *            This parameter can be GPIO_PortSourceGPIOx where x can be (A..E).
+ *          GPIO_PinSource - specifies the pin for the Event output.
+ *            This parameter can be GPIO_PinSourcex where x can be (0..15).
+ *
+ * @return  none
+ */
+void GPIO_EventOutputConfig(uint8_t GPIO_PortSource, uint8_t GPIO_PinSource)
+{
+    uint32_t tmpreg = 0x00;
+
+    tmpreg = AFIO->ECR;
+    tmpreg &= ECR_PORTPINCONFIG_MASK;
+    tmpreg |= (uint32_t)GPIO_PortSource << 0x04;
+    tmpreg |= GPIO_PinSource;
+    AFIO->ECR = tmpreg;
+}
+
+/*********************************************************************
+ * @fn      GPIO_EventOutputCmd
+ *
+ * @brief   Enables or disables the Event Output.
+ *
+ * @param   NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void GPIO_EventOutputCmd(FunctionalState NewState)
+{
+    if(NewState)
+    {
+        AFIO->ECR |= (1 << 7);
+    }
+    else
+    {
+        AFIO->ECR &= ~(1 << 7);
+    }
+}
+
+/*********************************************************************
+ * @fn      GPIO_PinRemapConfig
+ *
+ * @brief   Changes the mapping of the specified pin.
+ *
+ * @param   GPIO_Remap - selects the pin to remap.
+ *            GPIO_Remap_SPI1 - SPI1 Alternate Function mapping
+ *            GPIO_Remap_I2C1 - I2C1 Alternate Function mapping
+ *            GPIO_Remap_USART1 - USART1 Alternate Function mapping
+ *            GPIO_Remap_USART2 - USART2 Alternate Function mapping
+ *            GPIO_PartialRemap_USART3 - USART3 Partial Alternate Function mapping
+ *            GPIO_FullRemap_USART3 - USART3 Full Alternate Function mapping
+ *            GPIO_PartialRemap_TIM1 - TIM1 Partial Alternate Function mapping
+ *            GPIO_FullRemap_TIM1 - TIM1 Full Alternate Function mapping
+ *            GPIO_PartialRemap1_TIM2 - TIM2 Partial1 Alternate Function mapping
+ *            GPIO_PartialRemap2_TIM2 - TIM2 Partial2 Alternate Function mapping
+ *            GPIO_FullRemap_TIM2 - TIM2 Full Alternate Function mapping
+ *            GPIO_PartialRemap_TIM3 - TIM3 Partial Alternate Function mapping
+ *            GPIO_FullRemap_TIM3 - TIM3 Full Alternate Function mapping
+ *            GPIO_Remap_TIM4 - TIM4 Alternate Function mapping
+ *            GPIO_Remap1_CAN1 - CAN1 Alternate Function mapping
+ *            GPIO_Remap2_CAN1 - CAN1 Alternate Function mapping
+ *            GPIO_Remap_PD01 - PD01 Alternate Function mapping
+ *            GPIO_Remap_ADC1_ETRGINJ - ADC1 External Trigger Injected Conversion remapping
+ *            GPIO_Remap_ADC1_ETRGREG - ADC1 External Trigger Regular Conversion remapping
+ *            GPIO_Remap_ADC2_ETRGINJ - ADC2 External Trigger Injected Conversion remapping
+ *            GPIO_Remap_ADC2_ETRGREG - ADC2 External Trigger Regular Conversion remapping
+ *            GPIO_Remap_ETH - Ethernet remapping
+ *            GPIO_Remap_CAN2 - CAN2 remapping
+ *            GPIO_Remap_MII_RMII_SEL - MII or RMII selection
+ *            GPIO_Remap_SWJ_NoJTRST - Full SWJ Enabled (JTAG-DP + SW-DP) but without JTRST
+ *            GPIO_Remap_SWJ_JTAGDisable - JTAG-DP Disabled and SW-DP Enabled
+ *            GPIO_Remap_SWJ_Disable - Full SWJ Disabled (JTAG-DP + SW-DP)
+ *            GPIO_Remap_TIM2ITR1_PTP_SOF - Ethernet PTP output or USB OTG SOF (Start of Frame) connected
+ *        to TIM2 Internal Trigger 1 for calibration
+ *            GPIO_Remap_TIM2ITR1_PTP_SOF - Ethernet PTP output or USB OTG SOF (Start of Frame)
+ *            GPIO_Remap_TIM8 - TIM8 Alternate Function mapping
+ *            GPIO_PartialRemap_TIM9 - TIM9 Partial Alternate Function mapping
+ *            GPIO_FullRemap_TIM9 - TIM9 Full Alternate Function mapping
+ *            GPIO_PartialRemap_TIM10 - TIM10 Partial Alternate Function mapping
+ *            GPIO_FullRemap_TIM10 - TIM10 Full Alternate Function mapping
+ *            GPIO_Remap_FSMC_NADV - FSMC_NADV Alternate Function mapping
+ *            GPIO_PartialRemap_USART4 - USART4 Partial Alternate Function mapping
+ *            GPIO_FullRemap_USART4 - USART4 Full Alternate Function mapping
+ *            GPIO_PartialRemap_USART5 - USART5 Partial Alternate Function mapping
+ *            GPIO_FullRemap_USART5 - USART5 Full Alternate Function mapping
+ *            GPIO_PartialRemap_USART6 - USART6 Partial Alternate Function mapping
+ *            GPIO_FullRemap_USART6 - USART6 Full Alternate Function mapping
+ *            GPIO_PartialRemap_USART7 - USART7 Partial Alternate Function mapping
+ *            GPIO_FullRemap_USART7 - USART7 Full Alternate Function mapping
+ *            GPIO_PartialRemap_USART8 - USART8 Partial Alternate Function mapping
+ *            GPIO_FullRemap_USART8 - USART8 Full Alternate Function mapping
+ *            GPIO_Remap_USART1_HighBit - USART1 Alternate Function mapping high bit
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void GPIO_PinRemapConfig(uint32_t GPIO_Remap, FunctionalState NewState)
+{
+    uint32_t tmp = 0x00, tmp1 = 0x00, tmpreg = 0x00, tmpmask = 0x00;
+
+    if((GPIO_Remap & 0x80000000) == 0x80000000)
+    {
+        tmpreg = AFIO->PCFR2;
+    }
+    else
+    {
+        tmpreg = AFIO->PCFR1;
+
+#if defined (CH32V20x_D6) || defined (CH32V20x_D8)
+    if(((*(uint32_t *) 0x40022030) & 0x0F000000) == 0){
+        tmpreg = ((tmpreg>>1)&0xFFFFE000)|(tmpreg&0x00001FFF);
+    }
+
+#endif
+    }
+
+    tmpmask = (GPIO_Remap & DBGAFR_POSITION_MASK) >> 0x10;
+    tmp = GPIO_Remap & LSB_MASK;
+
+    /* Clear bit */
+    if((GPIO_Remap & 0x80000000) == 0x80000000)
+    {                                                                                                                   /* PCFR2 */
+        if((GPIO_Remap & (DBGAFR_LOCATION_MASK | DBGAFR_NUMBITS_MASK)) == (DBGAFR_LOCATION_MASK | DBGAFR_NUMBITS_MASK)) /* [31:16] 2bit */
+        {
+            tmp1 = ((uint32_t)0x03) << (tmpmask + 0x10);
+            tmpreg &= ~tmp1;
+        }
+        else if((GPIO_Remap & DBGAFR_NUMBITS_MASK) == DBGAFR_NUMBITS_MASK) /* [15:0] 2bit */
+        {
+            tmp1 = ((uint32_t)0x03) << tmpmask;
+            tmpreg &= ~tmp1;
+        }
+        else /* [31:0] 1bit */
+        {
+            tmpreg &= ~(tmp << ((GPIO_Remap >> 0x15) * 0x10));
+        }
+    }
+    else
+    {                                                                                                                   /* PCFR1 */
+        if((GPIO_Remap & (DBGAFR_LOCATION_MASK | DBGAFR_NUMBITS_MASK)) == (DBGAFR_LOCATION_MASK | DBGAFR_NUMBITS_MASK)) /* [26:24] 3bit SWD_JTAG */
+        {
+            tmpreg &= DBGAFR_SWJCFG_MASK;
+            AFIO->PCFR1 &= DBGAFR_SWJCFG_MASK;
+        }
+        else if((GPIO_Remap & DBGAFR_NUMBITS_MASK) == DBGAFR_NUMBITS_MASK) /* [15:0] 2bit */
+        {
+            tmp1 = ((uint32_t)0x03) << tmpmask;
+            tmpreg &= ~tmp1;
+            tmpreg |= ~DBGAFR_SWJCFG_MASK;
+        }
+        else /* [31:0] 1bit */
+        {
+            tmpreg &= ~(tmp << ((GPIO_Remap >> 0x15) * 0x10));
+            tmpreg |= ~DBGAFR_SWJCFG_MASK;
+        }
+    }
+
+    /* Set bit */
+    if(NewState != DISABLE)
+    {
+        tmpreg |= (tmp << ((GPIO_Remap >> 0x15) * 0x10));
+    }
+
+    if((GPIO_Remap & 0x80000000) == 0x80000000)
+    {
+        AFIO->PCFR2 = tmpreg;
+    }
+    else
+    {
+        AFIO->PCFR1 = tmpreg;
+    }
+}
+
+/*********************************************************************
+ * @fn      GPIO_EXTILineConfig
+ *
+ * @brief   Selects the GPIO pin used as EXTI Line.
+ *
+ * @param   GPIO_PortSource - selects the GPIO port to be used as source for EXTI lines.
+ *            This parameter can be GPIO_PortSourceGPIOx where x can be (A..G).
+ *          GPIO_PinSource - specifies the EXTI line to be configured.
+ *            This parameter can be GPIO_PinSourcex where x can be (0..15).
+ *
+ * @return  none
+ */
+void GPIO_EXTILineConfig(uint8_t GPIO_PortSource, uint8_t GPIO_PinSource)
+{
+    uint32_t tmp = 0x00;
+
+    tmp = ((uint32_t)0x0F) << (0x04 * (GPIO_PinSource & (uint8_t)0x03));
+    AFIO->EXTICR[GPIO_PinSource >> 0x02] &= ~tmp;
+    AFIO->EXTICR[GPIO_PinSource >> 0x02] |= (((uint32_t)GPIO_PortSource) << (0x04 * (GPIO_PinSource & (uint8_t)0x03)));
+}
+
+/*********************************************************************
+ * @fn      GPIO_ETH_MediaInterfaceConfig
+ *
+ * @brief   Selects the Ethernet media interface.
+ *
+ * @param   GPIO_ETH_MediaInterface - specifies the Media Interface mode.
+ *            GPIO_ETH_MediaInterface_MII - MII mode
+ *            GPIO_ETH_MediaInterface_RMII - RMII mode
+ *
+ * @return  none
+ */
+void GPIO_ETH_MediaInterfaceConfig(uint32_t GPIO_ETH_MediaInterface)
+{
+    if(GPIO_ETH_MediaInterface)
+    {
+        AFIO->PCFR1 |= (1 << 23);
+    }
+    else
+    {
+        AFIO->PCFR1 &= ~(1 << 23);
+    }
+}

--- a/Sources/source/Peripheral/src/ch32v20x_i2c.c
+++ b/Sources/source/Peripheral/src/ch32v20x_i2c.c
@@ -1,0 +1,1008 @@
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32v20x_i2c.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/06/06
+ * Description        : This file provides all the I2C firmware functions.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#include "ch32v20x_i2c.h"
+#include "ch32v20x_rcc.h"
+
+/* I2C SPE mask */
+#define CTLR1_PE_Set             ((uint16_t)0x0001)
+#define CTLR1_PE_Reset           ((uint16_t)0xFFFE)
+
+/* I2C START mask */
+#define CTLR1_START_Set          ((uint16_t)0x0100)
+#define CTLR1_START_Reset        ((uint16_t)0xFEFF)
+
+/* I2C STOP mask */
+#define CTLR1_STOP_Set           ((uint16_t)0x0200)
+#define CTLR1_STOP_Reset         ((uint16_t)0xFDFF)
+
+/* I2C ACK mask */
+#define CTLR1_ACK_Set            ((uint16_t)0x0400)
+#define CTLR1_ACK_Reset          ((uint16_t)0xFBFF)
+
+/* I2C ENGC mask */
+#define CTLR1_ENGC_Set           ((uint16_t)0x0040)
+#define CTLR1_ENGC_Reset         ((uint16_t)0xFFBF)
+
+/* I2C SWRST mask */
+#define CTLR1_SWRST_Set          ((uint16_t)0x8000)
+#define CTLR1_SWRST_Reset        ((uint16_t)0x7FFF)
+
+/* I2C PEC mask */
+#define CTLR1_PEC_Set            ((uint16_t)0x1000)
+#define CTLR1_PEC_Reset          ((uint16_t)0xEFFF)
+
+/* I2C ENPEC mask */
+#define CTLR1_ENPEC_Set          ((uint16_t)0x0020)
+#define CTLR1_ENPEC_Reset        ((uint16_t)0xFFDF)
+
+/* I2C ENARP mask */
+#define CTLR1_ENARP_Set          ((uint16_t)0x0010)
+#define CTLR1_ENARP_Reset        ((uint16_t)0xFFEF)
+
+/* I2C NOSTRETCH mask */
+#define CTLR1_NOSTRETCH_Set      ((uint16_t)0x0080)
+#define CTLR1_NOSTRETCH_Reset    ((uint16_t)0xFF7F)
+
+/* I2C registers Masks */
+#define CTLR1_CLEAR_Mask         ((uint16_t)0xFBF5)
+
+/* I2C DMAEN mask */
+#define CTLR2_DMAEN_Set          ((uint16_t)0x0800)
+#define CTLR2_DMAEN_Reset        ((uint16_t)0xF7FF)
+
+/* I2C LAST mask */
+#define CTLR2_LAST_Set           ((uint16_t)0x1000)
+#define CTLR2_LAST_Reset         ((uint16_t)0xEFFF)
+
+/* I2C FREQ mask */
+#define CTLR2_FREQ_Reset         ((uint16_t)0xFFC0)
+
+/* I2C ADD0 mask */
+#define OADDR1_ADD0_Set          ((uint16_t)0x0001)
+#define OADDR1_ADD0_Reset        ((uint16_t)0xFFFE)
+
+/* I2C ENDUAL mask */
+#define OADDR2_ENDUAL_Set        ((uint16_t)0x0001)
+#define OADDR2_ENDUAL_Reset      ((uint16_t)0xFFFE)
+
+/* I2C ADD2 mask */
+#define OADDR2_ADD2_Reset        ((uint16_t)0xFF01)
+
+/* I2C F/S mask */
+#define CKCFGR_FS_Set            ((uint16_t)0x8000)
+
+/* I2C CCR mask */
+#define CKCFGR_CCR_Set           ((uint16_t)0x0FFF)
+
+/* I2C FLAG mask */
+#define FLAG_Mask                ((uint32_t)0x00FFFFFF)
+
+/* I2C Interrupt Enable mask */
+#define ITEN_Mask                ((uint32_t)0x07000000)
+
+/*********************************************************************
+ * @fn      I2C_DeInit
+ *
+ * @brief   Deinitializes the I2Cx peripheral registers to their default
+ *        reset values.
+ *
+ * @param   I2Cx - where x can be 1 or 2 to select the I2C peripheral.
+ *
+ * @return  none
+ */
+void I2C_DeInit(I2C_TypeDef *I2Cx)
+{
+    if(I2Cx == I2C1)
+    {
+        RCC_APB1PeriphResetCmd(RCC_APB1Periph_I2C1, ENABLE);
+        RCC_APB1PeriphResetCmd(RCC_APB1Periph_I2C1, DISABLE);
+    }
+    else
+    {
+        RCC_APB1PeriphResetCmd(RCC_APB1Periph_I2C2, ENABLE);
+        RCC_APB1PeriphResetCmd(RCC_APB1Periph_I2C2, DISABLE);
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_Init
+ *
+ * @brief   Initializes the I2Cx peripheral according to the specified
+ *        parameters in the I2C_InitStruct.
+ * @param   I2Cx - where x can be 1 or 2 to select the I2C peripheral.
+ *          I2C_InitStruct - pointer to a I2C_InitTypeDef structure that
+ *        contains the configuration information for the specified I2C peripheral.
+ *
+ * @return  none
+ */
+void I2C_Init(I2C_TypeDef *I2Cx, I2C_InitTypeDef *I2C_InitStruct)
+{
+    uint16_t tmpreg = 0, freqrange = 0;
+    uint16_t result = 0x04;
+    uint32_t pclk1 = 8000000;
+
+    RCC_ClocksTypeDef rcc_clocks;
+
+    tmpreg = I2Cx->CTLR2;
+    tmpreg &= CTLR2_FREQ_Reset;
+    RCC_GetClocksFreq(&rcc_clocks);
+    pclk1 = rcc_clocks.PCLK1_Frequency;
+    freqrange = (uint16_t)(pclk1 / 1000000);
+    tmpreg |= freqrange;
+    I2Cx->CTLR2 = tmpreg;
+
+    I2Cx->CTLR1 &= CTLR1_PE_Reset;
+    tmpreg = 0;
+
+    if(I2C_InitStruct->I2C_ClockSpeed <= 100000)
+    {
+        result = (uint16_t)(pclk1 / (I2C_InitStruct->I2C_ClockSpeed << 1));
+
+        if(result < 0x04)
+        {
+            result = 0x04;
+        }
+
+        tmpreg |= result;
+        I2Cx->RTR = freqrange + 1;
+    }
+    else
+    {
+        if(I2C_InitStruct->I2C_DutyCycle == I2C_DutyCycle_2)
+        {
+            result = (uint16_t)(pclk1 / (I2C_InitStruct->I2C_ClockSpeed * 3));
+        }
+        else
+        {
+            result = (uint16_t)(pclk1 / (I2C_InitStruct->I2C_ClockSpeed * 25));
+            result |= I2C_DutyCycle_16_9;
+        }
+
+        if((result & CKCFGR_CCR_Set) == 0)
+        {
+            result |= (uint16_t)0x0001;
+        }
+
+        tmpreg |= (uint16_t)(result | CKCFGR_FS_Set);
+        I2Cx->RTR = (uint16_t)(((freqrange * (uint16_t)300) / (uint16_t)1000) + (uint16_t)1);
+    }
+
+    I2Cx->CKCFGR = tmpreg;
+    I2Cx->CTLR1 |= CTLR1_PE_Set;
+
+    tmpreg = I2Cx->CTLR1;
+    tmpreg &= CTLR1_CLEAR_Mask;
+    tmpreg |= (uint16_t)((uint32_t)I2C_InitStruct->I2C_Mode | I2C_InitStruct->I2C_Ack);
+    I2Cx->CTLR1 = tmpreg;
+
+    I2Cx->OADDR1 = (I2C_InitStruct->I2C_AcknowledgedAddress | I2C_InitStruct->I2C_OwnAddress1);
+}
+
+/*********************************************************************
+ * @fn      I2C_StructInit
+ *
+ * @brief   Fills each I2C_InitStruct member with its default value.
+ *
+ * @param   I2C_InitStruct - pointer to an I2C_InitTypeDef structure which
+ *        will be initialized.
+ *
+ * @return  none
+ */
+void I2C_StructInit(I2C_InitTypeDef *I2C_InitStruct)
+{
+    I2C_InitStruct->I2C_ClockSpeed = 5000;
+    I2C_InitStruct->I2C_Mode = I2C_Mode_I2C;
+    I2C_InitStruct->I2C_DutyCycle = I2C_DutyCycle_2;
+    I2C_InitStruct->I2C_OwnAddress1 = 0;
+    I2C_InitStruct->I2C_Ack = I2C_Ack_Disable;
+    I2C_InitStruct->I2C_AcknowledgedAddress = I2C_AcknowledgedAddress_7bit;
+}
+
+/*********************************************************************
+ * @fn      I2C_Cmd
+ *
+ * @brief   Enables or disables the specified I2C peripheral.
+ *
+ * @param   I2Cx - where x can be 1 or 2 to select the I2C peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void I2C_Cmd(I2C_TypeDef *I2Cx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        I2Cx->CTLR1 |= CTLR1_PE_Set;
+    }
+    else
+    {
+        I2Cx->CTLR1 &= CTLR1_PE_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_DMACmd
+ *
+ * @brief   Enables or disables the specified I2C DMA requests.
+ *
+ * @param   I2Cx - where x can be 1 or 2 to select the I2C peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void I2C_DMACmd(I2C_TypeDef *I2Cx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        I2Cx->CTLR2 |= CTLR2_DMAEN_Set;
+    }
+    else
+    {
+        I2Cx->CTLR2 &= CTLR2_DMAEN_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_DMALastTransferCmd
+ *
+ * @brief   Specifies if the next DMA transfer will be the last one.
+ *
+ * @param   I2Cx - where x can be 1 or 2 to select the I2C peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void I2C_DMALastTransferCmd(I2C_TypeDef *I2Cx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        I2Cx->CTLR2 |= CTLR2_LAST_Set;
+    }
+    else
+    {
+        I2Cx->CTLR2 &= CTLR2_LAST_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_GenerateSTART
+ *
+ * @brief   Generates I2Cx communication START condition.
+ *
+ * @param   I2Cx - where x can be 1 or 2 to select the I2C peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void I2C_GenerateSTART(I2C_TypeDef *I2Cx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        I2Cx->CTLR1 |= CTLR1_START_Set;
+    }
+    else
+    {
+        I2Cx->CTLR1 &= CTLR1_START_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_GenerateSTOP
+ *
+ * @brief   Generates I2Cx communication STOP condition.
+ *
+ * @param   I2Cx - where x can be 1 or 2 to select the I2C peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void I2C_GenerateSTOP(I2C_TypeDef *I2Cx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        I2Cx->CTLR1 |= CTLR1_STOP_Set;
+    }
+    else
+    {
+        I2Cx->CTLR1 &= CTLR1_STOP_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_AcknowledgeConfig
+ *
+ * @brief   Enables or disables the specified I2C acknowledge feature.
+ *
+ * @param   I2Cx - where x can be 1 or 2 to select the I2C peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void I2C_AcknowledgeConfig(I2C_TypeDef *I2Cx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        I2Cx->CTLR1 |= CTLR1_ACK_Set;
+    }
+    else
+    {
+        I2Cx->CTLR1 &= CTLR1_ACK_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_OwnAddress2Config
+ *
+ * @brief   Configures the specified I2C own address2.
+ *
+ * @param   I2Cx - where x can be 1 or 2 to select the I2C peripheral.
+ *          Address - specifies the 7bit I2C own address2.
+ *
+ * @return  none
+ */
+void I2C_OwnAddress2Config(I2C_TypeDef *I2Cx, uint8_t Address)
+{
+    uint16_t tmpreg = 0;
+
+    tmpreg = I2Cx->OADDR2;
+    tmpreg &= OADDR2_ADD2_Reset;
+    tmpreg |= (uint16_t)((uint16_t)Address & (uint16_t)0x00FE);
+    I2Cx->OADDR2 = tmpreg;
+}
+
+/*********************************************************************
+ * @fn      I2C_DualAddressCmd
+ *
+ * @brief   Enables or disables the specified I2C dual addressing mode.
+ *
+ * @param   I2Cx - where x can be 1 or 2 to select the I2C peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void I2C_DualAddressCmd(I2C_TypeDef *I2Cx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        I2Cx->OADDR2 |= OADDR2_ENDUAL_Set;
+    }
+    else
+    {
+        I2Cx->OADDR2 &= OADDR2_ENDUAL_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_GeneralCallCmd
+ *
+ * @brief   Enables or disables the specified I2C general call feature.
+ *
+ * @param   I2Cx - where x can be 1 or 2 to select the I2C peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void I2C_GeneralCallCmd(I2C_TypeDef *I2Cx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        I2Cx->CTLR1 |= CTLR1_ENGC_Set;
+    }
+    else
+    {
+        I2Cx->CTLR1 &= CTLR1_ENGC_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_ITConfig
+ *
+ * @brief   Enables or disables the specified I2C interrupts.
+ *
+ * @param   I2Cx - where x can be 1 or 2 to select the I2C peripheral.
+ *          I2C_IT - specifies the I2C interrupts sources to be enabled or disabled.
+ *            I2C_IT_BUF - Buffer interrupt mask.
+ *            I2C_IT_EVT - Event interrupt mask.
+ *            I2C_IT_ERR - Error interrupt mask.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void I2C_ITConfig(I2C_TypeDef *I2Cx, uint16_t I2C_IT, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        I2Cx->CTLR2 |= I2C_IT;
+    }
+    else
+    {
+        I2Cx->CTLR2 &= (uint16_t)~I2C_IT;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_SendData
+ *
+ * @brief   Sends a data byte through the I2Cx peripheral.
+ *
+ * @param   I2Cx - where x can be 1 or 2 to select the I2C peripheral.
+ *          Data - Byte to be transmitted.
+ *
+ * @return  none
+ */
+void I2C_SendData(I2C_TypeDef *I2Cx, uint8_t Data)
+{
+    I2Cx->DATAR = Data;
+}
+
+/*********************************************************************
+ * @fn      I2C_ReceiveData
+ *
+ * @brief   Returns the most recent received data by the I2Cx peripheral.
+ *
+ * @param   I2Cx - where x can be 1 or 2 to select the I2C peripheral.
+ *
+ * @return  The value of the received data.
+ */
+uint8_t I2C_ReceiveData(I2C_TypeDef *I2Cx)
+{
+    return (uint8_t)I2Cx->DATAR;
+}
+
+/*********************************************************************
+ * @fn      I2C_Send7bitAddress
+ *
+ * @brief   Transmits the address byte to select the slave device.
+ *
+ * @param   I2Cx - where x can be 1 or 2 to select the I2C peripheral.
+ *          Address - specifies the slave address which will be transmitted.
+ *          I2C_Direction - specifies whether the I2C device will be a
+ *        Transmitter or a Receiver.
+ *            I2C_Direction_Transmitter - Transmitter mode.
+ *            I2C_Direction_Receiver - Receiver mode.
+ *
+ * @return  none
+ */
+void I2C_Send7bitAddress(I2C_TypeDef *I2Cx, uint8_t Address, uint8_t I2C_Direction)
+{
+    if(I2C_Direction != I2C_Direction_Transmitter)
+    {
+        Address |= OADDR1_ADD0_Set;
+    }
+    else
+    {
+        Address &= OADDR1_ADD0_Reset;
+    }
+
+    I2Cx->DATAR = Address;
+}
+
+/*********************************************************************
+ * @fn      I2C_ReadRegister
+ *
+ * @brief   Reads the specified I2C register and returns its value.
+ *
+ * @param   I2Cx - where x can be 1 or 2 to select the I2C peripheral.
+ *          I2C_Register - specifies the register to read.
+ *            I2C_Register_CTLR1.
+ *            I2C_Register_CTLR2.
+ *            I2C_Register_OADDR1.
+ *            I2C_Register_OADDR2.
+ *            I2C_Register_DATAR.
+ *            I2C_Register_STAR1.
+ *            I2C_Register_STAR2.
+ *            I2C_Register_CKCFGR.
+ *            I2C_Register_RTR.
+ *
+ * @return  none
+ */
+uint16_t I2C_ReadRegister(I2C_TypeDef *I2Cx, uint8_t I2C_Register)
+{
+    __IO uint32_t tmp = 0;
+
+    tmp = (uint32_t)I2Cx;
+    tmp += I2C_Register;
+
+    return (*(__IO uint16_t *)tmp);
+}
+
+/*********************************************************************
+ * @fn      I2C_SoftwareResetCmd
+ *
+ * @brief   Enables or disables the specified I2C software reset.
+ *
+ * @param   I2Cx - where x can be 1 or 2 to select the I2C peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void I2C_SoftwareResetCmd(I2C_TypeDef *I2Cx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        I2Cx->CTLR1 |= CTLR1_SWRST_Set;
+    }
+    else
+    {
+        I2Cx->CTLR1 &= CTLR1_SWRST_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_NACKPositionConfig
+ *
+ * @brief   Selects the specified I2C NACK position in master receiver mode.
+ *
+ * @param   I2Cx - where x can be 1 or 2 to select the I2C peripheral.
+ *          I2C_NACKPosition - specifies the NACK position.
+ *            I2C_NACKPosition_Next - indicates that the next byte will be
+ *        the last received byte.
+ *            I2C_NACKPosition_Current - indicates that current byte is the
+ *        last received byte.
+ *       Note-    
+ *          This function configures the same bit (POS) as I2C_PECPositionConfig() 
+ *          but is intended to be used in I2C mode while I2C_PECPositionConfig() 
+ *          is intended to used in SMBUS mode. 
+ * @return  none
+ */
+void I2C_NACKPositionConfig(I2C_TypeDef *I2Cx, uint16_t I2C_NACKPosition)
+{
+    if(I2C_NACKPosition == I2C_NACKPosition_Next)
+    {
+        I2Cx->CTLR1 |= I2C_NACKPosition_Next;
+    }
+    else
+    {
+        I2Cx->CTLR1 &= I2C_NACKPosition_Current;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_SMBusAlertConfig
+ *
+ * @brief   Drives the SMBusAlert pin high or low for the specified I2C.
+ *
+ * @param   I2Cx - where x can be 1 or 2 to select the I2C peripheral.
+ *          I2C_SMBusAlert - specifies SMBAlert pin level.
+ *            I2C_SMBusAlert_Low - SMBAlert pin driven low.
+ *            I2C_SMBusAlert_High - SMBAlert pin driven high.
+ *
+ * @return  none
+ */
+void I2C_SMBusAlertConfig(I2C_TypeDef *I2Cx, uint16_t I2C_SMBusAlert)
+{
+    if(I2C_SMBusAlert == I2C_SMBusAlert_Low)
+    {
+        I2Cx->CTLR1 |= I2C_SMBusAlert_Low;
+    }
+    else
+    {
+        I2Cx->CTLR1 &= I2C_SMBusAlert_High;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_TransmitPEC
+ *
+ * @brief   Enables or disables the specified I2C PEC transfer.
+ *
+ * @param   I2Cx - where x can be 1 or 2 to select the I2C peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void I2C_TransmitPEC(I2C_TypeDef *I2Cx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        I2Cx->CTLR1 |= CTLR1_PEC_Set;
+    }
+    else
+    {
+        I2Cx->CTLR1 &= CTLR1_PEC_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_PECPositionConfig
+ *
+ * @brief   Selects the specified I2C PEC position.
+ *
+ * @param   I2Cx - where x can be 1 or 2 to select the I2C peripheral.
+ *          I2C_PECPosition - specifies the PEC position.
+ *            I2C_PECPosition_Next - indicates that the next byte is PEC.
+ *            I2C_PECPosition_Current - indicates that current byte is PEC.
+ *
+ * @return  none
+ */
+void I2C_PECPositionConfig(I2C_TypeDef *I2Cx, uint16_t I2C_PECPosition)
+{
+    if(I2C_PECPosition == I2C_PECPosition_Next)
+    {
+        I2Cx->CTLR1 |= I2C_PECPosition_Next;
+    }
+    else
+    {
+        I2Cx->CTLR1 &= I2C_PECPosition_Current;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_CalculatePEC
+ *
+ * @brief   Enables or disables the PEC value calculation of the transferred bytes.
+ *
+ * @param   I2Cx- where x can be 1 or 2 to select the I2C peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void I2C_CalculatePEC(I2C_TypeDef *I2Cx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        I2Cx->CTLR1 |= CTLR1_ENPEC_Set;
+    }
+    else
+    {
+        I2Cx->CTLR1 &= CTLR1_ENPEC_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_GetPEC
+ *
+ * @brief   Returns the PEC value for the specified I2C.
+ *
+ * @param   I2Cx - where x can be 1 or 2 to select the I2C peripheral.
+ *
+ * @return  The PEC value.
+ */
+uint8_t I2C_GetPEC(I2C_TypeDef *I2Cx)
+{
+    return ((I2Cx->STAR2) >> 8);
+}
+
+/*********************************************************************
+ * @fn      I2C_ARPCmd
+ *
+ * @brief   Enables or disables the specified I2C ARP.
+ *
+ * @param   I2Cx - where x can be 1 or 2 to select the I2C peripheral.
+ *            NewState - ENABLE or DISABLE.
+ *
+ * @return  The PEC value.
+ */
+void I2C_ARPCmd(I2C_TypeDef *I2Cx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        I2Cx->CTLR1 |= CTLR1_ENARP_Set;
+    }
+    else
+    {
+        I2Cx->CTLR1 &= CTLR1_ENARP_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_StretchClockCmd
+ *
+ * @brief   Enables or disables the specified I2C Clock stretching.
+ *
+ * @param   I2Cx - where x can be 1 or 2 to select the I2C peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void I2C_StretchClockCmd(I2C_TypeDef *I2Cx, FunctionalState NewState)
+{
+    if(NewState == DISABLE)
+    {
+        I2Cx->CTLR1 |= CTLR1_NOSTRETCH_Set;
+    }
+    else
+    {
+        I2Cx->CTLR1 &= CTLR1_NOSTRETCH_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_FastModeDutyCycleConfig
+ *
+ * @brief   Selects the specified I2C fast mode duty cycle.
+ *
+ * @param   I2Cx - where x can be 1 or 2 to select the I2C peripheral.
+ *          I2C_DutyCycle - specifies the fast mode duty cycle.
+ *            I2C_DutyCycle_2 - I2C fast mode Tlow/Thigh = 2.
+ *            I2C_DutyCycle_16_9 - I2C fast mode Tlow/Thigh = 16/9.
+ *
+ * @return  none
+ */
+void I2C_FastModeDutyCycleConfig(I2C_TypeDef *I2Cx, uint16_t I2C_DutyCycle)
+{
+    if(I2C_DutyCycle != I2C_DutyCycle_16_9)
+    {
+        I2Cx->CKCFGR &= I2C_DutyCycle_2;
+    }
+    else
+    {
+        I2Cx->CKCFGR |= I2C_DutyCycle_16_9;
+    }
+}
+
+/*********************************************************************
+ * @fn      I2C_CheckEvent
+ *
+ * @brief   Checks whether the last I2Cx Event is equal to the one passed
+ *        as parameter.
+ *
+ * @param   I2Cx- where x can be 1 or 2 to select the I2C peripheral.
+ *          I2C_EVENT: specifies the event to be checked.
+ *             I2C_EVENT_SLAVE_TRANSMITTER_ADDRESS_MATCHED - EVT1.
+ *             I2C_EVENT_SLAVE_RECEIVER_ADDRESS_MATCHED - EVT1.
+ *             I2C_EVENT_SLAVE_TRANSMITTER_SECONDADDRESS_MATCHED - EVT1.
+ *             I2C_EVENT_SLAVE_RECEIVER_SECONDADDRESS_MATCHED - EVT1.
+ *             I2C_EVENT_SLAVE_GENERALCALLADDRESS_MATCHED - EVT1.
+ *             I2C_EVENT_SLAVE_BYTE_RECEIVED - EVT2.
+ *             (I2C_EVENT_SLAVE_BYTE_RECEIVED | I2C_FLAG_DUALF) - EVT2.
+ *             (I2C_EVENT_SLAVE_BYTE_RECEIVED | I2C_FLAG_GENCALL) - EVT2.
+ *             I2C_EVENT_SLAVE_BYTE_TRANSMITTED - EVT3.
+ *             (I2C_EVENT_SLAVE_BYTE_TRANSMITTED | I2C_FLAG_DUALF) - EVT3.
+ *             (I2C_EVENT_SLAVE_BYTE_TRANSMITTED | I2C_FLAG_GENCALL) - EVT3.
+ *             I2C_EVENT_SLAVE_ACK_FAILURE - EVT3_2.
+ *             I2C_EVENT_SLAVE_STOP_DETECTED - EVT4.
+ *             I2C_EVENT_MASTER_MODE_SELECT - EVT5.
+ *             I2C_EVENT_MASTER_TRANSMITTER_MODE_SELECTED - EVT6.
+ *             I2C_EVENT_MASTER_RECEIVER_MODE_SELECTED - EVT6.
+ *             I2C_EVENT_MASTER_BYTE_RECEIVED - EVT7.
+ *             I2C_EVENT_MASTER_BYTE_TRANSMITTING - EVT8.
+ *             I2C_EVENT_MASTER_BYTE_TRANSMITTED - EVT8_2.
+ *             I2C_EVENT_MASTER_MODE_ADDRESS10 - EVT9.
+ *
+ * @return  ErrorStatus - READY or NoREADY.
+ */
+ErrorStatus I2C_CheckEvent(I2C_TypeDef *I2Cx, uint32_t I2C_EVENT)
+{
+    uint32_t    lastevent = 0;
+    uint32_t    flag1 = 0, flag2 = 0;
+    ErrorStatus status = NoREADY;
+
+    flag1 = I2Cx->STAR1;
+    flag2 = I2Cx->STAR2;
+    flag2 = flag2 << 16;
+
+    lastevent = (flag1 | flag2) & FLAG_Mask;
+
+    if((lastevent & I2C_EVENT) == I2C_EVENT)
+    {
+        status = READY;
+    }
+    else
+    {
+        status = NoREADY;
+    }
+
+    return status;
+}
+
+/*********************************************************************
+ * @fn      I2C_GetLastEvent
+ *
+ * @brief   Returns the last I2Cx Event.
+ *
+ * @param   I2Cx - where x can be 1 or 2 to select the I2C peripheral.
+ *
+ * @return  none
+ */
+uint32_t I2C_GetLastEvent(I2C_TypeDef *I2Cx)
+{
+    uint32_t lastevent = 0;
+    uint32_t flag1 = 0, flag2 = 0;
+
+    flag1 = I2Cx->STAR1;
+    flag2 = I2Cx->STAR2;
+    flag2 = flag2 << 16;
+    lastevent = (flag1 | flag2) & FLAG_Mask;
+
+    return lastevent;
+}
+
+/*********************************************************************
+ * @fn      I2C_GetFlagStatus
+ *
+ * @brief   Checks whether the last I2Cx Event is equal to the one passed
+ *        as parameter.
+ *
+ * @param   I2Cx - where x can be 1 or 2 to select the I2C peripheral.
+ *          I2C_FLAG - specifies the flag to check.
+ *            I2C_FLAG_DUALF - Dual flag (Slave mode).
+ *            I2C_FLAG_SMBHOST - SMBus host header (Slave mode).
+ *            I2C_FLAG_SMBDEFAULT - SMBus default header (Slave mode).
+ *            I2C_FLAG_GENCALL - General call header flag (Slave mode).
+ *            I2C_FLAG_TRA - Transmitter/Receiver flag.
+ *            I2C_FLAG_BUSY - Bus busy flag.
+ *            I2C_FLAG_MSL - Master/Slave flag.
+ *            I2C_FLAG_SMBALERT - SMBus Alert flag.
+ *            I2C_FLAG_TIMEOUT - Timeout or Tlow error flag.
+ *            I2C_FLAG_PECERR - PEC error in reception flag.
+ *            I2C_FLAG_OVR - Overrun/Underrun flag (Slave mode).
+ *            I2C_FLAG_AF - Acknowledge failure flag.
+ *            I2C_FLAG_ARLO - Arbitration lost flag (Master mode).
+ *            I2C_FLAG_BERR - Bus error flag.
+ *            I2C_FLAG_TXE - Data register empty flag (Transmitter).
+ *            I2C_FLAG_RXNE- Data register not empty (Receiver) flag.
+ *            I2C_FLAG_STOPF - Stop detection flag (Slave mode).
+ *            I2C_FLAG_ADD10 - 10-bit header sent flag (Master mode).
+ *            I2C_FLAG_BTF - Byte transfer finished flag.
+ *            I2C_FLAG_ADDR - Address sent flag (Master mode) "ADSL"
+ *        Address matched flag (Slave mode)"ENDA".
+ *            I2C_FLAG_SB - Start bit flag (Master mode).
+ *
+ * @return  FlagStatus - SET or RESET.
+ */
+FlagStatus I2C_GetFlagStatus(I2C_TypeDef *I2Cx, uint32_t I2C_FLAG)
+{
+    FlagStatus    bitstatus = RESET;
+    __IO uint32_t i2creg = 0, i2cxbase = 0;
+
+    i2cxbase = (uint32_t)I2Cx;
+    i2creg = I2C_FLAG >> 28;
+    I2C_FLAG &= FLAG_Mask;
+
+    if(i2creg != 0)
+    {
+        i2cxbase += 0x14;
+    }
+    else
+    {
+        I2C_FLAG = (uint32_t)(I2C_FLAG >> 16);
+        i2cxbase += 0x18;
+    }
+
+    if(((*(__IO uint32_t *)i2cxbase) & I2C_FLAG) != (uint32_t)RESET)
+    {
+        bitstatus = SET;
+    }
+    else
+    {
+        bitstatus = RESET;
+    }
+
+    return bitstatus;
+}
+
+/*********************************************************************
+ * @fn      I2C_ClearFlag
+ *
+ * @brief   Clears the I2Cx's pending flags.
+ *
+ * @param   I2Cx - where x can be 1 or 2 to select the I2C peripheral.
+ *          I2C_FLAG - specifies the flag to clear.
+ *            I2C_FLAG_SMBALERT - SMBus Alert flag.
+ *            I2C_FLAG_TIMEOUT - Timeout or Tlow error flag.
+ *            I2C_FLAG_PECERR - PEC error in reception flag.
+ *            I2C_FLAG_OVR - Overrun/Underrun flag (Slave mode).
+ *            I2C_FLAG_AF - Acknowledge failure flag.
+ *            I2C_FLAG_ARLO - Arbitration lost flag (Master mode).
+ *            I2C_FLAG_BERR - Bus error flag.
+ *          Note-
+ *           - STOPF (STOP detection) is cleared by software sequence: a read operation 
+ *             to I2C_STAR1 register (I2C_GetFlagStatus()) followed by a write operation 
+ *             to I2C_CTLR1 register (I2C_Cmd() to re-enable the I2C peripheral).
+ *           - ADD10 (10-bit header sent) is cleared by software sequence: a read 
+ *             operation to I2C_SATR1 (I2C_GetFlagStatus()) followed by writing the 
+ *             second byte of the address in DATAR register.
+ *           - BTF (Byte Transfer Finished) is cleared by software sequence: a read 
+ *             operation to I2C_SATR1 register (I2C_GetFlagStatus()) followed by a 
+ *             read/write to I2C_DATAR register (I2C_SendData()).
+ *           - ADDR (Address sent) is cleared by software sequence: a read operation to 
+ *             I2C_SATR1 register (I2C_GetFlagStatus()) followed by a read operation to 
+ *             I2C_SATR2 register ((void)(I2Cx->SR2)).
+ *           - SB (Start Bit) is cleared software sequence: a read operation to I2C_STAR1
+ *             register (I2C_GetFlagStatus()) followed by a write operation to I2C_DATAR
+ *             register  (I2C_SendData()). 
+ * @return  none
+ */
+void I2C_ClearFlag(I2C_TypeDef *I2Cx, uint32_t I2C_FLAG)
+{
+    uint32_t flagpos = 0;
+
+    flagpos = I2C_FLAG & FLAG_Mask;
+    I2Cx->STAR1 = (uint16_t)~flagpos;
+}
+
+/*********************************************************************
+ * @fn      I2C_GetITStatus
+ *
+ * @brief   Checks whether the specified I2C interrupt has occurred or not.
+ *
+ * @param   I2Cx - where x can be 1 or 2 to select the I2C peripheral.
+ *          II2C_IT - specifies the interrupt source to check.
+ *            I2C_IT_SMBALERT - SMBus Alert flag.
+ *            I2C_IT_TIMEOUT - Timeout or Tlow error flag.
+ *            I2C_IT_PECERR - PEC error in reception flag.
+ *            I2C_IT_OVR - Overrun/Underrun flag (Slave mode).
+ *            I2C_IT_AF - Acknowledge failure flag.
+ *            I2C_IT_ARLO - Arbitration lost flag (Master mode).
+ *            I2C_IT_BERR - Bus error flag.
+ *            I2C_IT_TXE - Data register empty flag (Transmitter).
+ *            I2C_IT_RXNE - Data register not empty (Receiver) flag.
+ *            I2C_IT_STOPF - Stop detection flag (Slave mode).
+ *            I2C_IT_ADD10 - 10-bit header sent flag (Master mode).
+ *            I2C_IT_BTF - Byte transfer finished flag.
+ *            I2C_IT_ADDR - Address sent flag (Master mode) "ADSL"  Address matched
+ *        flag (Slave mode)"ENDAD".
+ *            I2C_IT_SB - Start bit flag (Master mode).
+ *
+ * @return  none
+ */
+ITStatus I2C_GetITStatus(I2C_TypeDef *I2Cx, uint32_t I2C_IT)
+{
+    ITStatus bitstatus = RESET;
+    uint32_t enablestatus = 0;
+
+    enablestatus = (uint32_t)(((I2C_IT & ITEN_Mask) >> 16) & (I2Cx->CTLR2));
+    I2C_IT &= FLAG_Mask;
+
+    if(((I2Cx->STAR1 & I2C_IT) != (uint32_t)RESET) && enablestatus)
+    {
+        bitstatus = SET;
+    }
+    else
+    {
+        bitstatus = RESET;
+    }
+
+    return bitstatus;
+}
+
+/*********************************************************************
+ * @fn      I2C_ClearITPendingBit
+ *
+ * @brief   Clears the I2Cx interrupt pending bits.
+ *
+ * @param   I2Cx - where x can be 1 or 2 to select the I2C peripheral.
+ *          I2C_IT - specifies the interrupt pending bit to clear.
+ *            I2C_IT_SMBALERT - SMBus Alert interrupt.
+ *            I2C_IT_TIMEOUT - Timeout or Tlow error interrupt.
+ *            I2C_IT_PECERR - PEC error in reception  interrupt.
+ *            I2C_IT_OVR - Overrun/Underrun interrupt (Slave mode).
+ *            I2C_IT_AF - Acknowledge failure interrupt.
+ *            I2C_IT_ARLO - Arbitration lost interrupt (Master mode).
+ *            I2C_IT_BERR - Bus error interrupt.
+ *          Note-
+ *           - STOPF (STOP detection) is cleared by software sequence: a read operation 
+ *             to I2C_STAR1 register (I2C_GetITStatus()) followed by a write operation to 
+ *             I2C_CTLR1 register (I2C_Cmd() to re-enable the I2C peripheral).
+ *           - ADD10 (10-bit header sent) is cleared by software sequence: a read 
+ *             operation to I2C_STAR1 (I2C_GetITStatus()) followed by writing the second 
+ *             byte of the address in I2C_DATAR register.
+ *           - BTF (Byte Transfer Finished) is cleared by software sequence: a read 
+ *             operation to I2C_STAR1 register (I2C_GetITStatus()) followed by a 
+ *             read/write to I2C_DATAR register (I2C_SendData()).
+ *           - ADDR (Address sent) is cleared by software sequence: a read operation to 
+ *             I2C_STAR1 register (I2C_GetITStatus()) followed by a read operation to 
+ *             I2C_STAR2 register ((void)(I2Cx->SR2)).
+ *           - SB (Start Bit) is cleared by software sequence: a read operation to 
+ *             I2C_STAR1 register (I2C_GetITStatus()) followed by a write operation to 
+ *             I2C_DATAR register (I2C_SendData()).
+ *
+ * @return  none
+ */
+void I2C_ClearITPendingBit(I2C_TypeDef *I2Cx, uint32_t I2C_IT)
+{
+    uint32_t flagpos = 0;
+
+    flagpos = I2C_IT & FLAG_Mask;
+    I2Cx->STAR1 = (uint16_t)~flagpos;
+}

--- a/Sources/source/Peripheral/src/ch32v20x_misc.c
+++ b/Sources/source/Peripheral/src/ch32v20x_misc.c
@@ -1,0 +1,109 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : ch32v20x_misc.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/06/06
+ * Description        : This file provides all the miscellaneous firmware functions .
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#include "ch32v20x_misc.h"
+
+__IO uint32_t NVIC_Priority_Group = 0;
+
+/*********************************************************************
+ * @fn      NVIC_PriorityGroupConfig
+ *
+ * @brief   Configures the priority grouping - pre-emption priority and subpriority.
+ *
+ * @param   NVIC_PriorityGroup - specifies the priority grouping bits length.
+ *            NVIC_PriorityGroup_0 - 0 bits for pre-emption priority
+ *                                   4 bits for subpriority
+ *            NVIC_PriorityGroup_1 - 1 bits for pre-emption priority
+ *                                   3 bits for subpriority
+ *            NVIC_PriorityGroup_2 - 2 bits for pre-emption priority
+ *                                   2 bits for subpriority
+ *            NVIC_PriorityGroup_3 - 3 bits for pre-emption priority
+ *                                   1 bits for subpriority
+ *            NVIC_PriorityGroup_4 - 4 bits for pre-emption priority
+ *                                   0 bits for subpriority
+ *
+ * @return  none
+ */
+void NVIC_PriorityGroupConfig(uint32_t NVIC_PriorityGroup)
+{
+    NVIC_Priority_Group = NVIC_PriorityGroup;
+}
+
+/*********************************************************************
+ * @fn      NVIC_Init
+ *
+ * @brief   Initializes the NVIC peripheral according to the specified parameters in
+ *        the NVIC_InitStruct.
+ *
+ * @param   NVIC_InitStruct - pointer to a NVIC_InitTypeDef structure that contains the
+ *        configuration information for the specified NVIC peripheral.
+ *
+ * @return  none
+ */
+void NVIC_Init(NVIC_InitTypeDef *NVIC_InitStruct)
+{
+    uint8_t tmppre = 0;
+
+    if(NVIC_Priority_Group == NVIC_PriorityGroup_0)
+    {
+        NVIC_SetPriority(NVIC_InitStruct->NVIC_IRQChannel, NVIC_InitStruct->NVIC_IRQChannelSubPriority << 4);
+    }
+    else if(NVIC_Priority_Group == NVIC_PriorityGroup_1)
+    {
+        if(NVIC_InitStruct->NVIC_IRQChannelPreemptionPriority == 1)
+        {
+            NVIC_SetPriority(NVIC_InitStruct->NVIC_IRQChannel, (1 << 7) | (NVIC_InitStruct->NVIC_IRQChannelSubPriority << 4));
+        }
+        else
+        {
+            NVIC_SetPriority(NVIC_InitStruct->NVIC_IRQChannel, (0 << 7) | (NVIC_InitStruct->NVIC_IRQChannelSubPriority << 4));
+        }
+    }
+    else if(NVIC_Priority_Group == NVIC_PriorityGroup_2)
+    {
+        if(NVIC_InitStruct->NVIC_IRQChannelPreemptionPriority <= 1)
+        {
+            tmppre = NVIC_InitStruct->NVIC_IRQChannelSubPriority + (4 * NVIC_InitStruct->NVIC_IRQChannelPreemptionPriority);
+            NVIC_SetPriority(NVIC_InitStruct->NVIC_IRQChannel, (0 << 7) | (tmppre << 4));
+        }
+        else
+        {
+            tmppre = NVIC_InitStruct->NVIC_IRQChannelSubPriority + (4 * (NVIC_InitStruct->NVIC_IRQChannelPreemptionPriority - 2));
+            NVIC_SetPriority(NVIC_InitStruct->NVIC_IRQChannel, (1 << 7) | (tmppre << 4));
+        }
+    }
+    else if(NVIC_Priority_Group == NVIC_PriorityGroup_3)
+    {
+        if(NVIC_InitStruct->NVIC_IRQChannelPreemptionPriority <= 3)
+        {
+            tmppre = NVIC_InitStruct->NVIC_IRQChannelSubPriority + (2 * NVIC_InitStruct->NVIC_IRQChannelPreemptionPriority);
+            NVIC_SetPriority(NVIC_InitStruct->NVIC_IRQChannel, (0 << 7) | (tmppre << 4));
+        }
+        else
+        {
+            tmppre = NVIC_InitStruct->NVIC_IRQChannelSubPriority + (2 * (NVIC_InitStruct->NVIC_IRQChannelPreemptionPriority - 4));
+            NVIC_SetPriority(NVIC_InitStruct->NVIC_IRQChannel, (1 << 7) | (tmppre << 4));
+        }
+    }
+    else if(NVIC_Priority_Group == NVIC_PriorityGroup_4)
+    {
+        NVIC_SetPriority(NVIC_InitStruct->NVIC_IRQChannel, NVIC_InitStruct->NVIC_IRQChannelPreemptionPriority << 4);
+    }
+
+    if(NVIC_InitStruct->NVIC_IRQChannelCmd != DISABLE)
+    {
+        NVIC_EnableIRQ(NVIC_InitStruct->NVIC_IRQChannel);
+    }
+    else
+    {
+        NVIC_DisableIRQ(NVIC_InitStruct->NVIC_IRQChannel);
+    }
+}

--- a/Sources/source/Peripheral/src/ch32v20x_rcc.c
+++ b/Sources/source/Peripheral/src/ch32v20x_rcc.c
@@ -1,0 +1,1031 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : ch32v20x_rcc.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/06/06
+ * Description        : This file provides all the RCC firmware functions.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/ 
+#include "ch32v20x_rcc.h"
+
+/* RCC registers bit address in the alias region */
+#define RCC_OFFSET                (RCC_BASE - PERIPH_BASE)
+
+/* BDCTLR Register */
+#define BDCTLR_OFFSET             (RCC_OFFSET + 0x20)
+
+/* RCC registers bit mask */
+
+/* CTLR register bit mask */
+#define CTLR_HSEBYP_Reset           ((uint32_t)0xFFFBFFFF)
+#define CTLR_HSEBYP_Set             ((uint32_t)0x00040000)
+#define CTLR_HSEON_Reset            ((uint32_t)0xFFFEFFFF)
+#define CTLR_HSEON_Set              ((uint32_t)0x00010000)
+#define CTLR_HSITRIM_Mask           ((uint32_t)0xFFFFFF07)
+
+#define CFGR0_PLL_Mask              ((uint32_t)0xFFC0FFFF) 
+
+#define CFGR0_PLLMull_Mask          ((uint32_t)0x003C0000)
+#define CFGR0_PLLSRC_Mask           ((uint32_t)0x00010000)
+#define CFGR0_PLLXTPRE_Mask         ((uint32_t)0x00020000)
+#define CFGR0_SWS_Mask              ((uint32_t)0x0000000C)
+#define CFGR0_SW_Mask               ((uint32_t)0xFFFFFFFC)
+#define CFGR0_HPRE_Reset_Mask       ((uint32_t)0xFFFFFF0F)
+#define CFGR0_HPRE_Set_Mask         ((uint32_t)0x000000F0)
+#define CFGR0_PPRE1_Reset_Mask      ((uint32_t)0xFFFFF8FF)
+#define CFGR0_PPRE1_Set_Mask        ((uint32_t)0x00000700)
+#define CFGR0_PPRE2_Reset_Mask      ((uint32_t)0xFFFFC7FF)
+#define CFGR0_PPRE2_Set_Mask        ((uint32_t)0x00003800)
+#define CFGR0_ADCPRE_Reset_Mask     ((uint32_t)0xFFFF3FFF)
+#define CFGR0_ADCPRE_Set_Mask       ((uint32_t)0x0000C000)
+
+/* RSTSCKR register bit mask */
+#define RSTSCKR_RMVF_Set            ((uint32_t)0x01000000)
+
+/* CFGR2 register bit mask */
+#define CFGR2_PREDIV1SRC            ((uint32_t)0x00010000)
+#define CFGR2_PREDIV1               ((uint32_t)0x0000000F)
+#define CFGR2_PREDIV2               ((uint32_t)0x000000F0)
+#define CFGR2_PLL2MUL               ((uint32_t)0x00000F00)
+#define CFGR2_PLL3MUL               ((uint32_t)0x0000F000)
+
+/* RCC Flag Mask */
+#define FLAG_Mask                   ((uint8_t)0x1F)
+
+/* INTR register byte 2 (Bits[15:8]) base address */
+#define INTR_BYTE2_ADDRESS          ((uint32_t)0x40021009)
+
+/* INTR register byte 3 (Bits[23:16]) base address */
+#define INTR_BYTE3_ADDRESS          ((uint32_t)0x4002100A)
+
+/* CFGR0 register byte 4 (Bits[31:24]) base address */
+#define CFGR0_BYTE4_ADDRESS         ((uint32_t)0x40021007)
+
+/* BDCTLR register base address */
+#define BDCTLR_ADDRESS              (PERIPH_BASE + BDCTLR_OFFSET)
+
+
+static __I uint8_t APBAHBPrescTable[16] = {0, 0, 0, 0, 1, 2, 3, 4, 1, 2, 3, 4, 6, 7, 8, 9};
+static __I uint8_t ADCPrescTable[4] = {2, 4, 6, 8};
+
+/*********************************************************************
+ * @fn      RCC_DeInit
+ *
+ * @brief   Resets the RCC clock configuration to the default reset state.
+ *          Note-
+ *          HSE can not be stopped if it is used directly or through the PLL as system clock.
+ * @return  none
+ */
+void RCC_DeInit(void)
+{
+  RCC->CTLR |= (uint32_t)0x00000001;
+  RCC->CFGR0 &= (uint32_t)0xF8FF0000;  
+  RCC->CTLR &= (uint32_t)0xFEF6FFFF;
+  RCC->CTLR &= (uint32_t)0xFFFBFFFF;
+  RCC->CFGR0 &= (uint32_t)0xFF80FFFF;
+  RCC->INTR = 0x009F0000;
+}
+
+/*********************************************************************
+ * @fn      RCC_HSEConfig
+ *
+ * @brief   Configures the External High Speed oscillator (HSE).
+ *
+ * @param   RCC_HSE -
+ *            RCC_HSE_OFF - HSE oscillator OFF.
+ *            RCC_HSE_ON - HSE oscillator ON.
+ *            RCC_HSE_Bypass - HSE oscillator bypassed with external clock.
+ *            Note-
+ *            HSE can not be stopped if it is used directly or through the PLL as system clock.
+ * @return  none
+ */
+void RCC_HSEConfig(uint32_t RCC_HSE)
+{
+  RCC->CTLR &= CTLR_HSEON_Reset;
+  RCC->CTLR &= CTLR_HSEBYP_Reset;
+
+  switch(RCC_HSE)
+  {
+    case RCC_HSE_ON:
+      RCC->CTLR |= CTLR_HSEON_Set;
+      break;
+      
+    case RCC_HSE_Bypass:
+      RCC->CTLR |= CTLR_HSEBYP_Set | CTLR_HSEON_Set;
+      break;
+      
+    default:
+      break;
+  }
+}
+
+/*********************************************************************
+ * @fn      RCC_WaitForHSEStartUp
+ *
+ * @brief   Waits for HSE start-up.
+ *
+ * @return  READY - HSE oscillator is stable and ready to use.
+ *          NoREADY - HSE oscillator not yet ready.
+ */
+ErrorStatus RCC_WaitForHSEStartUp(void)
+{
+  __IO uint32_t StartUpCounter = 0;
+	
+  ErrorStatus status = NoREADY;
+  FlagStatus HSEStatus = RESET;
+  
+  do
+  {
+    HSEStatus = RCC_GetFlagStatus(RCC_FLAG_HSERDY);
+    StartUpCounter++;  
+  } while((StartUpCounter != HSE_STARTUP_TIMEOUT) && (HSEStatus == RESET));
+  
+  if (RCC_GetFlagStatus(RCC_FLAG_HSERDY) != RESET)
+  {
+    status = READY;
+  }
+  else
+  {
+    status = NoREADY;
+  }  
+	
+  return (status);
+}
+
+/*********************************************************************
+ * @fn      RCC_AdjustHSICalibrationValue
+ *
+ * @brief   Adjusts the Internal High Speed oscillator (HSI) calibration value.
+ *
+ * @param   HSICalibrationValue - specifies the calibration trimming value.
+ *                    This parameter must be a number between 0 and 0x1F.
+ *
+ * @return  none
+ */
+void RCC_AdjustHSICalibrationValue(uint8_t HSICalibrationValue)
+{
+  uint32_t tmpreg = 0;
+
+  tmpreg = RCC->CTLR;
+  tmpreg &= CTLR_HSITRIM_Mask;
+  tmpreg |= (uint32_t)HSICalibrationValue << 3;
+  RCC->CTLR = tmpreg;
+}
+
+/*********************************************************************
+ * @fn      RCC_HSICmd
+ *
+ * @brief   Enables or disables the Internal High Speed oscillator (HSI).
+ *
+ * @param   NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void RCC_HSICmd(FunctionalState NewState)
+{
+	if(NewState)
+	{
+		RCC->CTLR |= (1<<0);
+	}
+	else{
+		RCC->CTLR &= ~(1<<0);		
+	}
+}
+
+/*********************************************************************
+ * @fn      RCC_PLLConfig
+ *
+ * @brief   Configures the PLL clock source and multiplication factor.
+ *
+ * @param   RCC_PLLSource - specifies the PLL entry clock source.
+ *            RCC_PLLSource_HSI_Div2 - HSI oscillator clock divided by 2
+ *        selected as PLL clock entry.
+ *            RCC_PLLSource_PREDIV1 - PREDIV1 clock selected as PLL clock
+ *        entry.
+ *          RCC_PLLMul - specifies the PLL multiplication factor.
+ *            This parameter can be RCC_PLLMul_x where x:[2,16].
+ *              RCC_PLLMul_2
+ *              RCC_PLLMul_3
+ *              RCC_PLLMul_4
+ *              RCC_PLLMul_5
+ *              RCC_PLLMul_6
+ *              RCC_PLLMul_7
+ *              RCC_PLLMul_8
+ *              RCC_PLLMul_9
+ *              RCC_PLLMul_10
+ *              RCC_PLLMul_11
+ *              RCC_PLLMul_12
+ *              RCC_PLLMul_13
+ *              RCC_PLLMul_14
+ *              RCC_PLLMul_15
+ *              RCC_PLLMul_16
+ *              RCC_PLLMul_18
+ *
+ * @return  none
+ */
+void RCC_PLLConfig(uint32_t RCC_PLLSource, uint32_t RCC_PLLMul)
+{
+  uint32_t tmpreg = 0;
+
+  tmpreg = RCC->CFGR0;
+
+  tmpreg &= CFGR0_PLL_Mask;
+  tmpreg |= RCC_PLLSource | RCC_PLLMul;
+  RCC->CFGR0 = tmpreg;
+}
+
+/*********************************************************************
+ * @fn      RCC_PLLCmd
+ *
+ * @brief   Enables or disables the PLL.
+ *          Note-The PLL can not be disabled if it is used as system clock.
+ *          
+ *
+ * @param   NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void RCC_PLLCmd(FunctionalState NewState)
+{
+	if(NewState)
+	{
+		RCC->CTLR |= (1<<24);
+	}
+	else{
+		RCC->CTLR &= ~(1<<24);		
+	}
+}
+
+/*********************************************************************
+ * @fn      RCC_SYSCLKConfig
+ *
+ * @brief   Configures the system clock (SYSCLK).
+ *
+ * @param   RCC_SYSCLKSource - specifies the clock source used as system clock.
+ *            RCC_SYSCLKSource_HSI - HSI selected as system clock.
+ *            RCC_SYSCLKSource_HSE - HSE selected as system clock.
+ *            RCC_SYSCLKSource_PLLCLK - PLL selected as system clock.
+ *
+ * @return  none
+ */
+void RCC_SYSCLKConfig(uint32_t RCC_SYSCLKSource)
+{
+  uint32_t tmpreg = 0;
+
+  tmpreg = RCC->CFGR0;
+  tmpreg &= CFGR0_SW_Mask;
+  tmpreg |= RCC_SYSCLKSource;
+  RCC->CFGR0 = tmpreg;
+}
+
+/*********************************************************************
+ * @fn      RCC_GetSYSCLKSource
+ *
+ * @brief   Returns the clock source used as system clock.
+ *
+ * @return  0x00 - HSI used as system clock.
+ *          0x04 - HSE used as system clock.
+ *          0x08 - PLL used as system clock.
+ */
+uint8_t RCC_GetSYSCLKSource(void)
+{
+  return ((uint8_t)(RCC->CFGR0 & CFGR0_SWS_Mask));
+}
+
+/*********************************************************************
+ * @fn      RCC_HCLKConfig
+ *
+ * @brief   Configures the AHB clock (HCLK).
+ *
+ * @param   RCC_SYSCLK - defines the AHB clock divider. This clock is derived from
+ *        the system clock (SYSCLK).
+ *            RCC_SYSCLK_Div1 - AHB clock = SYSCLK.
+ *            RCC_SYSCLK_Div2 - AHB clock = SYSCLK/2.
+ *            RCC_SYSCLK_Div4 - AHB clock = SYSCLK/4.
+ *            RCC_SYSCLK_Div8 - AHB clock = SYSCLK/8.
+ *            RCC_SYSCLK_Div16 - AHB clock = SYSCLK/16.
+ *            RCC_SYSCLK_Div64 - AHB clock = SYSCLK/64.
+ *            RCC_SYSCLK_Div128 - AHB clock = SYSCLK/128.
+ *            RCC_SYSCLK_Div256 - AHB clock = SYSCLK/256.
+ *            RCC_SYSCLK_Div512 - AHB clock = SYSCLK/512.
+ *
+ * @return  none
+ */
+void RCC_HCLKConfig(uint32_t RCC_SYSCLK)
+{
+  uint32_t tmpreg = 0;
+
+  tmpreg = RCC->CFGR0;
+  tmpreg &= CFGR0_HPRE_Reset_Mask;
+  tmpreg |= RCC_SYSCLK;
+  RCC->CFGR0 = tmpreg;
+}
+
+/*********************************************************************
+ * @fn      RCC_PCLK1Config
+ *
+ * @brief   Configures the Low Speed APB clock (PCLK1).
+ *
+ * @param   RCC_HCLK - defines the APB1 clock divider. This clock is derived from
+ *        the AHB clock (HCLK).
+ *            RCC_HCLK_Div1 - APB1 clock = HCLK.
+ *            RCC_HCLK_Div2 - APB1 clock = HCLK/2.
+ *            RCC_HCLK_Div4 - APB1 clock = HCLK/4.
+ *            RCC_HCLK_Div8 - APB1 clock = HCLK/8.
+ *            RCC_HCLK_Div16 - APB1 clock = HCLK/16.
+ *
+ * @return  none
+ */
+void RCC_PCLK1Config(uint32_t RCC_HCLK)
+{
+  uint32_t tmpreg = 0;
+
+  tmpreg = RCC->CFGR0;
+  tmpreg &= CFGR0_PPRE1_Reset_Mask;
+  tmpreg |= RCC_HCLK;
+  RCC->CFGR0 = tmpreg;
+}
+
+/*********************************************************************
+ * @fn      RCC_PCLK2Config
+ *
+ * @brief   Configures the High Speed APB clock (PCLK2).
+ *
+ * @param   RCC_HCLK - defines the APB2 clock divider. This clock is derived from
+ *        the AHB clock (HCLK).
+ *            RCC_HCLK_Div1 - APB2 clock = HCLK.
+ *            RCC_HCLK_Div2 - APB2 clock = HCLK/2.
+ *            RCC_HCLK_Div4 - APB2 clock = HCLK/4.
+ *            RCC_HCLK_Div8 - APB2 clock = HCLK/8.
+ *            RCC_HCLK_Div16 - APB2 clock = HCLK/16.
+ * @return  none
+ */
+void RCC_PCLK2Config(uint32_t RCC_HCLK)
+{
+  uint32_t tmpreg = 0;
+
+  tmpreg = RCC->CFGR0;
+  tmpreg &= CFGR0_PPRE2_Reset_Mask;
+  tmpreg |= RCC_HCLK << 3;
+  RCC->CFGR0 = tmpreg;
+}
+
+/*********************************************************************
+ * @fn      RCC_ITConfig
+ *
+ * @brief   Enables or disables the specified RCC interrupts.
+ *
+ * @param   RCC_IT - specifies the RCC interrupt sources to be enabled or disabled.
+ *            RCC_IT_LSIRDY - LSI ready interrupt.
+ *            RCC_IT_LSERDY - LSE ready interrupt.
+ *            RCC_IT_HSIRDY - HSI ready interrupt.
+ *            RCC_IT_HSERDY - HSE ready interrupt.
+ *            RCC_IT_PLLRDY - PLL ready interrupt.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void RCC_ITConfig(uint8_t RCC_IT, FunctionalState NewState)
+{
+  if (NewState != DISABLE)
+  {
+    *(__IO uint8_t *) INTR_BYTE2_ADDRESS |= RCC_IT;
+  }
+  else
+  {
+    *(__IO uint8_t *) INTR_BYTE2_ADDRESS &= (uint8_t)~RCC_IT;
+  }
+}
+
+/*********************************************************************
+ * @fn      RCC_USBCLKConfig
+ *
+ * @brief   Configures the USB clock (USBCLK).
+ *
+ * @param    RCC_USBCLKSource: specifies the USB clock source. This clock is
+ *        derived from the PLL output.
+ *             RCC_USBCLKSource_PLLCLK_Div1 - PLL clock selected as USB clock source(48Mhz).
+ *             RCC_USBCLKSource_PLLCLK_Div2 - PLL clock selected as USB clock source(96MHz).
+ *             RCC_USBCLKSource_PLLCLK_Div3 - PLL clock selected as USB clock source(144MHz).
+ *             RCC_USBCLKSource_PLLCLK_Div5 - PLL clock selected as USB clock source(240MHz).
+ *
+ * @return  none
+ */
+void RCC_USBCLKConfig(uint32_t RCC_USBCLKSource)
+{
+    RCC->CFGR0 &= ~((uint32_t)3<<22);
+    RCC->CFGR0 |= RCC_USBCLKSource<<22;
+}
+
+/*********************************************************************
+ * @fn      RCC_ADCCLKConfig
+ *
+ * @brief   Configures the ADC clock (ADCCLK).
+ *
+ * @param   RCC_PCLK2 - defines the ADC clock divider. This clock is derived from
+ *        the APB2 clock (PCLK2).
+ *          RCC_PCLK2_Div2 - ADC clock = PCLK2/2.
+ *          RCC_PCLK2_Div4 - ADC clock = PCLK2/4.
+ *          RCC_PCLK2_Div6 - ADC clock = PCLK2/6.
+ *          RCC_PCLK2_Div8 - ADC clock = PCLK2/8.
+ *
+ * @return  none
+ */
+void RCC_ADCCLKConfig(uint32_t RCC_PCLK2)
+{
+  uint32_t tmpreg = 0;
+
+  tmpreg = RCC->CFGR0;
+  tmpreg &= CFGR0_ADCPRE_Reset_Mask;
+  tmpreg |= RCC_PCLK2;
+  RCC->CFGR0 = tmpreg;
+}
+
+/*********************************************************************
+ * @fn      RCC_LSEConfig
+ *
+ * @brief   Configures the External Low Speed oscillator (LSE).
+ *
+ * @param   RCC_LSE - specifies the new state of the LSE.
+ *            RCC_LSE_OFF - LSE oscillator OFF.
+ *            RCC_LSE_ON - LSE oscillator ON.
+ *            RCC_LSE_Bypass - LSE oscillator bypassed with external clock.
+ *
+ * @return  none
+ */
+void RCC_LSEConfig(uint8_t RCC_LSE)
+{
+  *(__IO uint8_t *) BDCTLR_ADDRESS = RCC_LSE_OFF;
+  *(__IO uint8_t *) BDCTLR_ADDRESS = RCC_LSE_OFF;
+	
+  switch(RCC_LSE)
+  {
+    case RCC_LSE_ON:
+      *(__IO uint8_t *) BDCTLR_ADDRESS = RCC_LSE_ON;
+      break;
+      
+    case RCC_LSE_Bypass:
+      *(__IO uint8_t *) BDCTLR_ADDRESS = RCC_LSE_Bypass | RCC_LSE_ON;
+      break;            
+      
+    default:
+      break;      
+  }
+}
+
+/*********************************************************************
+ * @fn      RCC_LSICmd
+ *
+ * @brief   Enables or disables the Internal Low Speed oscillator (LSI).
+ *          Note-
+ *          LSI can not be disabled if the IWDG is running.
+ *
+ * @param   NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void RCC_LSICmd(FunctionalState NewState)
+{
+	if(NewState)
+	{
+		RCC->RSTSCKR |= (1<<0);
+	}
+	else{
+		RCC->RSTSCKR &= ~(1<<0);		
+	}	
+}
+
+/*********************************************************************
+ * @fn      RCC_RTCCLKConfig
+ *
+ * @brief   Once the RTC clock is selected it can't be changed unless the Backup domain is reset.
+ *
+ * @param   RCC_RTCCLKSource - specifies the RTC clock source.
+ *            RCC_RTCCLKSource_LSE - LSE selected as RTC clock.
+ *            RCC_RTCCLKSource_LSI - LSI selected as RTC clock.
+ *            RCC_RTCCLKSource_HSE_Div128 - HSE clock divided by 128 selected as RTC clock.
+ *         Note-   
+ *           Once the RTC clock is selected it can't be changed unless the Backup domain is reset.
+ * @return  none
+ */
+void RCC_RTCCLKConfig(uint32_t RCC_RTCCLKSource)
+{
+  RCC->BDCTLR |= RCC_RTCCLKSource;
+}
+
+/*********************************************************************
+ * @fn      RCC_RTCCLKCmd
+ *
+ * @brief   This function must be used only after the RTC clock was selected
+ *        using the RCC_RTCCLKConfig function.
+ *
+ * @param   NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void RCC_RTCCLKCmd(FunctionalState NewState)
+{
+	if(NewState)
+	{
+		RCC->BDCTLR |= (1<<15);
+	}
+	else{
+		RCC->BDCTLR &= ~(1<<15);		
+	}	
+}
+
+/*********************************************************************
+ * @fn      RCC_GetClocksFreq
+ *
+ * @brief   The result of this function could be not correct when using
+ *        fractional value for HSE crystal.
+ *
+ * @param   RCC_Clocks - pointer to a RCC_ClocksTypeDef structure which will hold
+ *        the clocks frequencies.
+ *
+ * @return  none
+ */
+void RCC_GetClocksFreq(RCC_ClocksTypeDef* RCC_Clocks)
+{
+    uint32_t tmp = 0, pllmull = 0, pllsource = 0, presc = 0;
+
+    tmp = RCC->CFGR0 & CFGR0_SWS_Mask;
+
+    switch (tmp)
+    {
+      case 0x00:
+        RCC_Clocks->SYSCLK_Frequency = HSI_VALUE;
+        break;
+
+      case 0x04:
+        RCC_Clocks->SYSCLK_Frequency = HSE_VALUE;
+        break;
+
+      case 0x08:
+        pllmull = RCC->CFGR0 & CFGR0_PLLMull_Mask;
+        pllsource = RCC->CFGR0 & CFGR0_PLLSRC_Mask;
+
+        pllmull = ( pllmull >> 18) + 2;
+
+        if(pllmull == 17) pllmull = 18;
+
+
+        if (pllsource == 0x00)
+        {
+          if(EXTEN->EXTEN_CTR & EXTEN_PLL_HSI_PRE){
+              RCC_Clocks->SYSCLK_Frequency = (HSI_VALUE) * pllmull;
+          }
+          else{
+              RCC_Clocks->SYSCLK_Frequency = (HSI_VALUE >>1) * pllmull;
+          }
+        }
+        else
+        {
+#if defined (CH32V20x_D8W)
+          if((RCC->CFGR0 & (3<<22)) == (3<<22))
+          {
+              RCC_Clocks->SYSCLK_Frequency = ((HSE_VALUE>>1)) * pllmull;
+          }
+          else
+#endif
+          if ((RCC->CFGR0 & CFGR0_PLLXTPRE_Mask) != (uint32_t)RESET)
+          {
+#if defined (CH32V20x_D8) || defined (CH32V20x_D8W)
+              RCC_Clocks->SYSCLK_Frequency = ((HSE_VALUE>>2) >> 1) * pllmull;
+#else
+            RCC_Clocks->SYSCLK_Frequency = (HSE_VALUE >> 1) * pllmull;
+#endif
+          }
+          else
+          {
+#if defined (CH32V20x_D8) || defined (CH32V20x_D8W)
+              RCC_Clocks->SYSCLK_Frequency = (HSE_VALUE>>2) * pllmull;
+#else
+            RCC_Clocks->SYSCLK_Frequency = HSE_VALUE * pllmull;
+#endif
+
+          }
+        }
+
+        break;
+
+      default:
+        RCC_Clocks->SYSCLK_Frequency = HSI_VALUE;
+        break;
+    }
+
+    tmp = RCC->CFGR0 & CFGR0_HPRE_Set_Mask;
+    tmp = tmp >> 4;
+    presc = APBAHBPrescTable[tmp];
+    RCC_Clocks->HCLK_Frequency = RCC_Clocks->SYSCLK_Frequency >> presc;
+    tmp = RCC->CFGR0 & CFGR0_PPRE1_Set_Mask;
+    tmp = tmp >> 8;
+    presc = APBAHBPrescTable[tmp];
+    RCC_Clocks->PCLK1_Frequency = RCC_Clocks->HCLK_Frequency >> presc;
+    tmp = RCC->CFGR0 & CFGR0_PPRE2_Set_Mask;
+    tmp = tmp >> 11;
+    presc = APBAHBPrescTable[tmp];
+    RCC_Clocks->PCLK2_Frequency = RCC_Clocks->HCLK_Frequency >> presc;
+    tmp = RCC->CFGR0 & CFGR0_ADCPRE_Set_Mask;
+    tmp = tmp >> 14;
+    presc = ADCPrescTable[tmp];
+    RCC_Clocks->ADCCLK_Frequency = RCC_Clocks->PCLK2_Frequency / presc;
+}
+
+/*********************************************************************
+ * @fn      RCC_AHBPeriphClockCmd
+ *
+ * @brief   Enables or disables the AHB peripheral clock.
+ *
+ * @param   RCC_AHBPeriph - specifies the AHB peripheral to gates its clock.
+ *            RCC_AHBPeriph_DMA1.
+ *            RCC_AHBPeriph_DMA2.
+ *            RCC_AHBPeriph_SRAM.
+ *            RCC_AHBPeriph_CRC.
+ *            RCC_AHBPeriph_OTG_FS
+ *          Note-
+ *          SRAM  clock can be disabled only during sleep mode.
+ *          NewState: ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void RCC_AHBPeriphClockCmd(uint32_t RCC_AHBPeriph, FunctionalState NewState)
+{
+  if (NewState != DISABLE)
+  {
+    RCC->AHBPCENR |= RCC_AHBPeriph;
+  }
+  else
+  {
+    RCC->AHBPCENR &= ~RCC_AHBPeriph;
+  }
+}
+
+/*********************************************************************
+ * @fn      RCC_APB2PeriphClockCmd
+ *
+ * @brief   Enables or disables the High Speed APB (APB2) peripheral clock.
+ *
+ * @param   RCC_APB2Periph - specifies the APB2 peripheral to gates its clock.
+ *            RCC_APB2Periph_AFIO.
+ *            RCC_APB2Periph_GPIOA.
+ *            RCC_APB2Periph_GPIOB.
+ *            RCC_APB2Periph_GPIOC.
+ *            RCC_APB2Periph_GPIOD.
+ *            RCC_APB2Periph_GPIOE
+ *            RCC_APB2Periph_ADC1.
+ *            RCC_APB2Periph_ADC2
+ *            RCC_APB2Periph_TIM1.
+ *            RCC_APB2Periph_SPI1.
+ *            RCC_APB2Periph_TIM8
+ *            RCC_APB2Periph_USART1.
+ *          NewState - ENABLE or DISABLE
+ *
+ * @return  none
+ */
+void RCC_APB2PeriphClockCmd(uint32_t RCC_APB2Periph, FunctionalState NewState)
+{
+  if (NewState != DISABLE)
+  {
+    RCC->APB2PCENR |= RCC_APB2Periph;
+  }
+  else
+  {
+    RCC->APB2PCENR &= ~RCC_APB2Periph;
+  }
+}
+
+/*********************************************************************
+ * @fn      RCC_APB1PeriphClockCmd
+ *
+ * @brief   Enables or disables the Low Speed APB (APB1) peripheral clock.
+ *
+ * @param   RCC_APB1Periph - specifies the APB1 peripheral to gates its clock.
+ *            RCC_APB1Periph_TIM2.
+ *            RCC_APB1Periph_TIM3.
+ *            RCC_APB1Periph_TIM4.
+ *            RCC_APB1Periph_TIM5
+ *            RCC_APB1Periph_WWDG.
+ *            RCC_APB1Periph_SPI2.
+ *            RCC_APB1Periph_USART2.
+ *            RCC_APB1Periph_USART3.
+ *            RCC_APB1Periph_UART4
+ *            RCC_APB1Periph_I2C1.
+ *            RCC_APB1Periph_I2C2.
+ *            RCC_APB1Periph_USB.
+ *            RCC_APB1Periph_CAN1.
+ *            RCC_APB1Periph_BKP.
+ *            RCC_APB1Periph_PWR.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void RCC_APB1PeriphClockCmd(uint32_t RCC_APB1Periph, FunctionalState NewState)
+{
+  if (NewState != DISABLE)
+  {
+    RCC->APB1PCENR |= RCC_APB1Periph;
+  }
+  else
+  {
+    RCC->APB1PCENR &= ~RCC_APB1Periph;
+  }
+}
+
+/*********************************************************************
+ * @fn      RCC_APB2PeriphResetCmd
+ *
+ * @brief   Forces or releases High Speed APB (APB2) peripheral reset.
+ *
+ * @param   RCC_APB2Periph - specifies the APB2 peripheral to reset.
+ *            RCC_APB2Periph_AFIO.
+ *            RCC_APB2Periph_GPIOA.
+ *            RCC_APB2Periph_GPIOB.
+ *            RCC_APB2Periph_GPIOC.
+ *            RCC_APB2Periph_GPIOD.
+ *            RCC_APB2Periph_GPIOE
+ *            RCC_APB2Periph_ADC1.
+ *            RCC_APB2Periph_ADC2
+ *            RCC_APB2Periph_TIM1.
+ *            RCC_APB2Periph_SPI1.
+ *            RCC_APB2Periph_TIM8
+ *            RCC_APB2Periph_USART1.
+ *          NewState - ENABLE or DISABLE
+ *
+ * @return  none
+ */
+void RCC_APB2PeriphResetCmd(uint32_t RCC_APB2Periph, FunctionalState NewState)
+{
+  if (NewState != DISABLE)
+  {
+    RCC->APB2PRSTR |= RCC_APB2Periph;
+  }
+  else
+  {
+    RCC->APB2PRSTR &= ~RCC_APB2Periph;
+  }
+}
+
+/*********************************************************************
+ * @fn      RCC_APB1PeriphResetCmd
+ *
+ * @brief   Forces or releases Low Speed APB (APB1) peripheral reset.
+ *
+ * @param   RCC_APB1Periph - specifies the APB1 peripheral to reset.
+ *            RCC_APB1Periph_TIM2.
+ *            RCC_APB1Periph_TIM3.
+ *            RCC_APB1Periph_TIM4.
+ *            RCC_APB1Periph_TIM5
+ *            RCC_APB1Periph_WWDG.
+ *            RCC_APB1Periph_SPI2.
+ *            RCC_APB1Periph_USART2.
+ *            RCC_APB1Periph_USART3.
+ *            RCC_APB1Periph_UART4
+ *            RCC_APB1Periph_I2C1.
+ *            RCC_APB1Periph_I2C2.
+ *            RCC_APB1Periph_USB.
+ *            RCC_APB1Periph_CAN1.
+ *            RCC_APB1Periph_BKP.
+ *            RCC_APB1Periph_PWR.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void RCC_APB1PeriphResetCmd(uint32_t RCC_APB1Periph, FunctionalState NewState)
+{
+  if (NewState != DISABLE)
+  {
+    RCC->APB1PRSTR |= RCC_APB1Periph;
+  }
+  else
+  {
+    RCC->APB1PRSTR &= ~RCC_APB1Periph;
+  }
+}
+
+/*********************************************************************
+ * @fn      RCC_BackupResetCmd
+ *
+ * @brief   Forces or releases the Backup domain reset.
+ *
+ * @param   NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void RCC_BackupResetCmd(FunctionalState NewState)
+{
+	if(NewState)
+	{
+		RCC->BDCTLR |= (1<<16);
+	}
+	else{
+		RCC->BDCTLR &= ~(1<<16);		
+	}		
+}
+
+/*******************************************************************************
+* Function Name  : RCC_ClockSecuritySystemCmd
+* Description    : Enables or disables the Clock Security System.
+* Input          : NewState: ENABLE or DISABLE.
+* Return         : None
+*******************************************************************************/	
+void RCC_ClockSecuritySystemCmd(FunctionalState NewState)
+{
+	if(NewState)
+	{
+		RCC->CTLR |= (1<<19);
+	}
+	else{
+		RCC->CTLR &= ~(1<<19);		
+	}		
+}
+
+/*********************************************************************
+ * @fn      RCC_MCOConfig
+ *
+ * @brief   Selects the clock source to output on MCO pin.
+ *
+ * @param   RCC_MCO - specifies the clock source to output.
+ *            RCC_MCO_NoClock - No clock selected.
+ *            RCC_MCO_SYSCLK - System clock selected.
+ *            RCC_MCO_HSI - HSI oscillator clock selected.
+ *            RCC_MCO_HSE - HSE oscillator clock selected.
+ *            RCC_MCO_PLLCLK_Div2 - PLL clock divided by 2 selected.
+ *
+ * @return  none
+ */
+void RCC_MCOConfig(uint8_t RCC_MCO)
+{
+  *(__IO uint8_t *) CFGR0_BYTE4_ADDRESS = RCC_MCO;
+}
+
+/*********************************************************************
+ * @fn      RCC_GetFlagStatus
+ *
+ * @brief   Checks whether the specified RCC flag is set or not.
+ *
+ * @param   RCC_FLAG - specifies the flag to check.
+ *            RCC_FLAG_HSIRDY - HSI oscillator clock ready.
+ *            RCC_FLAG_HSERDY - HSE oscillator clock ready.
+ *            RCC_FLAG_PLLRDY - PLL clock ready.
+ *            RCC_FLAG_PLL2RDY - PLL2 clock ready.
+ *            RCC_FLAG_PLL3RDY - PLL3 clock ready.
+ *            RCC_FLAG_LSERDY - LSE oscillator clock ready.
+ *            RCC_FLAG_LSIRDY - LSI oscillator clock ready.
+ *            RCC_FLAG_PINRST - Pin reset.
+ *            RCC_FLAG_PORRST - POR/PDR reset.
+ *            RCC_FLAG_SFTRST - Software reset.
+ *            RCC_FLAG_IWDGRST - Independent Watchdog reset.
+ *            RCC_FLAG_WWDGRST - Window Watchdog reset.
+ *            RCC_FLAG_LPWRRST - Low Power reset.
+ *
+ * @return  FlagStatus - SET or RESET.
+ */
+FlagStatus RCC_GetFlagStatus(uint8_t RCC_FLAG)
+{
+  uint32_t tmp = 0;
+  uint32_t statusreg = 0;
+	
+  FlagStatus bitstatus = RESET;
+  tmp = RCC_FLAG >> 5;
+	
+  if (tmp == 1)            
+  {
+    statusreg = RCC->CTLR;
+  }
+  else if (tmp == 2)       
+  {
+    statusreg = RCC->BDCTLR;
+  }
+  else                    
+  {
+    statusreg = RCC->RSTSCKR;
+  }
+
+  tmp = RCC_FLAG & FLAG_Mask;
+	
+  if ((statusreg & ((uint32_t)1 << tmp)) != (uint32_t)RESET)
+  {
+    bitstatus = SET;
+  }
+  else
+  {
+    bitstatus = RESET;
+  }
+
+  return bitstatus;
+}
+
+/*********************************************************************
+ * @fn      RCC_ClearFlag
+ *
+ * @brief   Clears the RCC reset flags.
+ *          Note-   
+ *          The reset flags are: RCC_FLAG_PINRST, RCC_FLAG_PORRST, RCC_FLAG_SFTRST,
+ *          RCC_FLAG_IWDGRST, RCC_FLAG_WWDGRST, RCC_FLAG_LPWRRST
+ * @return  none
+ */
+void RCC_ClearFlag(void)
+{
+  RCC->RSTSCKR |= RSTSCKR_RMVF_Set;
+}
+
+/*********************************************************************
+ * @fn      RCC_GetITStatus
+ *
+ * @brief   Checks whether the specified RCC interrupt has occurred or not.
+ *
+ * @param   RCC_IT - specifies the RCC interrupt source to check.
+ *            RCC_IT_LSIRDY - LSI ready interrupt.
+ *            RCC_IT_LSERDY - LSE ready interrupt.
+ *            RCC_IT_HSIRDY - HSI ready interrupt.
+ *            RCC_IT_HSERDY - HSE ready interrupt.
+ *            RCC_IT_PLLRDY - PLL ready interrupt.
+ *            RCC_IT_PLL2RDY - PLL2 ready interrupt.
+ *            RCC_IT_PLL3RDY - PLL3 ready interrupt.
+ *            RCC_IT_CSS - Clock Security System interrupt.
+ *
+ * @return  ITStatus - SET or RESET.
+ */
+
+ITStatus RCC_GetITStatus(uint8_t RCC_IT)
+{
+  ITStatus bitstatus = RESET;
+
+  if ((RCC->INTR & RCC_IT) != (uint32_t)RESET)
+  {
+    bitstatus = SET;
+  }
+  else
+  {
+    bitstatus = RESET;
+  }
+
+  return  bitstatus;
+}
+
+/*********************************************************************
+ * @fn      RCC_ClearITPendingBit
+ *
+ * @brief   Clears the RCC's interrupt pending bits.
+ *
+ * @param   RCC_IT - specifies the interrupt pending bit to clear.
+ *            RCC_IT_LSIRDY - LSI ready interrupt.
+ *            RCC_IT_LSERDY - LSE ready interrupt.
+ *            RCC_IT_HSIRDY - HSI ready interrupt.
+ *            RCC_IT_HSERDY - HSE ready interrupt.
+ *            RCC_IT_PLLRDY - PLL ready interrupt.
+ *            RCC_IT_PLL2RDY - PLL2 ready interrupt.
+ *            RCC_IT_PLL3RDY - PLL3 ready interrupt.
+ *            RCC_IT_CSS - Clock Security System interrupt.
+ *
+ * @return  none
+ */
+void RCC_ClearITPendingBit(uint8_t RCC_IT)
+{
+  *(__IO uint8_t *) INTR_BYTE3_ADDRESS = RCC_IT;
+}
+
+/*********************************************************************
+ * @fn      RCC_ADCCLKADJcmd
+ *
+ * @brief   Enable ADC clock duty cycle adjustment.
+ *
+ * @param   NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void RCC_ADCCLKADJcmd(FunctionalState NewState)
+{
+  if (NewState != DISABLE)
+  {
+    RCC->CFGR0 |= (1<<31);
+  }
+  else
+  {
+    RCC->CFGR0 &= ~(1<<31);
+  }
+}
+
+/*********************************************************************
+ * @fn      RCC_ETHDIVConfig
+ *
+ * @brief   Configures the ETH clock.
+ *
+ * @param   RCC_ETHPRE_Div - defines the USBHS clock divider.
+ *            RCC_ETHCLK_Div1 - ETH clock = AHB/1.
+ *            RCC_ETHCLK_Div2 - ETH clock = AHB/2.
+ *
+ * @return  none
+ */
+void RCC_ETHDIVConfig(uint32_t RCC_ETHPRE_Div)
+{
+    RCC->CFGR0 &= ~((uint32_t)1<<28);
+    RCC->CFGR0 |= RCC_ETHPRE_Div<<28;
+}
+
+
+

--- a/Sources/source/Peripheral/src/ch32v20x_tim.c
+++ b/Sources/source/Peripheral/src/ch32v20x_tim.c
@@ -1,0 +1,2353 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : ch32v20x_tim.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/06/06
+ * Description        : This file provides all the TIM firmware functions.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#include "ch32v20x_tim.h"
+#include "ch32v20x_rcc.h"
+
+/* TIM registers bit mask */
+#define SMCFGR_ETR_Mask    ((uint16_t)0x00FF)
+#define CHCTLR_Offset      ((uint16_t)0x0018)
+#define CCER_CCE_Set       ((uint16_t)0x0001)
+#define CCER_CCNE_Set      ((uint16_t)0x0004)
+
+static void TI1_Config(TIM_TypeDef *TIMx, uint16_t TIM_ICPolarity, uint16_t TIM_ICSelection,
+                       uint16_t TIM_ICFilter);
+static void TI2_Config(TIM_TypeDef *TIMx, uint16_t TIM_ICPolarity, uint16_t TIM_ICSelection,
+                       uint16_t TIM_ICFilter);
+static void TI3_Config(TIM_TypeDef *TIMx, uint16_t TIM_ICPolarity, uint16_t TIM_ICSelection,
+                       uint16_t TIM_ICFilter);
+static void TI4_Config(TIM_TypeDef *TIMx, uint16_t TIM_ICPolarity, uint16_t TIM_ICSelection,
+                       uint16_t TIM_ICFilter);
+
+/*********************************************************************
+ * @fn      TIM_DeInit
+ *
+ * @brief   Deinitializes the TIMx peripheral registers to their default
+ *        reset values.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *
+ * @return  none
+ */
+void TIM_DeInit(TIM_TypeDef *TIMx)
+{
+    if(TIMx == TIM1)
+    {
+        RCC_APB2PeriphResetCmd(RCC_APB2Periph_TIM1, ENABLE);
+        RCC_APB2PeriphResetCmd(RCC_APB2Periph_TIM1, DISABLE);
+    }
+    else if(TIMx == TIM2)
+    {
+        RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM2, ENABLE);
+        RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM2, DISABLE);
+    }
+    else if(TIMx == TIM3)
+    {
+        RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM3, ENABLE);
+        RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM3, DISABLE);
+    }
+    else if(TIMx == TIM4)
+    {
+        RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM4, ENABLE);
+        RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM4, DISABLE);
+    }
+    else if(TIMx == TIM5)
+    {
+        RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM5, ENABLE);
+        RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM5, DISABLE);
+    }
+}
+
+/*********************************************************************
+ * @fn      TIM_TimeBaseInit
+ *
+ * @brief   Initializes the TIMx Time Base Unit peripheral according to
+ *        the specified parameters in the TIM_TimeBaseInitStruct.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_TimeBaseInitStruct - pointer to a TIM_TimeBaseInitTypeDef
+ *        structure.
+ *
+ * @return  none
+ */
+void TIM_TimeBaseInit(TIM_TypeDef *TIMx, TIM_TimeBaseInitTypeDef *TIM_TimeBaseInitStruct)
+{
+    uint16_t tmpcr1 = 0;
+
+    tmpcr1 = TIMx->CTLR1;
+
+    if((TIMx == TIM1) || (TIMx == TIM2) || (TIMx == TIM3) || (TIMx == TIM4) || (TIMx == TIM5))
+    {
+        tmpcr1 &= (uint16_t)(~((uint16_t)(TIM_DIR | TIM_CMS)));
+        tmpcr1 |= (uint32_t)TIM_TimeBaseInitStruct->TIM_CounterMode;
+    }
+
+    tmpcr1 &= (uint16_t)(~((uint16_t)TIM_CTLR1_CKD));
+    tmpcr1 |= (uint32_t)TIM_TimeBaseInitStruct->TIM_ClockDivision;
+
+    TIMx->CTLR1 = tmpcr1;
+    TIMx->ATRLR = TIM_TimeBaseInitStruct->TIM_Period;
+    TIMx->PSC = TIM_TimeBaseInitStruct->TIM_Prescaler;
+
+    if(TIMx == TIM1)
+    {
+        TIMx->RPTCR = TIM_TimeBaseInitStruct->TIM_RepetitionCounter;
+    }
+
+    TIMx->SWEVGR = TIM_PSCReloadMode_Immediate;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC1Init
+ *
+ * @brief   Initializes the TIMx Channel1 according to the specified
+ *        parameters in the TIM_OCInitStruct.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_OCInitStruct - pointer to a TIM_OCInitTypeDef structure.
+ *
+ * @return  none
+ */
+void TIM_OC1Init(TIM_TypeDef *TIMx, TIM_OCInitTypeDef *TIM_OCInitStruct)
+{
+    uint16_t tmpccmrx = 0, tmpccer = 0, tmpcr2 = 0;
+
+    TIMx->CCER &= (uint16_t)(~(uint16_t)TIM_CC1E);
+    tmpccer = TIMx->CCER;
+    tmpcr2 = TIMx->CTLR2;
+    tmpccmrx = TIMx->CHCTLR1;
+    tmpccmrx &= (uint16_t)(~((uint16_t)TIM_OC1M));
+    tmpccmrx &= (uint16_t)(~((uint16_t)TIM_CC1S));
+    tmpccmrx |= TIM_OCInitStruct->TIM_OCMode;
+    tmpccer &= (uint16_t)(~((uint16_t)TIM_CC1P));
+    tmpccer |= TIM_OCInitStruct->TIM_OCPolarity;
+    tmpccer |= TIM_OCInitStruct->TIM_OutputState;
+
+    if(TIMx == TIM1)
+    {
+        tmpccer &= (uint16_t)(~((uint16_t)TIM_CC1NP));
+        tmpccer |= TIM_OCInitStruct->TIM_OCNPolarity;
+
+        tmpccer &= (uint16_t)(~((uint16_t)TIM_CC1NE));
+        tmpccer |= TIM_OCInitStruct->TIM_OutputNState;
+
+        tmpcr2 &= (uint16_t)(~((uint16_t)TIM_OIS1));
+        tmpcr2 &= (uint16_t)(~((uint16_t)TIM_OIS1N));
+
+        tmpcr2 |= TIM_OCInitStruct->TIM_OCIdleState;
+        tmpcr2 |= TIM_OCInitStruct->TIM_OCNIdleState;
+    }
+
+    TIMx->CTLR2 = tmpcr2;
+    TIMx->CHCTLR1 = tmpccmrx;
+    TIMx->CH1CVR = TIM_OCInitStruct->TIM_Pulse;
+    TIMx->CCER = tmpccer;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC2Init
+ *
+ * @brief   Initializes the TIMx Channel2 according to the specified
+ *        parameters in the TIM_OCInitStruct.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_OCInitStruct - pointer to a TIM_OCInitTypeDef structure.
+ *
+ * @return  none
+ */
+void TIM_OC2Init(TIM_TypeDef *TIMx, TIM_OCInitTypeDef *TIM_OCInitStruct)
+{
+    uint16_t tmpccmrx = 0, tmpccer = 0, tmpcr2 = 0;
+
+    TIMx->CCER &= (uint16_t)(~((uint16_t)TIM_CC2E));
+    tmpccer = TIMx->CCER;
+    tmpcr2 = TIMx->CTLR2;
+    tmpccmrx = TIMx->CHCTLR1;
+    tmpccmrx &= (uint16_t)(~((uint16_t)TIM_OC2M));
+    tmpccmrx &= (uint16_t)(~((uint16_t)TIM_CC2S));
+    tmpccmrx |= (uint16_t)(TIM_OCInitStruct->TIM_OCMode << 8);
+    tmpccer &= (uint16_t)(~((uint16_t)TIM_CC2P));
+    tmpccer |= (uint16_t)(TIM_OCInitStruct->TIM_OCPolarity << 4);
+    tmpccer |= (uint16_t)(TIM_OCInitStruct->TIM_OutputState << 4);
+
+    if(TIMx == TIM1)
+    {
+        tmpccer &= (uint16_t)(~((uint16_t)TIM_CC2NP));
+        tmpccer |= (uint16_t)(TIM_OCInitStruct->TIM_OCNPolarity << 4);
+        tmpccer &= (uint16_t)(~((uint16_t)TIM_CC2NE));
+        tmpccer |= (uint16_t)(TIM_OCInitStruct->TIM_OutputNState << 4);
+
+        tmpcr2 &= (uint16_t)(~((uint16_t)TIM_OIS2));
+        tmpcr2 &= (uint16_t)(~((uint16_t)TIM_OIS2N));
+        tmpcr2 |= (uint16_t)(TIM_OCInitStruct->TIM_OCIdleState << 2);
+        tmpcr2 |= (uint16_t)(TIM_OCInitStruct->TIM_OCNIdleState << 2);
+    }
+
+    TIMx->CTLR2 = tmpcr2;
+    TIMx->CHCTLR1 = tmpccmrx;
+    TIMx->CH2CVR = TIM_OCInitStruct->TIM_Pulse;
+    TIMx->CCER = tmpccer;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC3Init
+ *
+ * @brief   Initializes the TIMx Channel3 according to the specified
+ *        parameters in the TIM_OCInitStruct.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_OCInitStruct - pointer to a TIM_OCInitTypeDef structure.
+ *
+ * @return  none
+ */
+void TIM_OC3Init(TIM_TypeDef *TIMx, TIM_OCInitTypeDef *TIM_OCInitStruct)
+{
+    uint16_t tmpccmrx = 0, tmpccer = 0, tmpcr2 = 0;
+
+    TIMx->CCER &= (uint16_t)(~((uint16_t)TIM_CC3E));
+    tmpccer = TIMx->CCER;
+    tmpcr2 = TIMx->CTLR2;
+    tmpccmrx = TIMx->CHCTLR2;
+    tmpccmrx &= (uint16_t)(~((uint16_t)TIM_OC3M));
+    tmpccmrx &= (uint16_t)(~((uint16_t)TIM_CC3S));
+    tmpccmrx |= TIM_OCInitStruct->TIM_OCMode;
+    tmpccer &= (uint16_t)(~((uint16_t)TIM_CC3P));
+    tmpccer |= (uint16_t)(TIM_OCInitStruct->TIM_OCPolarity << 8);
+    tmpccer |= (uint16_t)(TIM_OCInitStruct->TIM_OutputState << 8);
+
+    if(TIMx == TIM1)
+    {
+        tmpccer &= (uint16_t)(~((uint16_t)TIM_CC3NP));
+        tmpccer |= (uint16_t)(TIM_OCInitStruct->TIM_OCNPolarity << 8);
+        tmpccer &= (uint16_t)(~((uint16_t)TIM_CC3NE));
+        tmpccer |= (uint16_t)(TIM_OCInitStruct->TIM_OutputNState << 8);
+        tmpcr2 &= (uint16_t)(~((uint16_t)TIM_OIS3));
+        tmpcr2 &= (uint16_t)(~((uint16_t)TIM_OIS3N));
+        tmpcr2 |= (uint16_t)(TIM_OCInitStruct->TIM_OCIdleState << 4);
+        tmpcr2 |= (uint16_t)(TIM_OCInitStruct->TIM_OCNIdleState << 4);
+    }
+
+    TIMx->CTLR2 = tmpcr2;
+    TIMx->CHCTLR2 = tmpccmrx;
+    TIMx->CH3CVR = TIM_OCInitStruct->TIM_Pulse;
+    TIMx->CCER = tmpccer;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC4Init
+ *
+ * @brief   Initializes the TIMx Channel4 according to the specified
+ *        parameters in the TIM_OCInitStruct.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_OCInitStruct - pointer to a TIM_OCInitTypeDef structure.
+ *
+ * @return  none
+ */
+void TIM_OC4Init(TIM_TypeDef *TIMx, TIM_OCInitTypeDef *TIM_OCInitStruct)
+{
+    uint16_t tmpccmrx = 0, tmpccer = 0, tmpcr2 = 0;
+
+    TIMx->CCER &= (uint16_t)(~((uint16_t)TIM_CC4E));
+    tmpccer = TIMx->CCER;
+    tmpcr2 = TIMx->CTLR2;
+    tmpccmrx = TIMx->CHCTLR2;
+    tmpccmrx &= (uint16_t)(~((uint16_t)TIM_OC4M));
+    tmpccmrx &= (uint16_t)(~((uint16_t)TIM_CC4S));
+    tmpccmrx |= (uint16_t)(TIM_OCInitStruct->TIM_OCMode << 8);
+    tmpccer &= (uint16_t)(~((uint16_t)TIM_CC4P));
+    tmpccer |= (uint16_t)(TIM_OCInitStruct->TIM_OCPolarity << 12);
+    tmpccer |= (uint16_t)(TIM_OCInitStruct->TIM_OutputState << 12);
+
+    if(TIMx == TIM1)
+    {
+        tmpcr2 &= (uint16_t)(~((uint16_t)TIM_OIS4));
+        tmpcr2 |= (uint16_t)(TIM_OCInitStruct->TIM_OCIdleState << 6);
+    }
+
+    TIMx->CTLR2 = tmpcr2;
+    TIMx->CHCTLR2 = tmpccmrx;
+    TIMx->CH4CVR = TIM_OCInitStruct->TIM_Pulse;
+    TIMx->CCER = tmpccer;
+}
+
+/*********************************************************************
+ * @fn      TIM_ICInit
+ *
+ * @brief   IInitializes the TIM peripheral according to the specified
+ *        parameters in the TIM_ICInitStruct.
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_ICInitStruct - pointer to a TIM_ICInitTypeDef structure.
+ *
+ * @return  none
+ */
+void TIM_ICInit(TIM_TypeDef *TIMx, TIM_ICInitTypeDef *TIM_ICInitStruct)
+{
+    if(TIM_ICInitStruct->TIM_Channel == TIM_Channel_1)
+    {
+        TI1_Config(TIMx, TIM_ICInitStruct->TIM_ICPolarity,
+                   TIM_ICInitStruct->TIM_ICSelection,
+                   TIM_ICInitStruct->TIM_ICFilter);
+        TIM_SetIC1Prescaler(TIMx, TIM_ICInitStruct->TIM_ICPrescaler);
+    }
+    else if(TIM_ICInitStruct->TIM_Channel == TIM_Channel_2)
+    {
+        TI2_Config(TIMx, TIM_ICInitStruct->TIM_ICPolarity,
+                   TIM_ICInitStruct->TIM_ICSelection,
+                   TIM_ICInitStruct->TIM_ICFilter);
+        TIM_SetIC2Prescaler(TIMx, TIM_ICInitStruct->TIM_ICPrescaler);
+    }
+    else if(TIM_ICInitStruct->TIM_Channel == TIM_Channel_3)
+    {
+        TI3_Config(TIMx, TIM_ICInitStruct->TIM_ICPolarity,
+                   TIM_ICInitStruct->TIM_ICSelection,
+                   TIM_ICInitStruct->TIM_ICFilter);
+        TIM_SetIC3Prescaler(TIMx, TIM_ICInitStruct->TIM_ICPrescaler);
+    }
+    else
+    {
+        TI4_Config(TIMx, TIM_ICInitStruct->TIM_ICPolarity,
+                   TIM_ICInitStruct->TIM_ICSelection,
+                   TIM_ICInitStruct->TIM_ICFilter);
+        TIM_SetIC4Prescaler(TIMx, TIM_ICInitStruct->TIM_ICPrescaler);
+    }
+}
+
+/*********************************************************************
+ * @fn      TIM_PWMIConfig
+ *
+ * @brief   Configures the TIM peripheral according to the specified
+ *        parameters in the TIM_ICInitStruct to measure an external
+ *        PWM signal.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_ICInitStruct - pointer to a TIM_ICInitTypeDef structure.
+ *
+ * @return  none
+ */
+void TIM_PWMIConfig(TIM_TypeDef *TIMx, TIM_ICInitTypeDef *TIM_ICInitStruct)
+{
+    uint16_t icoppositepolarity = TIM_ICPolarity_Rising;
+    uint16_t icoppositeselection = TIM_ICSelection_DirectTI;
+
+    if(TIM_ICInitStruct->TIM_ICPolarity == TIM_ICPolarity_Rising)
+    {
+        icoppositepolarity = TIM_ICPolarity_Falling;
+    }
+    else
+    {
+        icoppositepolarity = TIM_ICPolarity_Rising;
+    }
+
+    if(TIM_ICInitStruct->TIM_ICSelection == TIM_ICSelection_DirectTI)
+    {
+        icoppositeselection = TIM_ICSelection_IndirectTI;
+    }
+    else
+    {
+        icoppositeselection = TIM_ICSelection_DirectTI;
+    }
+
+    if(TIM_ICInitStruct->TIM_Channel == TIM_Channel_1)
+    {
+        TI1_Config(TIMx, TIM_ICInitStruct->TIM_ICPolarity, TIM_ICInitStruct->TIM_ICSelection,
+                   TIM_ICInitStruct->TIM_ICFilter);
+        TIM_SetIC1Prescaler(TIMx, TIM_ICInitStruct->TIM_ICPrescaler);
+        TI2_Config(TIMx, icoppositepolarity, icoppositeselection, TIM_ICInitStruct->TIM_ICFilter);
+        TIM_SetIC2Prescaler(TIMx, TIM_ICInitStruct->TIM_ICPrescaler);
+    }
+    else
+    {
+        TI2_Config(TIMx, TIM_ICInitStruct->TIM_ICPolarity, TIM_ICInitStruct->TIM_ICSelection,
+                   TIM_ICInitStruct->TIM_ICFilter);
+        TIM_SetIC2Prescaler(TIMx, TIM_ICInitStruct->TIM_ICPrescaler);
+        TI1_Config(TIMx, icoppositepolarity, icoppositeselection, TIM_ICInitStruct->TIM_ICFilter);
+        TIM_SetIC1Prescaler(TIMx, TIM_ICInitStruct->TIM_ICPrescaler);
+    }
+}
+
+/*********************************************************************
+ * @fn      TIM_BDTRConfig
+ *
+ * @brief   Configures the: Break feature, dead time, Lock level, the OSSI,
+ *      the OSSR State and the AOE(automatic output enable).
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_BDTRInitStruct - pointer to a TIM_BDTRInitTypeDef structure.
+ *
+ * @return  none
+ */
+void TIM_BDTRConfig(TIM_TypeDef *TIMx, TIM_BDTRInitTypeDef *TIM_BDTRInitStruct)
+{
+    TIMx->BDTR = (uint32_t)TIM_BDTRInitStruct->TIM_OSSRState | TIM_BDTRInitStruct->TIM_OSSIState |
+                 TIM_BDTRInitStruct->TIM_LOCKLevel | TIM_BDTRInitStruct->TIM_DeadTime |
+                 TIM_BDTRInitStruct->TIM_Break | TIM_BDTRInitStruct->TIM_BreakPolarity |
+                 TIM_BDTRInitStruct->TIM_AutomaticOutput;
+}
+
+/*********************************************************************
+ * @fn      TIM_TimeBaseStructInit
+ *
+ * @brief   Fills each TIM_TimeBaseInitStruct member with its default value.
+ *
+ * @param   TIM_TimeBaseInitStruct - pointer to a TIM_TimeBaseInitTypeDef structure.
+ *
+ * @return  none
+ */
+void TIM_TimeBaseStructInit(TIM_TimeBaseInitTypeDef *TIM_TimeBaseInitStruct)
+{
+    TIM_TimeBaseInitStruct->TIM_Period = 0xFFFF;
+    TIM_TimeBaseInitStruct->TIM_Prescaler = 0x0000;
+    TIM_TimeBaseInitStruct->TIM_ClockDivision = TIM_CKD_DIV1;
+    TIM_TimeBaseInitStruct->TIM_CounterMode = TIM_CounterMode_Up;
+    TIM_TimeBaseInitStruct->TIM_RepetitionCounter = 0x0000;
+}
+
+/*********************************************************************
+ * @fn      TIM_OCStructInit
+ *
+ * @brief   Fills each TIM_OCInitStruct member with its default value.
+ *
+ * @param   TIM_OCInitStruct - pointer to a TIM_OCInitTypeDef structure.
+ *
+ * @return  none
+ */
+void TIM_OCStructInit(TIM_OCInitTypeDef *TIM_OCInitStruct)
+{
+    TIM_OCInitStruct->TIM_OCMode = TIM_OCMode_Timing;
+    TIM_OCInitStruct->TIM_OutputState = TIM_OutputState_Disable;
+    TIM_OCInitStruct->TIM_OutputNState = TIM_OutputNState_Disable;
+    TIM_OCInitStruct->TIM_Pulse = 0x0000;
+    TIM_OCInitStruct->TIM_OCPolarity = TIM_OCPolarity_High;
+    TIM_OCInitStruct->TIM_OCNPolarity = TIM_OCPolarity_High;
+    TIM_OCInitStruct->TIM_OCIdleState = TIM_OCIdleState_Reset;
+    TIM_OCInitStruct->TIM_OCNIdleState = TIM_OCNIdleState_Reset;
+}
+
+/*********************************************************************
+ * @fn      TIM_ICStructInit
+ *
+ * @brief   Fills each TIM_ICInitStruct member with its default value.
+ *
+ * @param   TIM_ICInitStruct - pointer to a TIM_ICInitTypeDef structure.
+ *
+ * @return  none
+ */
+void TIM_ICStructInit(TIM_ICInitTypeDef *TIM_ICInitStruct)
+{
+    TIM_ICInitStruct->TIM_Channel = TIM_Channel_1;
+    TIM_ICInitStruct->TIM_ICPolarity = TIM_ICPolarity_Rising;
+    TIM_ICInitStruct->TIM_ICSelection = TIM_ICSelection_DirectTI;
+    TIM_ICInitStruct->TIM_ICPrescaler = TIM_ICPSC_DIV1;
+    TIM_ICInitStruct->TIM_ICFilter = 0x00;
+}
+
+/*********************************************************************
+ * @fn      TIM_BDTRStructInit
+ *
+ * @brief   Fills each TIM_BDTRInitStruct member with its default value.
+ *
+ * @param   TIM_BDTRInitStruct - pointer to a TIM_BDTRInitTypeDef structure.
+ *
+ * @return  none
+ */
+void TIM_BDTRStructInit(TIM_BDTRInitTypeDef *TIM_BDTRInitStruct)
+{
+    TIM_BDTRInitStruct->TIM_OSSRState = TIM_OSSRState_Disable;
+    TIM_BDTRInitStruct->TIM_OSSIState = TIM_OSSIState_Disable;
+    TIM_BDTRInitStruct->TIM_LOCKLevel = TIM_LOCKLevel_OFF;
+    TIM_BDTRInitStruct->TIM_DeadTime = 0x00;
+    TIM_BDTRInitStruct->TIM_Break = TIM_Break_Disable;
+    TIM_BDTRInitStruct->TIM_BreakPolarity = TIM_BreakPolarity_Low;
+    TIM_BDTRInitStruct->TIM_AutomaticOutput = TIM_AutomaticOutput_Disable;
+}
+
+/*********************************************************************
+ * @fn      TIM_Cmd
+ *
+ * @brief   Enables or disables the specified TIM peripheral.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void TIM_Cmd(TIM_TypeDef *TIMx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        TIMx->CTLR1 |= TIM_CEN;
+    }
+    else
+    {
+        TIMx->CTLR1 &= (uint16_t)(~((uint16_t)TIM_CEN));
+    }
+}
+
+/*********************************************************************
+ * @fn      TIM_CtrlPWMOutputs
+ *
+ * @brief   Enables or disables the TIM peripheral Main Outputs.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void TIM_CtrlPWMOutputs(TIM_TypeDef *TIMx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        TIMx->BDTR |= TIM_MOE;
+    }
+    else
+    {
+        TIMx->BDTR &= (uint16_t)(~((uint16_t)TIM_MOE));
+    }
+}
+
+/*********************************************************************
+ * @fn      TIM_ITConfig
+ *
+ * @brief   Enables or disables the specified TIM interrupts.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_IT - specifies the TIM interrupts sources to be enabled or disabled.
+ *            TIM_IT_Update - TIM update Interrupt source.
+ *            TIM_IT_CC1 - TIM Capture Compare 1 Interrupt source.
+ *            TIM_IT_CC2 - TIM Capture Compare 2 Interrupt source
+ *            TIM_IT_CC3 - TIM Capture Compare 3 Interrupt source.
+ *            TIM_IT_CC4 - TIM Capture Compare 4 Interrupt source.
+ *            TIM_IT_COM - TIM Commutation Interrupt source.
+ *            TIM_IT_Trigger - TIM Trigger Interrupt source.
+ *            TIM_IT_Break - TIM Break Interrupt source.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void TIM_ITConfig(TIM_TypeDef *TIMx, uint16_t TIM_IT, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        TIMx->DMAINTENR |= TIM_IT;
+    }
+    else
+    {
+        TIMx->DMAINTENR &= (uint16_t)~TIM_IT;
+    }
+}
+
+/*******************************************************************************
+ * @fn             TIM_GenerateEvent
+ *
+ * @brief          Configures the TIMx event to be generate by software.
+ *
+ * @param          TIMx: where x can be 1 to 4 to select the TIM peripheral.
+ *                 TIM_EventSource: specifies the event source.
+ *                 TIM_EventSource_Update: Timer update Event source.
+ *                 TIM_EventSource_CC1: Timer Capture Compare 1 Event source.
+ *                 TIM_EventSource_CC2: Timer Capture Compare 2 Event source.
+ *                 TIM_EventSource_CC3: Timer Capture Compare 3 Event source.
+ *                 TIM_EventSource_CC4: Timer Capture Compare 4 Event source.
+ *                 TIM_EventSource_COM: Timer COM event source.
+ *                 TIM_EventSource_Trigger: Timer Trigger Event source.
+ *                 TIM_EventSource_Break: Timer Break event source.
+ *
+ * @return None
+ */
+void TIM_GenerateEvent(TIM_TypeDef *TIMx, uint16_t TIM_EventSource)
+{
+    TIMx->SWEVGR = TIM_EventSource;
+}
+
+/*********************************************************************
+ * @fn      TIM_DMAConfig
+ *
+ * @brief   Configures the TIMx's DMA interface.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_DMABase: DMA Base address.
+ *            TIM_DMABase_CR.
+ *            TIM_DMABase_CR2.
+ *            TIM_DMABase_SMCR.
+ *            TIM_DMABase_DIER.
+ *            TIM1_DMABase_SR.
+ *            TIM_DMABase_EGR.
+ *            TIM_DMABase_CCMR1.
+ *            TIM_DMABase_CCMR2.
+ *            TIM_DMABase_CCER.
+ *            TIM_DMABase_CNT.
+ *            TIM_DMABase_PSC.
+ *            TIM_DMABase_CCR1.
+ *            TIM_DMABase_CCR2.
+ *            TIM_DMABase_CCR3.
+ *            TIM_DMABase_CCR4.
+ *            TIM_DMABase_BDTR.
+ *            TIM_DMABase_DCR.
+ *          TIM_DMABurstLength - DMA Burst length.
+ *            TIM_DMABurstLength_1Transfer.
+ *            TIM_DMABurstLength_18Transfers.
+ *
+ * @return  none
+ */
+void TIM_DMAConfig(TIM_TypeDef *TIMx, uint16_t TIM_DMABase, uint16_t TIM_DMABurstLength)
+{
+    TIMx->DMACFGR = TIM_DMABase | TIM_DMABurstLength;
+}
+
+/*********************************************************************
+ * @fn      TIM_DMACmd
+ *
+ * @brief   Enables or disables the TIMx's DMA Requests.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_DMASource - specifies the DMA Request sources.
+ *            TIM_DMA_Update - TIM update Interrupt source.
+ *            TIM_DMA_CC1 - TIM Capture Compare 1 DMA source.
+ *            TIM_DMA_CC2 - TIM Capture Compare 2 DMA source.
+ *            TIM_DMA_CC3 - TIM Capture Compare 3 DMA source.
+ *            TIM_DMA_CC4 - TIM Capture Compare 4 DMA source.
+ *            TIM_DMA_COM - TIM Commutation DMA source.
+ *            TIM_DMA_Trigger - TIM Trigger DMA source.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void TIM_DMACmd(TIM_TypeDef *TIMx, uint16_t TIM_DMASource, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        TIMx->DMAINTENR |= TIM_DMASource;
+    }
+    else
+    {
+        TIMx->DMAINTENR &= (uint16_t)~TIM_DMASource;
+    }
+}
+
+/*********************************************************************
+ * @fn      TIM_InternalClockConfig
+ *
+ * @brief   Configures the TIMx internal Clock.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *
+ * @return  none
+ */
+void TIM_InternalClockConfig(TIM_TypeDef *TIMx)
+{
+    TIMx->SMCFGR &= (uint16_t)(~((uint16_t)TIM_SMS));
+}
+
+/*********************************************************************
+ * @fn      TIM_ITRxExternalClockConfig
+ *
+ * @brief   Configures the TIMx Internal Trigger as External Clock.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_InputTriggerSource: Trigger source.
+ *            TIM_TS_ITR0 - Internal Trigger 0.
+ *            TIM_TS_ITR1 - Internal Trigger 1.
+ *            TIM_TS_ITR2 - Internal Trigger 2.
+ *            TIM_TS_ITR3 - Internal Trigger 3.
+ *
+ * @return  none
+ */
+void TIM_ITRxExternalClockConfig(TIM_TypeDef *TIMx, uint16_t TIM_InputTriggerSource)
+{
+    TIM_SelectInputTrigger(TIMx, TIM_InputTriggerSource);
+    TIMx->SMCFGR |= TIM_SlaveMode_External1;
+}
+
+/*********************************************************************
+ * @fn      TIM_TIxExternalClockConfig
+ *
+ * @brief   Configures the TIMx Trigger as External Clock.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_TIxExternalCLKSource - Trigger source.
+ *            TIM_TIxExternalCLK1Source_TI1ED - TI1 Edge Detector.
+ *            TIM_TIxExternalCLK1Source_TI1 - Filtered Timer Input 1.
+ *            TIM_TIxExternalCLK1Source_TI2 - Filtered Timer Input 2.
+ *          TIM_ICPolarity - specifies the TIx Polarity.
+ *             TIM_ICPolarity_Rising.
+ *             TIM_ICPolarity_Falling.
+ *             TIM_DMA_COM - TIM Commutation DMA source.
+ *             TIM_DMA_Trigger - TIM Trigger DMA source.
+ *          ICFilter - specifies the filter value.
+ *             This parameter must be a value between 0x0 and 0xF.
+ *
+ * @return  none
+ */
+void TIM_TIxExternalClockConfig(TIM_TypeDef *TIMx, uint16_t TIM_TIxExternalCLKSource,
+                                uint16_t TIM_ICPolarity, uint16_t ICFilter)
+{
+    if(TIM_TIxExternalCLKSource == TIM_TIxExternalCLK1Source_TI2)
+    {
+        TI2_Config(TIMx, TIM_ICPolarity, TIM_ICSelection_DirectTI, ICFilter);
+    }
+    else
+    {
+        TI1_Config(TIMx, TIM_ICPolarity, TIM_ICSelection_DirectTI, ICFilter);
+    }
+
+    TIM_SelectInputTrigger(TIMx, TIM_TIxExternalCLKSource);
+    TIMx->SMCFGR |= TIM_SlaveMode_External1;
+}
+
+/*********************************************************************
+ * @fn      TIM_ETRClockMode1Config
+ *
+ * @brief   Configures the External clock Mode1.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_ExtTRGPrescaler - The external Trigger Prescaler.
+ *            TIM_ExtTRGPSC_OFF - ETRP Prescaler OFF.
+ *            TIM_ExtTRGPSC_DIV2 - ETRP frequency divided by 2.
+ *            TIM_ExtTRGPSC_DIV4 - ETRP frequency divided by 4.
+ *            TIM_ExtTRGPSC_DIV8 - ETRP frequency divided by 8.
+ *          TIM_ExtTRGPolarity - The external Trigger Polarity.
+ *            TIM_ExtTRGPolarity_Inverted - active low or falling edge active.
+ *            TIM_ExtTRGPolarity_NonInverted - active high or rising edge active.
+ *          ExtTRGFilter - External Trigger Filter.
+ *             This parameter must be a value between 0x0 and 0xF.
+ *
+ * @return  none
+ */
+void TIM_ETRClockMode1Config(TIM_TypeDef *TIMx, uint16_t TIM_ExtTRGPrescaler, uint16_t TIM_ExtTRGPolarity,
+                             uint16_t ExtTRGFilter)
+{
+    uint16_t tmpsmcr = 0;
+
+    TIM_ETRConfig(TIMx, TIM_ExtTRGPrescaler, TIM_ExtTRGPolarity, ExtTRGFilter);
+    tmpsmcr = TIMx->SMCFGR;
+    tmpsmcr &= (uint16_t)(~((uint16_t)TIM_SMS));
+    tmpsmcr |= TIM_SlaveMode_External1;
+    tmpsmcr &= (uint16_t)(~((uint16_t)TIM_TS));
+    tmpsmcr |= TIM_TS_ETRF;
+    TIMx->SMCFGR = tmpsmcr;
+}
+
+/*********************************************************************
+ * @fn      TIM_ETRClockMode2Config
+ *
+ * @brief   Configures the External clock Mode2.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_ExtTRGPrescaler - The external Trigger Prescaler.
+ *            TIM_ExtTRGPSC_OFF - ETRP Prescaler OFF.
+ *            TIM_ExtTRGPSC_DIV2 - ETRP frequency divided by 2.
+ *            TIM_ExtTRGPSC_DIV4 - ETRP frequency divided by 4.
+ *            TIM_ExtTRGPSC_DIV8 - ETRP frequency divided by 8.
+ *          TIM_ExtTRGPolarity - The external Trigger Polarity.
+ *            TIM_ExtTRGPolarity_Inverted - active low or falling edge active.
+ *            TIM_ExtTRGPolarity_NonInverted - active high or rising edge active.
+ *          ExtTRGFilter - External Trigger Filter.
+ *            This parameter must be a value between 0x0 and 0xF.
+ *
+ * @return  none
+ */
+void TIM_ETRClockMode2Config(TIM_TypeDef *TIMx, uint16_t TIM_ExtTRGPrescaler,
+                             uint16_t TIM_ExtTRGPolarity, uint16_t ExtTRGFilter)
+{
+    TIM_ETRConfig(TIMx, TIM_ExtTRGPrescaler, TIM_ExtTRGPolarity, ExtTRGFilter);
+    TIMx->SMCFGR |= TIM_ECE;
+}
+
+/*********************************************************************
+ * @fn      TIM_ETRConfig
+ *
+ * @brief   Configures the TIMx External Trigger (ETR).
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_ExtTRGPrescaler - The external Trigger Prescaler.
+ *            TIM_ExtTRGPSC_OFF - ETRP Prescaler OFF.
+ *            TIM_ExtTRGPSC_DIV2 - ETRP frequency divided by 2.
+ *            TIM_ExtTRGPSC_DIV4 - ETRP frequency divided by 4.
+ *            TIM_ExtTRGPSC_DIV8 - ETRP frequency divided by 8.
+ *          TIM_ExtTRGPolarity - The external Trigger Polarity.
+ *            TIM_ExtTRGPolarity_Inverted - active low or falling edge active.
+ *            TIM_ExtTRGPolarity_NonInverted - active high or rising edge active.
+ *          ExtTRGFilter - External Trigger Filter.
+ *            This parameter must be a value between 0x0 and 0xF.
+ *
+ * @return  none
+ */
+void TIM_ETRConfig(TIM_TypeDef *TIMx, uint16_t TIM_ExtTRGPrescaler, uint16_t TIM_ExtTRGPolarity,
+                   uint16_t ExtTRGFilter)
+{
+    uint16_t tmpsmcr = 0;
+
+    tmpsmcr = TIMx->SMCFGR;
+    tmpsmcr &= SMCFGR_ETR_Mask;
+    tmpsmcr |= (uint16_t)(TIM_ExtTRGPrescaler | (uint16_t)(TIM_ExtTRGPolarity | (uint16_t)(ExtTRGFilter << (uint16_t)8)));
+    TIMx->SMCFGR = tmpsmcr;
+}
+
+/*********************************************************************
+ * @fn      TIM_PrescalerConfig
+ *
+ * @brief   Configures the TIMx Prescaler.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          Prescaler - specifies the Prescaler Register value.
+ *          TIM_PSCReloadMode - specifies the TIM Prescaler Reload mode.
+ *            TIM_PSCReloadMode - specifies the TIM Prescaler Reload mode.
+ *            TIM_PSCReloadMode_Update - The Prescaler is loaded at the update event.
+ *            TIM_PSCReloadMode_Immediate - The Prescaler is loaded immediately.
+ *
+ * @return  none
+ */
+void TIM_PrescalerConfig(TIM_TypeDef *TIMx, uint16_t Prescaler, uint16_t TIM_PSCReloadMode)
+{
+    TIMx->PSC = Prescaler;
+    TIMx->SWEVGR = TIM_PSCReloadMode;
+}
+
+/*********************************************************************
+ * @fn      TIM_CounterModeConfig
+ *
+ * @brief   Specifies the TIMx Counter Mode to be used.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_CounterMode - specifies the Counter Mode to be used.
+ *            TIM_CounterMode_Up - TIM Up Counting Mode.
+ *            TIM_CounterMode_Down - TIM Down Counting Mode.
+ *            TIM_CounterMode_CenterAligned1 - TIM Center Aligned Mode1.
+ *            TIM_CounterMode_CenterAligned2 - TIM Center Aligned Mode2.
+ *            TIM_CounterMode_CenterAligned3 - TIM Center Aligned Mode3.
+ *
+ * @return  none
+ */
+void TIM_CounterModeConfig(TIM_TypeDef *TIMx, uint16_t TIM_CounterMode)
+{
+    uint16_t tmpcr1 = 0;
+
+    tmpcr1 = TIMx->CTLR1;
+    tmpcr1 &= (uint16_t)(~((uint16_t)(TIM_DIR | TIM_CMS)));
+    tmpcr1 |= TIM_CounterMode;
+    TIMx->CTLR1 = tmpcr1;
+}
+
+/*********************************************************************
+ * @fn      TIM_SelectInputTrigger
+ *
+ * @brief   Selects the Input Trigger source.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_InputTriggerSource - The Input Trigger source.
+ *            TIM_TS_ITR0 - Internal Trigger 0.
+ *            TIM_TS_ITR1 - Internal Trigger 1.
+ *            TIM_TS_ITR2 - Internal Trigger 2.
+ *            TIM_TS_ITR3 - Internal Trigger 3.
+ *            TIM_TS_TI1F_ED - TI1 Edge Detector.
+ *            TIM_TS_TI1FP1 - Filtered Timer Input 1.
+ *            TIM_TS_TI2FP2 - Filtered Timer Input 2.
+ *            TIM_TS_ETRF - External Trigger input.
+ *
+ * @return  none
+ */
+void TIM_SelectInputTrigger(TIM_TypeDef *TIMx, uint16_t TIM_InputTriggerSource)
+{
+    uint16_t tmpsmcr = 0;
+
+    tmpsmcr = TIMx->SMCFGR;
+    tmpsmcr &= (uint16_t)(~((uint16_t)TIM_TS));
+    tmpsmcr |= TIM_InputTriggerSource;
+    TIMx->SMCFGR = tmpsmcr;
+}
+
+/*********************************************************************
+ * @fn      TIM_EncoderInterfaceConfig
+ *
+ * @brief   Configures the TIMx Encoder Interface.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_EncoderMode - specifies the TIMx Encoder Mode.
+ *            TIM_EncoderMode_TI1 - Counter counts on TI1FP1 edge depending
+ *        on TI2FP2 level.
+ *            TIM_EncoderMode_TI2 - Counter counts on TI2FP2 edge depending
+ *        on TI1FP1 level.
+ *            TIM_EncoderMode_TI12 - Counter counts on both TI1FP1 and
+ *        TI2FP2 edges depending.
+ *          TIM_IC1Polarity - specifies the IC1 Polarity.
+ *            TIM_ICPolarity_Falling - IC Falling edge.
+ *            TTIM_ICPolarity_Rising - IC Rising edge.
+ *          TIM_IC2Polarity - specifies the IC2 Polarity.
+ *            TIM_ICPolarity_Falling - IC Falling edge.
+ *            TIM_ICPolarity_Rising - IC Rising edge.
+ *
+ * @return  none
+ */
+void TIM_EncoderInterfaceConfig(TIM_TypeDef *TIMx, uint16_t TIM_EncoderMode,
+                                uint16_t TIM_IC1Polarity, uint16_t TIM_IC2Polarity)
+{
+    uint16_t tmpsmcr = 0;
+    uint16_t tmpccmr1 = 0;
+    uint16_t tmpccer = 0;
+
+    tmpsmcr = TIMx->SMCFGR;
+    tmpccmr1 = TIMx->CHCTLR1;
+    tmpccer = TIMx->CCER;
+    tmpsmcr &= (uint16_t)(~((uint16_t)TIM_SMS));
+    tmpsmcr |= TIM_EncoderMode;
+    tmpccmr1 &= (uint16_t)(((uint16_t) ~((uint16_t)TIM_CC1S)) & (uint16_t)(~((uint16_t)TIM_CC2S)));
+    tmpccmr1 |= TIM_CC1S_0 | TIM_CC2S_0;
+    tmpccer &= (uint16_t)(((uint16_t) ~((uint16_t)TIM_CC1P)) & ((uint16_t) ~((uint16_t)TIM_CC2P)));
+    tmpccer |= (uint16_t)(TIM_IC1Polarity | (uint16_t)(TIM_IC2Polarity << (uint16_t)4));
+    TIMx->SMCFGR = tmpsmcr;
+    TIMx->CHCTLR1 = tmpccmr1;
+    TIMx->CCER = tmpccer;
+}
+
+/*********************************************************************
+ * @fn      TIM_ForcedOC1Config
+ *
+ * @brief   Forces the TIMx output 1 waveform to active or inactive level.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_ForcedAction - specifies the forced Action to be set to the
+ *        output waveform.
+ *            TIM_ForcedAction_Active - Force active level on OC1REF.
+ *            TIM_ForcedAction_InActive - Force inactive level on OC1REF.
+ *
+ * @return  none
+ */
+void TIM_ForcedOC1Config(TIM_TypeDef *TIMx, uint16_t TIM_ForcedAction)
+{
+    uint16_t tmpccmr1 = 0;
+
+    tmpccmr1 = TIMx->CHCTLR1;
+    tmpccmr1 &= (uint16_t) ~((uint16_t)TIM_OC1M);
+    tmpccmr1 |= TIM_ForcedAction;
+    TIMx->CHCTLR1 = tmpccmr1;
+}
+
+/*********************************************************************
+ * @fn      TIM_ForcedOC2Config
+ *
+ * @brief   Forces the TIMx output 2 waveform to active or inactive level.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_ForcedAction - specifies the forced Action to be set to the
+ *        output waveform.
+ *            TIM_ForcedAction_Active - Force active level on OC2REF.
+ *            TIM_ForcedAction_InActive - Force inactive level on OC2REF.
+ *
+ * @return  none
+ */
+void TIM_ForcedOC2Config(TIM_TypeDef *TIMx, uint16_t TIM_ForcedAction)
+{
+    uint16_t tmpccmr1 = 0;
+
+    tmpccmr1 = TIMx->CHCTLR1;
+    tmpccmr1 &= (uint16_t) ~((uint16_t)TIM_OC2M);
+    tmpccmr1 |= (uint16_t)(TIM_ForcedAction << 8);
+    TIMx->CHCTLR1 = tmpccmr1;
+}
+
+/*********************************************************************
+ * @fn      TIM_ForcedOC3Config
+ *
+ * @brief   Forces the TIMx output 3 waveform to active or inactive level.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_ForcedAction - specifies the forced Action to be set to the
+ *        output waveform.
+ *            TIM_ForcedAction_Active - Force active level on OC3REF.
+ *            TIM_ForcedAction_InActive - Force inactive level on OC3REF.
+ *
+ * @return  none
+ */
+void TIM_ForcedOC3Config(TIM_TypeDef *TIMx, uint16_t TIM_ForcedAction)
+{
+    uint16_t tmpccmr2 = 0;
+
+    tmpccmr2 = TIMx->CHCTLR2;
+    tmpccmr2 &= (uint16_t) ~((uint16_t)TIM_OC3M);
+    tmpccmr2 |= TIM_ForcedAction;
+    TIMx->CHCTLR2 = tmpccmr2;
+}
+
+/*********************************************************************
+ * @fn      TIM_ForcedOC4Config
+ *
+ * @brief   Forces the TIMx output 4 waveform to active or inactive level.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_ForcedAction - specifies the forced Action to be set to the
+ *        output waveform.
+ *            TIM_ForcedAction_Active - Force active level on OC4REF.
+ *            TIM_ForcedAction_InActive - Force inactive level on OC4REF.
+ *
+ * @return  none
+ */
+void TIM_ForcedOC4Config(TIM_TypeDef *TIMx, uint16_t TIM_ForcedAction)
+{
+    uint16_t tmpccmr2 = 0;
+
+    tmpccmr2 = TIMx->CHCTLR2;
+    tmpccmr2 &= (uint16_t) ~((uint16_t)TIM_OC4M);
+    tmpccmr2 |= (uint16_t)(TIM_ForcedAction << 8);
+    TIMx->CHCTLR2 = tmpccmr2;
+}
+
+/*********************************************************************
+ * @fn      TIM_ARRPreloadConfig
+ *
+ * @brief   Enables or disables TIMx peripheral Preload register on ARR.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void TIM_ARRPreloadConfig(TIM_TypeDef *TIMx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        TIMx->CTLR1 |= TIM_ARPE;
+    }
+    else
+    {
+        TIMx->CTLR1 &= (uint16_t) ~((uint16_t)TIM_ARPE);
+    }
+}
+
+/*********************************************************************
+ * @fn      TIM_SelectCOM
+ *
+ * @brief   Selects the TIM peripheral Commutation event.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void TIM_SelectCOM(TIM_TypeDef *TIMx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        TIMx->CTLR2 |= TIM_CCUS;
+    }
+    else
+    {
+        TIMx->CTLR2 &= (uint16_t) ~((uint16_t)TIM_CCUS);
+    }
+}
+
+/*********************************************************************
+ * @fn      TIM_SelectCCDMA
+ *
+ * @brief   Selects the TIMx peripheral Capture Compare DMA source.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void TIM_SelectCCDMA(TIM_TypeDef *TIMx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        TIMx->CTLR2 |= TIM_CCDS;
+    }
+    else
+    {
+        TIMx->CTLR2 &= (uint16_t) ~((uint16_t)TIM_CCDS);
+    }
+}
+
+/*********************************************************************
+ * @fn      TIM_CCPreloadControl
+ *
+ * @brief   DSets or Resets the TIM peripheral Capture Compare Preload Control bit.
+ *        reset values (Affects also the I2Ss).
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void TIM_CCPreloadControl(TIM_TypeDef *TIMx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        TIMx->CTLR2 |= TIM_CCPC;
+    }
+    else
+    {
+        TIMx->CTLR2 &= (uint16_t) ~((uint16_t)TIM_CCPC);
+    }
+}
+
+/*********************************************************************
+ * @fn      TIM_OC1PreloadConfig
+ *
+ * @brief   Enables or disables the TIMx peripheral Preload register on CCR1.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_OCPreload - new state of the TIMx peripheral Preload register.
+ *            TIM_OCPreload_Enable.
+ *            TIM_OCPreload_Disable.
+ *
+ * @return  none
+ */
+void TIM_OC1PreloadConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCPreload)
+{
+    uint16_t tmpccmr1 = 0;
+
+    tmpccmr1 = TIMx->CHCTLR1;
+    tmpccmr1 &= (uint16_t) ~((uint16_t)TIM_OC1PE);
+    tmpccmr1 |= TIM_OCPreload;
+    TIMx->CHCTLR1 = tmpccmr1;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC2PreloadConfig
+ *
+ * @brief   Enables or disables the TIMx peripheral Preload register on CCR2.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_OCPreload - new state of the TIMx peripheral Preload register.
+ *            TIM_OCPreload_Enable.
+ *            TIM_OCPreload_Disable.
+ *
+ * @return  none
+ */
+void TIM_OC2PreloadConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCPreload)
+{
+    uint16_t tmpccmr1 = 0;
+
+    tmpccmr1 = TIMx->CHCTLR1;
+    tmpccmr1 &= (uint16_t) ~((uint16_t)TIM_OC2PE);
+    tmpccmr1 |= (uint16_t)(TIM_OCPreload << 8);
+    TIMx->CHCTLR1 = tmpccmr1;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC3PreloadConfig
+ *
+ * @brief   Enables or disables the TIMx peripheral Preload register on CCR3.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_OCPreload - new state of the TIMx peripheral Preload register.
+ *            TIM_OCPreload_Enable.
+ *            TIM_OCPreload_Disable.
+ *
+ * @return  none
+ */
+void TIM_OC3PreloadConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCPreload)
+{
+    uint16_t tmpccmr2 = 0;
+
+    tmpccmr2 = TIMx->CHCTLR2;
+    tmpccmr2 &= (uint16_t) ~((uint16_t)TIM_OC3PE);
+    tmpccmr2 |= TIM_OCPreload;
+    TIMx->CHCTLR2 = tmpccmr2;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC4PreloadConfig
+ *
+ * @brief   Enables or disables the TIMx peripheral Preload register on CCR4.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_OCPreload - new state of the TIMx peripheral Preload register.
+ *            TIM_OCPreload_Enable.
+ *            TIM_OCPreload_Disable.
+ *
+ * @return  none
+ */
+void TIM_OC4PreloadConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCPreload)
+{
+    uint16_t tmpccmr2 = 0;
+
+    tmpccmr2 = TIMx->CHCTLR2;
+    tmpccmr2 &= (uint16_t) ~((uint16_t)TIM_OC4PE);
+    tmpccmr2 |= (uint16_t)(TIM_OCPreload << 8);
+    TIMx->CHCTLR2 = tmpccmr2;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC1FastConfig
+ *
+ * @brief   Configures the TIMx Output Compare 1 Fast feature.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_OCFast - new state of the Output Compare Fast Enable Bit.
+ *            TIM_OCFast_Enable - TIM output compare fast enable.
+ *            TIM_OCFast_Disable - TIM output compare fast disable.
+ *
+ * @return  none
+ */
+void TIM_OC1FastConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCFast)
+{
+    uint16_t tmpccmr1 = 0;
+
+    tmpccmr1 = TIMx->CHCTLR1;
+    tmpccmr1 &= (uint16_t) ~((uint16_t)TIM_OC1FE);
+    tmpccmr1 |= TIM_OCFast;
+    TIMx->CHCTLR1 = tmpccmr1;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC2FastConfig
+ *
+ * @brief   Configures the TIMx Output Compare 2 Fast feature.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_OCFast - new state of the Output Compare Fast Enable Bit.
+ *            TIM_OCFast_Enable - TIM output compare fast enable.
+ *            TIM_OCFast_Disable - TIM output compare fast disable.
+ *
+ * @return  none
+ */
+void TIM_OC2FastConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCFast)
+{
+    uint16_t tmpccmr1 = 0;
+
+    tmpccmr1 = TIMx->CHCTLR1;
+    tmpccmr1 &= (uint16_t) ~((uint16_t)TIM_OC2FE);
+    tmpccmr1 |= (uint16_t)(TIM_OCFast << 8);
+    TIMx->CHCTLR1 = tmpccmr1;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC3FastConfig
+ *
+ * @brief   Configures the TIMx Output Compare 3 Fast feature.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_OCFast - new state of the Output Compare Fast Enable Bit.
+ *            TIM_OCFast_Enable - TIM output compare fast enable.
+ *            TIM_OCFast_Disable - TIM output compare fast disable.
+ *
+ * @return  none
+ */
+void TIM_OC3FastConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCFast)
+{
+    uint16_t tmpccmr2 = 0;
+
+    tmpccmr2 = TIMx->CHCTLR2;
+    tmpccmr2 &= (uint16_t) ~((uint16_t)TIM_OC3FE);
+    tmpccmr2 |= TIM_OCFast;
+    TIMx->CHCTLR2 = tmpccmr2;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC4FastConfig
+ *
+ * @brief   Configures the TIMx Output Compare 4 Fast feature.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_OCFast - new state of the Output Compare Fast Enable Bit.
+ *            TIM_OCFast_Enable - TIM output compare fast enable.
+ *            TIM_OCFast_Disable - TIM output compare fast disable.
+ *
+ * @return  none
+ */
+void TIM_OC4FastConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCFast)
+{
+    uint16_t tmpccmr2 = 0;
+
+    tmpccmr2 = TIMx->CHCTLR2;
+    tmpccmr2 &= (uint16_t) ~((uint16_t)TIM_OC4FE);
+    tmpccmr2 |= (uint16_t)(TIM_OCFast << 8);
+    TIMx->CHCTLR2 = tmpccmr2;
+}
+
+/*********************************************************************
+ * @fn      TIM_ClearOC1Ref
+ *
+ * @brief   Clears or safeguards the OCREF1 signal on an external event.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_OCClear - new state of the Output Compare Clear Enable Bit.
+ *            TIM_OCClear_Enable - TIM Output clear enable.
+ *            TIM_OCClear_Disable - TIM Output clear disable.
+ *
+ * @return  none
+ */
+void TIM_ClearOC1Ref(TIM_TypeDef *TIMx, uint16_t TIM_OCClear)
+{
+    uint16_t tmpccmr1 = 0;
+
+    tmpccmr1 = TIMx->CHCTLR1;
+    tmpccmr1 &= (uint16_t) ~((uint16_t)TIM_OC1CE);
+    tmpccmr1 |= TIM_OCClear;
+    TIMx->CHCTLR1 = tmpccmr1;
+}
+
+/*********************************************************************
+ * @fn      TIM_ClearOC2Ref
+ *
+ * @brief   Clears or safeguards the OCREF2 signal on an external event.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_OCClear - new state of the Output Compare Clear Enable Bit.
+ *            TIM_OCClear_Enable - TIM Output clear enable.
+ *            TIM_OCClear_Disable - TIM Output clear disable.
+ *
+ * @return  none
+ */
+void TIM_ClearOC2Ref(TIM_TypeDef *TIMx, uint16_t TIM_OCClear)
+{
+    uint16_t tmpccmr1 = 0;
+
+    tmpccmr1 = TIMx->CHCTLR1;
+    tmpccmr1 &= (uint16_t) ~((uint16_t)TIM_OC2CE);
+    tmpccmr1 |= (uint16_t)(TIM_OCClear << 8);
+    TIMx->CHCTLR1 = tmpccmr1;
+}
+
+/*********************************************************************
+ * @fn      TIM_ClearOC3Ref
+ *
+ * @brief   Clears or safeguards the OCREF3 signal on an external event.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_OCClear - new state of the Output Compare Clear Enable Bit.
+ *            TIM_OCClear_Enable - TIM Output clear enable.
+ *            TIM_OCClear_Disable - TIM Output clear disable.
+ *
+ * @return  none
+ */
+void TIM_ClearOC3Ref(TIM_TypeDef *TIMx, uint16_t TIM_OCClear)
+{
+    uint16_t tmpccmr2 = 0;
+
+    tmpccmr2 = TIMx->CHCTLR2;
+    tmpccmr2 &= (uint16_t) ~((uint16_t)TIM_OC3CE);
+    tmpccmr2 |= TIM_OCClear;
+    TIMx->CHCTLR2 = tmpccmr2;
+}
+
+/*********************************************************************
+ * @fn      TIM_ClearOC4Ref
+ *
+ * @brief   Clears or safeguards the OCREF4 signal on an external event.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_OCClear - new state of the Output Compare Clear Enable Bit.
+ *            TIM_OCClear_Enable - TIM Output clear enable.
+ *            TIM_OCClear_Disable - TIM Output clear disable.
+ *
+ * @return  none
+ */
+void TIM_ClearOC4Ref(TIM_TypeDef *TIMx, uint16_t TIM_OCClear)
+{
+    uint16_t tmpccmr2 = 0;
+
+    tmpccmr2 = TIMx->CHCTLR2;
+    tmpccmr2 &= (uint16_t) ~((uint16_t)TIM_OC4CE);
+    tmpccmr2 |= (uint16_t)(TIM_OCClear << 8);
+    TIMx->CHCTLR2 = tmpccmr2;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC1PolarityConfig
+ *
+ * @brief   Configures the TIMx channel 1 polarity.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_OCPolarity - specifies the OC1 Polarity.
+ *            TIM_OCPolarity_High - Output Compare active high.
+ *            TIM_OCPolarity_Low - Output Compare active low.
+ *
+ * @return  none
+ */
+void TIM_OC1PolarityConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCPolarity)
+{
+    uint16_t tmpccer = 0;
+
+    tmpccer = TIMx->CCER;
+    tmpccer &= (uint16_t) ~((uint16_t)TIM_CC1P);
+    tmpccer |= TIM_OCPolarity;
+    TIMx->CCER = tmpccer;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC1NPolarityConfig
+ *
+ * @brief   Configures the TIMx channel 1 polarity.
+ *
+ * @param   TIMx - where x can be 1 to select the TIM peripheral.
+ *          TIM_OCNPolarity - specifies the OC1N Polarity.
+ *            TIM_OCNPolarity_High - Output Compare active high.
+ *            TIM_OCNPolarity_Low - Output Compare active low.
+ *
+ * @return  none
+ */
+void TIM_OC1NPolarityConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCNPolarity)
+{
+    uint16_t tmpccer = 0;
+
+    tmpccer = TIMx->CCER;
+    tmpccer &= (uint16_t) ~((uint16_t)TIM_CC1NP);
+    tmpccer |= TIM_OCNPolarity;
+    TIMx->CCER = tmpccer;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC2PolarityConfig
+ *
+ * @brief   Configures the TIMx channel 2 polarity.
+ *
+ * @param   TIMx - where x can be 1 to 4 to select the TIM peripheral.
+ *          TIM_OCPolarity - specifies the OC2 Polarity.
+ *            TIM_OCPolarity_High - Output Compare active high.
+ *            TIM_OCPolarity_Low - Output Compare active low.
+ *
+ * @return  none
+ */
+void TIM_OC2PolarityConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCPolarity)
+{
+    uint16_t tmpccer = 0;
+
+    tmpccer = TIMx->CCER;
+    tmpccer &= (uint16_t) ~((uint16_t)TIM_CC2P);
+    tmpccer |= (uint16_t)(TIM_OCPolarity << 4);
+    TIMx->CCER = tmpccer;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC2NPolarityConfig
+ *
+ * @brief   Configures the TIMx channel 2 polarity.
+ *
+ * @param   TIMx - where x can be 1 to select the TIM peripheral.
+ *          TIM_OCNPolarity - specifies the OC1N Polarity.
+ *            TIM_OCNPolarity_High - Output Compare active high.
+ *            TIM_OCNPolarity_Low - Output Compare active low.
+ *
+ * @return  none
+ */
+void TIM_OC2NPolarityConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCNPolarity)
+{
+    uint16_t tmpccer = 0;
+
+    tmpccer = TIMx->CCER;
+    tmpccer &= (uint16_t) ~((uint16_t)TIM_CC2NP);
+    tmpccer |= (uint16_t)(TIM_OCNPolarity << 4);
+    TIMx->CCER = tmpccer;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC3PolarityConfig
+ *
+ * @brief   Configures the TIMx Channel 3 polarity.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *          TIM_OCPolarit - specifies the OC3 Polarity.
+ *            TIM_OCPolarity_High - Output Compare active high.
+ *            TIM_OCPolarity_Low - Output Compare active low.
+ *
+ * @return  none
+ */
+void TIM_OC3PolarityConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCPolarity)
+{
+    uint16_t tmpccer = 0;
+
+    tmpccer = TIMx->CCER;
+    tmpccer &= (uint16_t) ~((uint16_t)TIM_CC3P);
+    tmpccer |= (uint16_t)(TIM_OCPolarity << 8);
+    TIMx->CCER = tmpccer;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC3NPolarityConfig
+ *
+ * @brief   Configures the TIMx Channel 3N polarity.
+ *
+ * @param   TIMx - where x can be 1 to select the TIM peripheral.
+ *          TIM_OCNPolarity - specifies the OC2N Polarity.
+ *            TIM_OCNPolarity_High - Output Compare active high.
+ *            TIM_OCNPolarity_Low - Output Compare active low.
+ *
+ * @return  none
+ */
+void TIM_OC3NPolarityConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCNPolarity)
+{
+    uint16_t tmpccer = 0;
+
+    tmpccer = TIMx->CCER;
+    tmpccer &= (uint16_t) ~((uint16_t)TIM_CC3NP);
+    tmpccer |= (uint16_t)(TIM_OCNPolarity << 8);
+    TIMx->CCER = tmpccer;
+}
+
+/*********************************************************************
+ * @fn      TIM_OC4PolarityConfig
+ *
+ * @brief   Configures the TIMx Channel 4 polarity.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *          TIM_OCPolarit - specifies the OC3 Polarity.
+ *            TIM_OCPolarity_High - Output Compare active high.
+ *            TIM_OCPolarity_Low - Output Compare active low.
+ *
+ * @return  none
+ */
+void TIM_OC4PolarityConfig(TIM_TypeDef *TIMx, uint16_t TIM_OCPolarity)
+{
+    uint16_t tmpccer = 0;
+
+    tmpccer = TIMx->CCER;
+    tmpccer &= (uint16_t) ~((uint16_t)TIM_CC4P);
+    tmpccer |= (uint16_t)(TIM_OCPolarity << 12);
+    TIMx->CCER = tmpccer;
+}
+
+/*********************************************************************
+ * @fn      TIM_CCxCmd
+ *
+ * @brief   Enables or disables the TIM Capture Compare Channel x.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *          TIM_Channel - specifies the TIM Channel.
+ *            TIM_Channel_1 - TIM Channel 1.
+ *            TIM_Channel_2 - TIM Channel 2.
+ *            TIM_Channel_3 - TIM Channel 3.
+ *            TIM_Channel_4 - TIM Channel 4.
+ *          TIM_CCx - specifies the TIM Channel CCxE bit new state.
+ *            TIM_CCx_Enable.
+ *            TIM_CCx_Disable.
+ *
+ * @return  none
+ */
+void TIM_CCxCmd(TIM_TypeDef *TIMx, uint16_t TIM_Channel, uint16_t TIM_CCx)
+{
+    uint16_t tmp = 0;
+
+    tmp = CCER_CCE_Set << TIM_Channel;
+    TIMx->CCER &= (uint16_t)~tmp;
+    TIMx->CCER |= (uint16_t)(TIM_CCx << TIM_Channel);
+}
+
+/*********************************************************************
+ * @fn      TIM_CCxNCmd
+ *
+ * @brief   Enables or disables the TIM Capture Compare Channel xN.
+ *
+ * @param   TIMx - where x can be 1 select the TIM peripheral.
+ *          TIM_Channel - specifies the TIM Channel.
+ *            TIM_Channel_1 - TIM Channel 1.
+ *            TIM_Channel_2 - TIM Channel 2.
+ *            TIM_Channel_3 - TIM Channel 3.
+ *          TIM_CCxN - specifies the TIM Channel CCxNE bit new state.
+ *            TIM_CCxN_Enable.
+ *            TIM_CCxN_Disable.
+ *
+ * @return  none
+ */
+void TIM_CCxNCmd(TIM_TypeDef *TIMx, uint16_t TIM_Channel, uint16_t TIM_CCxN)
+{
+    uint16_t tmp = 0;
+
+    tmp = CCER_CCNE_Set << TIM_Channel;
+    TIMx->CCER &= (uint16_t)~tmp;
+    TIMx->CCER |= (uint16_t)(TIM_CCxN << TIM_Channel);
+}
+
+/*********************************************************************
+ * @fn      TIM_SelectOCxM
+ *
+ * @brief   Selects the TIM Output Compare Mode.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *          TIM_Channel - specifies the TIM Channel.
+ *            TIM_Channel_1 - TIM Channel 1.
+ *            TIM_Channel_2 - TIM Channel 2.
+ *            TIM_Channel_3 - TIM Channel 3.
+ *            TIM_Channel_4 - TIM Channel 4.
+ *          TIM_OCMode - specifies the TIM Output Compare Mode.
+ *            TIM_OCMode_Timing.
+ *            TIM_OCMode_Active.
+ *            TIM_OCMode_Toggle.
+ *            TIM_OCMode_PWM1.
+ *            TIM_OCMode_PWM2.
+ *            TIM_ForcedAction_Active.
+ *            TIM_ForcedAction_InActive.
+ *
+ * @return  none
+ */
+void TIM_SelectOCxM(TIM_TypeDef *TIMx, uint16_t TIM_Channel, uint16_t TIM_OCMode)
+{
+    uint32_t tmp = 0;
+    uint16_t tmp1 = 0;
+
+    tmp = (uint32_t)TIMx;
+    tmp += CHCTLR_Offset;
+    tmp1 = CCER_CCE_Set << (uint16_t)TIM_Channel;
+    TIMx->CCER &= (uint16_t)~tmp1;
+
+    if((TIM_Channel == TIM_Channel_1) || (TIM_Channel == TIM_Channel_3))
+    {
+        tmp += (TIM_Channel >> 1);
+        *(__IO uint32_t *)tmp &= (uint32_t) ~((uint32_t)TIM_OC1M);
+        *(__IO uint32_t *)tmp |= TIM_OCMode;
+    }
+    else
+    {
+        tmp += (uint16_t)(TIM_Channel - (uint16_t)4) >> (uint16_t)1;
+        *(__IO uint32_t *)tmp &= (uint32_t) ~((uint32_t)TIM_OC2M);
+        *(__IO uint32_t *)tmp |= (uint16_t)(TIM_OCMode << 8);
+    }
+}
+
+/*********************************************************************
+ * @fn      TIM_UpdateDisableConfig
+ *
+ * @brief   Enables or Disables the TIMx Update event.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void TIM_UpdateDisableConfig(TIM_TypeDef *TIMx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        TIMx->CTLR1 |= TIM_UDIS;
+    }
+    else
+    {
+        TIMx->CTLR1 &= (uint16_t) ~((uint16_t)TIM_UDIS);
+    }
+}
+
+/*********************************************************************
+ * @fn      TIM_UpdateRequestConfig
+ *
+ * @brief   Configures the TIMx Update Request Interrupt source.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *          TIM_UpdateSource - specifies the Update source.
+ *            TIM_UpdateSource_Regular.
+ *            TIM_UpdateSource_Global.
+ *
+ * @return  none
+ */
+void TIM_UpdateRequestConfig(TIM_TypeDef *TIMx, uint16_t TIM_UpdateSource)
+{
+    if(TIM_UpdateSource != TIM_UpdateSource_Global)
+    {
+        TIMx->CTLR1 |= TIM_URS;
+    }
+    else
+    {
+        TIMx->CTLR1 &= (uint16_t) ~((uint16_t)TIM_URS);
+    }
+}
+
+/*********************************************************************
+ * @fn      TIM_SelectHallSensor
+ *
+ * @brief   Enables or disables the TIMx's Hall sensor interface.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void TIM_SelectHallSensor(TIM_TypeDef *TIMx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        TIMx->CTLR2 |= TIM_TI1S;
+    }
+    else
+    {
+        TIMx->CTLR2 &= (uint16_t) ~((uint16_t)TIM_TI1S);
+    }
+}
+
+/*********************************************************************
+ * @fn      TIM_SelectOnePulseMode
+ *
+ * @brief   Selects the TIMx's One Pulse Mode.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *          TIM_OPMode - specifies the OPM Mode to be used.
+ *            TIM_OPMode_Single.
+ *            TIM_OPMode_Repetitive.
+ *
+ * @return  none
+ */
+void TIM_SelectOnePulseMode(TIM_TypeDef *TIMx, uint16_t TIM_OPMode)
+{
+    TIMx->CTLR1 &= (uint16_t) ~((uint16_t)TIM_OPM);
+    TIMx->CTLR1 |= TIM_OPMode;
+}
+
+/*********************************************************************
+ * @fn      TIM_SelectOutputTrigger
+ *
+ * @brief   Selects the TIMx Trigger Output Mode.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *          TIM_TRGOSource - specifies the Trigger Output source.
+ *            TIM_TRGOSource_Reset -  The UG bit in the TIM_EGR register is
+ *        used as the trigger output (TRGO).
+ *            TIM_TRGOSource_Enable - The Counter Enable CEN is used as the
+ *        trigger output (TRGO).
+ *            TIM_TRGOSource_Update - The update event is selected as the
+ *        trigger output (TRGO).
+ *            TIM_TRGOSource_OC1 - The trigger output sends a positive pulse
+ *        when the CC1IF flag is to be set, as soon as a capture or compare match occurs (TRGO).
+ *            TIM_TRGOSource_OC1Ref - OC1REF signal is used as the trigger output (TRGO).
+ *            TIM_TRGOSource_OC2Ref - OC2REF signal is used as the trigger output (TRGO).
+ *            TIM_TRGOSource_OC3Ref - OC3REF signal is used as the trigger output (TRGO).
+ *            TIM_TRGOSource_OC4Ref - OC4REF signal is used as the trigger output (TRGO).
+ *
+ * @return  none
+ */
+void TIM_SelectOutputTrigger(TIM_TypeDef *TIMx, uint16_t TIM_TRGOSource)
+{
+    TIMx->CTLR2 &= (uint16_t) ~((uint16_t)TIM_MMS);
+    TIMx->CTLR2 |= TIM_TRGOSource;
+}
+
+/*********************************************************************
+ * @fn      TIM_SelectSlaveMode
+ *
+ * @brief   Selects the TIMx Slave Mode.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *          TIM_SlaveMode - specifies the Timer Slave Mode.
+ *            TIM_SlaveMode_Reset - Rising edge of the selected trigger
+ *        signal (TRGI) re-initializes.
+ *            TIM_SlaveMode_Gated - The counter clock is enabled when the
+ *        trigger signal (TRGI) is high.
+ *            TIM_SlaveMode_Trigger - The counter starts at a rising edge
+ *        of the trigger TRGI.
+ *            TIM_SlaveMode_External1 - Rising edges of the selected trigger
+ *        (TRGI) clock the counter.
+ *
+ * @return  none
+ */
+void TIM_SelectSlaveMode(TIM_TypeDef *TIMx, uint16_t TIM_SlaveMode)
+{
+    TIMx->SMCFGR &= (uint16_t) ~((uint16_t)TIM_SMS);
+    TIMx->SMCFGR |= TIM_SlaveMode;
+}
+
+/*********************************************************************
+ * @fn      TIM_SelectMasterSlaveMode
+ *
+ * @brief   Sets or Resets the TIMx Master/Slave Mode.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *          TIM_MasterSlaveMode - specifies the Timer Master Slave Mode.
+ *            TIM_MasterSlaveMode_Enable - synchronization between the current
+ *        timer and its slaves (through TRGO).
+ *            TIM_MasterSlaveMode_Disable - No action.
+ *
+ * @return  none
+ */
+void TIM_SelectMasterSlaveMode(TIM_TypeDef *TIMx, uint16_t TIM_MasterSlaveMode)
+{
+    TIMx->SMCFGR &= (uint16_t) ~((uint16_t)TIM_MSM);
+    TIMx->SMCFGR |= TIM_MasterSlaveMode;
+}
+
+/*********************************************************************
+ * @fn      TIM_SetCounter
+ *
+ * @brief   Sets the TIMx Counter Register value.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *          Counter - specifies the Counter register new value.
+ *
+ * @return  none
+ */
+void TIM_SetCounter(TIM_TypeDef *TIMx, uint16_t Counter)
+{
+    TIMx->CNT = Counter;
+}
+
+/*********************************************************************
+ * @fn      TIM_SetAutoreload
+ *
+ * @brief   Sets the TIMx Autoreload Register value.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *          Autoreload - specifies the Autoreload register new value.
+ *
+ * @return  none
+ */
+void TIM_SetAutoreload(TIM_TypeDef *TIMx, uint16_t Autoreload)
+{
+    TIMx->ATRLR = Autoreload;
+}
+
+/*********************************************************************
+ * @fn      TIM_SetCompare1
+ *
+ * @brief   Sets the TIMx Capture Compare1 Register value.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *          Compare1 - specifies the Capture Compare1 register new value.
+ *
+ * @return  none
+ */
+void TIM_SetCompare1(TIM_TypeDef *TIMx, uint16_t Compare1)
+{
+    TIMx->CH1CVR = Compare1;
+}
+
+/*********************************************************************
+ * @fn      TIM_SetCompare2
+ *
+ * @brief   Sets the TIMx Capture Compare2 Register value.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *          Compare1 - specifies the Capture Compare1 register new value.
+ *
+ * @return  none
+ */
+void TIM_SetCompare2(TIM_TypeDef *TIMx, uint16_t Compare2)
+{
+    TIMx->CH2CVR = Compare2;
+}
+
+/*********************************************************************
+ * @fn      TIM_SetCompare3
+ *
+ * @brief   Sets the TIMx Capture Compare3 Register value.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *          Compare1 - specifies the Capture Compare1 register new value.
+ *
+ * @return  none
+ */
+void TIM_SetCompare3(TIM_TypeDef *TIMx, uint16_t Compare3)
+{
+    TIMx->CH3CVR = Compare3;
+}
+
+/*********************************************************************
+ * @fn      TIM_SetCompare4
+ *
+ * @brief   Sets the TIMx Capture Compare4 Register value.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *          Compare1 - specifies the Capture Compare1 register new value.
+ *
+ * @return  none
+ */
+void TIM_SetCompare4(TIM_TypeDef *TIMx, uint16_t Compare4)
+{
+    TIMx->CH4CVR = Compare4;
+}
+
+/*********************************************************************
+ * @fn      TIM_SetIC1Prescaler
+ *
+ * @brief   Sets the TIMx Input Capture 1 prescaler.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *          TIM_ICPSC - specifies the Input Capture1 prescaler new value.
+ *            TIM_ICPSC_DIV1 - no prescaler.
+ *            TIM_ICPSC_DIV2 - capture is done once every 2 events.
+ *            TIM_ICPSC_DIV4 - capture is done once every 4 events.
+ *            TIM_ICPSC_DIV8 - capture is done once every 8 events.
+ *
+ * @return  none
+ */
+void TIM_SetIC1Prescaler(TIM_TypeDef *TIMx, uint16_t TIM_ICPSC)
+{
+    TIMx->CHCTLR1 &= (uint16_t) ~((uint16_t)TIM_IC1PSC);
+    TIMx->CHCTLR1 |= TIM_ICPSC;
+}
+
+/*********************************************************************
+ * @fn      TIM_SetIC2Prescaler
+ *
+ * @brief   Sets the TIMx Input Capture 2 prescaler.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *          TIM_ICPSC - specifies the Input Capture1 prescaler new value.
+ *            TIM_ICPSC_DIV1 - no prescaler.
+ *            TIM_ICPSC_DIV2 - capture is done once every 2 events.
+ *            TIM_ICPSC_DIV4 - capture is done once every 4 events.
+ *            TIM_ICPSC_DIV8 - capture is done once every 8 events.
+ *
+ * @return  none
+ */
+void TIM_SetIC2Prescaler(TIM_TypeDef *TIMx, uint16_t TIM_ICPSC)
+{
+    TIMx->CHCTLR1 &= (uint16_t) ~((uint16_t)TIM_IC2PSC);
+    TIMx->CHCTLR1 |= (uint16_t)(TIM_ICPSC << 8);
+}
+
+/*********************************************************************
+ * @fn      TIM_SetIC3Prescaler
+ *
+ * @brief   Sets the TIMx Input Capture 3 prescaler.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *          TIM_ICPSC - specifies the Input Capture1 prescaler new value.
+ *            TIM_ICPSC_DIV1 - no prescaler.
+ *            TIM_ICPSC_DIV2 - capture is done once every 2 events.
+ *            TIM_ICPSC_DIV4 - capture is done once every 4 events.
+ *            TIM_ICPSC_DIV8 - capture is done once every 8 events.
+ *
+ * @return  none
+ */
+void TIM_SetIC3Prescaler(TIM_TypeDef *TIMx, uint16_t TIM_ICPSC)
+{
+    TIMx->CHCTLR2 &= (uint16_t) ~((uint16_t)TIM_IC3PSC);
+    TIMx->CHCTLR2 |= TIM_ICPSC;
+}
+
+/*********************************************************************
+ * @fn      TIM_SetIC4Prescaler
+ *
+ * @brief   Sets the TIMx Input Capture 4 prescaler.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *          TIM_ICPSC - specifies the Input Capture1 prescaler new value.
+ *            TIM_ICPSC_DIV1 - no prescaler.
+ *            TIM_ICPSC_DIV2 - capture is done once every 2 events.
+ *            TIM_ICPSC_DIV4 - capture is done once every 4 events.
+ *            TIM_ICPSC_DIV8 - capture is done once every 8 events.
+ *
+ * @return  none
+ */
+void TIM_SetIC4Prescaler(TIM_TypeDef *TIMx, uint16_t TIM_ICPSC)
+{
+    TIMx->CHCTLR2 &= (uint16_t) ~((uint16_t)TIM_IC4PSC);
+    TIMx->CHCTLR2 |= (uint16_t)(TIM_ICPSC << 8);
+}
+
+/*********************************************************************
+ * @fn      TIM_SetClockDivision
+ *
+ * @brief   Sets the TIMx Clock Division value.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *          TIM_CKD - specifies the clock division value.
+ *            TIM_CKD_DIV1 - TDTS = Tck_tim.
+ *            TIM_CKD_DIV2 - TDTS = 2*Tck_tim.
+ *            TIM_CKD_DIV4 - TDTS = 4*Tck_tim.
+ *
+ * @return  none
+ */
+void TIM_SetClockDivision(TIM_TypeDef *TIMx, uint16_t TIM_CKD)
+{
+    TIMx->CTLR1 &= (uint16_t) ~((uint16_t)TIM_CTLR1_CKD);
+    TIMx->CTLR1 |= TIM_CKD;
+}
+
+/*********************************************************************
+ * @fn      TIM_GetCapture1
+ *
+ * @brief   Gets the TIMx Input Capture 1 value.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *
+ * @return  TIMx->CH1CVR - Capture Compare 1 Register value.
+ */
+uint16_t TIM_GetCapture1(TIM_TypeDef *TIMx)
+{
+    return TIMx->CH1CVR;
+}
+
+/*********************************************************************
+ * @fn      TIM_GetCapture2
+ *
+ * @brief   Gets the TIMx Input Capture 2 value.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *
+ * @return  TIMx->CH2CVR - Capture Compare 2 Register value.
+ */
+uint16_t TIM_GetCapture2(TIM_TypeDef *TIMx)
+{
+    return TIMx->CH2CVR;
+}
+
+/*********************************************************************
+ * @fn      TIM_GetCapture3
+ *
+ * @brief   Gets the TIMx Input Capture 3 value.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *
+ * @return  TIMx->CH3CVR - Capture Compare 3 Register value.
+ */
+uint16_t TIM_GetCapture3(TIM_TypeDef *TIMx)
+{
+    return TIMx->CH3CVR;
+}
+
+/*********************************************************************
+ * @fn      TIM_GetCapture4
+ *
+ * @brief   Gets the TIMx Input Capture 4 value.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *
+ * @return  TIMx->CH4CVR - Capture Compare 4 Register value.
+ */
+uint16_t TIM_GetCapture4(TIM_TypeDef *TIMx)
+{
+    return TIMx->CH4CVR;
+}
+
+/*********************************************************************
+ * @fn      TIM_GetCounter
+ *
+ * @brief   Gets the TIMx Counter value.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *
+ * @return  TIMx->CNT - Counter Register value.
+ */
+uint16_t TIM_GetCounter(TIM_TypeDef *TIMx)
+{
+    return TIMx->CNT;
+}
+
+/*********************************************************************
+ * @fn      TIM_GetPrescaler
+ *
+ * @brief   Gets the TIMx Prescaler value.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *
+ * @return  TIMx->PSC - Prescaler Register value.
+ */
+uint16_t TIM_GetPrescaler(TIM_TypeDef *TIMx)
+{
+    return TIMx->PSC;
+}
+
+/*********************************************************************
+ * @fn      TIM_GetFlagStatus
+ *
+ * @brief   Checks whether the specified TIM flag is set or not.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *          TIM_FLAG - specifies the flag to check.
+ *            TIM_FLAG_Update - TIM update Flag.
+ *            TIM_FLAG_CC1 - TIM Capture Compare 1 Flag.
+ *            TIM_FLAG_CC2 - TIM Capture Compare 2 Flag.
+ *            TIM_FLAG_CC3 - TIM Capture Compare 3 Flag.
+ *            TIM_FLAG_CC4 - TIM Capture Compare 4 Flag.
+ *            TIM_FLAG_COM - TIM Commutation Flag.
+ *            TIM_FLAG_Trigger - TIM Trigger Flag.
+ *            TIM_FLAG_Break - TIM Break Flag.
+ *            TIM_FLAG_CC1OF - TIM Capture Compare 1 overcapture Flag.
+ *            TIM_FLAG_CC2OF - TIM Capture Compare 2 overcapture Flag.
+ *            TIM_FLAG_CC3OF - TIM Capture Compare 3 overcapture Flag.
+ *            TIM_FLAG_CC4OF - TIM Capture Compare 4 overcapture Flag.
+ *
+ * @return  none
+ */
+FlagStatus TIM_GetFlagStatus(TIM_TypeDef *TIMx, uint16_t TIM_FLAG)
+{
+    ITStatus bitstatus = RESET;
+
+    if((TIMx->INTFR & TIM_FLAG) != (uint16_t)RESET)
+    {
+        bitstatus = SET;
+    }
+    else
+    {
+        bitstatus = RESET;
+    }
+
+    return bitstatus;
+}
+
+/*********************************************************************
+ * @fn      TIM_ClearFlag
+ *
+ * @brief   Clears the TIMx's pending flags.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *          TIM_FLAG - specifies the flag to check.
+ *            TIM_FLAG_Update - TIM update Flag.
+ *            TIM_FLAG_CC1 - TIM Capture Compare 1 Flag.
+ *            TIM_FLAG_CC2 - TIM Capture Compare 2 Flag.
+ *            TIM_FLAG_CC3 - TIM Capture Compare 3 Flag.
+ *            TIM_FLAG_CC4 - TIM Capture Compare 4 Flag.
+ *            TIM_FLAG_COM - TIM Commutation Flag.
+ *            TIM_FLAG_Trigger - TIM Trigger Flag.
+ *            TIM_FLAG_Break - TIM Break Flag.
+ *            TIM_FLAG_CC1OF - TIM Capture Compare 1 overcapture Flag.
+ *            TIM_FLAG_CC2OF - TIM Capture Compare 2 overcapture Flag.
+ *            TIM_FLAG_CC3OF - TIM Capture Compare 3 overcapture Flag.
+ *            TIM_FLAG_CC4OF - TIM Capture Compare 4 overcapture Flag.
+ *
+ * @return  none
+ */
+void TIM_ClearFlag(TIM_TypeDef *TIMx, uint16_t TIM_FLAG)
+{
+    TIMx->INTFR = (uint16_t)~TIM_FLAG;
+}
+
+/*********************************************************************
+ * @fn      TIM_GetITStatus
+ *
+ * @brief   Checks whether the TIM interrupt has occurred or not.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *          TIM_IT - specifies the TIM interrupt source to check.
+ *            TIM_IT_Update - TIM update Interrupt source.
+ *            TIM_IT_CC1 - TIM Capture Compare 1 Interrupt source.
+ *            TIM_IT_CC2 - TIM Capture Compare 2 Interrupt source.
+ *            TIM_IT_CC3 - TIM Capture Compare 3 Interrupt source.
+ *            TIM_IT_CC4 - TIM Capture Compare 4 Interrupt source.
+ *            TIM_IT_COM - TIM Commutation Interrupt source.
+ *            TIM_IT_Trigger - TIM Trigger Interrupt source.
+ *            TIM_IT_Break - TIM Break Interrupt source.
+ *
+ * @return  none
+ */
+ITStatus TIM_GetITStatus(TIM_TypeDef *TIMx, uint16_t TIM_IT)
+{
+    ITStatus bitstatus = RESET;
+    uint16_t itstatus = 0x0, itenable = 0x0;
+
+    itstatus = TIMx->INTFR & TIM_IT;
+
+    itenable = TIMx->DMAINTENR & TIM_IT;
+    if((itstatus != (uint16_t)RESET) && (itenable != (uint16_t)RESET))
+    {
+        bitstatus = SET;
+    }
+    else
+    {
+        bitstatus = RESET;
+    }
+
+    return bitstatus;
+}
+
+/*********************************************************************
+ * @fn      TIM_ClearITPendingBit
+ *
+ * @brief   Clears the TIMx's interrupt pending bits.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *          TIM_IT - specifies the TIM interrupt source to check.
+ *            TIM_IT_Update - TIM update Interrupt source.
+ *            TIM_IT_CC1 - TIM Capture Compare 1 Interrupt source.
+ *            TIM_IT_CC2 - TIM Capture Compare 2 Interrupt source.
+ *            TIM_IT_CC3 - TIM Capture Compare 3 Interrupt source.
+ *            TIM_IT_CC4 - TIM Capture Compare 4 Interrupt source.
+ *            TIM_IT_COM - TIM Commutation Interrupt source.
+ *            TIM_IT_Trigger - TIM Trigger Interrupt source.
+ *            TIM_IT_Break - TIM Break Interrupt source.
+ *
+ * @return  none
+ */
+void TIM_ClearITPendingBit(TIM_TypeDef *TIMx, uint16_t TIM_IT)
+{
+    TIMx->INTFR = (uint16_t)~TIM_IT;
+}
+
+/*********************************************************************
+ * @fn      TI1_Config
+ *
+ * @brief   Configure the TI1 as Input.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *          IM_ICPolarity - The Input Polarity.
+ *             TIM_ICPolarity_Rising.
+ *             TIM_ICPolarity_Falling.
+ *          TIM_ICSelection - specifies the input to be used.
+ *             TIM_ICSelection_DirectTI - TIM Input 1 is selected to be
+ *        connected to IC1.
+ *             TIM_ICSelection_IndirectTI - TIM Input 1 is selected to be
+ *        connected to IC2.
+ *             TIM_ICSelection_TRC - TIM Input 1 is selected to be connected
+ *        to TRC.
+ *          TIM_ICFilter - Specifies the Input Capture Filter.
+ *            This parameter must be a value between 0x00 and 0x0F.
+ *
+ * @return  none
+ */
+static void TI1_Config(TIM_TypeDef *TIMx, uint16_t TIM_ICPolarity, uint16_t TIM_ICSelection,
+                       uint16_t TIM_ICFilter)
+{
+    uint16_t tmpccmr1 = 0, tmpccer = 0;
+
+    TIMx->CCER &= (uint16_t) ~((uint16_t)TIM_CC1E);
+    tmpccmr1 = TIMx->CHCTLR1;
+    tmpccer = TIMx->CCER;
+    tmpccmr1 &= (uint16_t)(((uint16_t) ~((uint16_t)TIM_CC1S)) & ((uint16_t) ~((uint16_t)TIM_IC1F)));
+    tmpccmr1 |= (uint16_t)(TIM_ICSelection | (uint16_t)(TIM_ICFilter << (uint16_t)4));
+
+    if((TIMx == TIM1) || (TIMx == TIM2) || (TIMx == TIM3) || (TIMx == TIM4) || (TIMx == TIM5))
+    {
+        tmpccer &= (uint16_t) ~((uint16_t)(TIM_CC1P));
+        tmpccer |= (uint16_t)(TIM_ICPolarity | (uint16_t)TIM_CC1E);
+    }
+    else
+    {
+        tmpccer &= (uint16_t) ~((uint16_t)(TIM_CC1P | TIM_CC1NP));
+        tmpccer |= (uint16_t)(TIM_ICPolarity | (uint16_t)TIM_CC1E);
+    }
+
+    TIMx->CHCTLR1 = tmpccmr1;
+    TIMx->CCER = tmpccer;
+}
+
+/*********************************************************************
+ * @fn      TI2_Config
+ *
+ * @brief   Configure the TI2 as Input.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *          IM_ICPolarity - The Input Polarity.
+ *             TIM_ICPolarity_Rising.
+ *             TIM_ICPolarity_Falling.
+ *          TIM_ICSelection - specifies the input to be used.
+ *             TIM_ICSelection_DirectTI - TIM Input 1 is selected to be
+ *        connected to IC1.
+ *             TIM_ICSelection_IndirectTI - TIM Input 1 is selected to be
+ *        connected to IC2.
+ *             TIM_ICSelection_TRC - TIM Input 1 is selected to be connected
+ *        to TRC.
+ *          TIM_ICFilter - Specifies the Input Capture Filter.
+ *            This parameter must be a value between 0x00 and 0x0F.
+ *
+ * @return  none
+ */
+static void TI2_Config(TIM_TypeDef *TIMx, uint16_t TIM_ICPolarity, uint16_t TIM_ICSelection,
+                       uint16_t TIM_ICFilter)
+{
+    uint16_t tmpccmr1 = 0, tmpccer = 0, tmp = 0;
+
+    TIMx->CCER &= (uint16_t) ~((uint16_t)TIM_CC2E);
+    tmpccmr1 = TIMx->CHCTLR1;
+    tmpccer = TIMx->CCER;
+    tmp = (uint16_t)(TIM_ICPolarity << 4);
+    tmpccmr1 &= (uint16_t)(((uint16_t) ~((uint16_t)TIM_CC2S)) & ((uint16_t) ~((uint16_t)TIM_IC2F)));
+    tmpccmr1 |= (uint16_t)(TIM_ICFilter << 12);
+    tmpccmr1 |= (uint16_t)(TIM_ICSelection << 8);
+
+    if((TIMx == TIM1) || (TIMx == TIM2) || (TIMx == TIM3) || (TIMx == TIM4) || (TIMx == TIM5))
+    {
+        tmpccer &= (uint16_t) ~((uint16_t)(TIM_CC2P));
+        tmpccer |= (uint16_t)(tmp | (uint16_t)TIM_CC2E);
+    }
+    else
+    {
+        tmpccer &= (uint16_t) ~((uint16_t)(TIM_CC2P | TIM_CC2NP));
+        tmpccer |= (uint16_t)(TIM_ICPolarity | (uint16_t)TIM_CC2E);
+    }
+
+    TIMx->CHCTLR1 = tmpccmr1;
+    TIMx->CCER = tmpccer;
+}
+
+/*********************************************************************
+ * @fn      TI3_Config
+ *
+ * @brief   Configure the TI3 as Input.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *          IM_ICPolarity - The Input Polarity.
+ *             TIM_ICPolarity_Rising.
+ *             TIM_ICPolarity_Falling.
+ *          TIM_ICSelection - specifies the input to be used.
+ *             TIM_ICSelection_DirectTI - TIM Input 1 is selected to be
+ *        connected to IC1.
+ *             TIM_ICSelection_IndirectTI - TIM Input 1 is selected to be
+ *        connected to IC2.
+ *             TIM_ICSelection_TRC - TIM Input 1 is selected to be connected
+ *        to TRC.
+ *          TIM_ICFilter - Specifies the Input Capture Filter.
+ *            This parameter must be a value between 0x00 and 0x0F.
+ *
+ * @return  none
+ */
+static void TI3_Config(TIM_TypeDef *TIMx, uint16_t TIM_ICPolarity, uint16_t TIM_ICSelection,
+                       uint16_t TIM_ICFilter)
+{
+    uint16_t tmpccmr2 = 0, tmpccer = 0, tmp = 0;
+
+    TIMx->CCER &= (uint16_t) ~((uint16_t)TIM_CC3E);
+    tmpccmr2 = TIMx->CHCTLR2;
+    tmpccer = TIMx->CCER;
+    tmp = (uint16_t)(TIM_ICPolarity << 8);
+    tmpccmr2 &= (uint16_t)(((uint16_t) ~((uint16_t)TIM_CC3S)) & ((uint16_t) ~((uint16_t)TIM_IC3F)));
+    tmpccmr2 |= (uint16_t)(TIM_ICSelection | (uint16_t)(TIM_ICFilter << (uint16_t)4));
+
+    if((TIMx == TIM1) || (TIMx == TIM2) || (TIMx == TIM3) || (TIMx == TIM4) || (TIMx == TIM5))
+    {
+        tmpccer &= (uint16_t) ~((uint16_t)(TIM_CC3P));
+        tmpccer |= (uint16_t)(tmp | (uint16_t)TIM_CC3E);
+    }
+    else
+    {
+        tmpccer &= (uint16_t) ~((uint16_t)(TIM_CC3P | TIM_CC3NP));
+        tmpccer |= (uint16_t)(TIM_ICPolarity | (uint16_t)TIM_CC3E);
+    }
+
+    TIMx->CHCTLR2 = tmpccmr2;
+    TIMx->CCER = tmpccer;
+}
+
+/*********************************************************************
+ * @fn      TI4_Config
+ *
+ * @brief   Configure the TI4 as Input.
+ *
+ * @param   TIMx - where x can be 1 to 4 select the TIM peripheral.
+ *          IM_ICPolarity - The Input Polarity.
+ *             TIM_ICPolarity_Rising.
+ *             TIM_ICPolarity_Falling.
+ *          TIM_ICSelection - specifies the input to be used.
+ *             TIM_ICSelection_DirectTI - TIM Input 1 is selected to be
+ *        connected to IC1.
+ *             TIM_ICSelection_IndirectTI - TIM Input 1 is selected to be
+ *        connected to IC2.
+ *             TIM_ICSelection_TRC - TIM Input 1 is selected to be connected
+ *        to TRC.
+ *          TIM_ICFilter - Specifies the Input Capture Filter.
+ *            This parameter must be a value between 0x00 and 0x0F.
+ *
+ * @return  none
+ */
+static void TI4_Config(TIM_TypeDef *TIMx, uint16_t TIM_ICPolarity, uint16_t TIM_ICSelection,
+                       uint16_t TIM_ICFilter)
+{
+    uint16_t tmpccmr2 = 0, tmpccer = 0, tmp = 0;
+
+    TIMx->CCER &= (uint16_t) ~((uint16_t)TIM_CC4E);
+    tmpccmr2 = TIMx->CHCTLR2;
+    tmpccer = TIMx->CCER;
+    tmp = (uint16_t)(TIM_ICPolarity << 12);
+    tmpccmr2 &= (uint16_t)((uint16_t)(~(uint16_t)TIM_CC4S) & ((uint16_t) ~((uint16_t)TIM_IC4F)));
+    tmpccmr2 |= (uint16_t)(TIM_ICSelection << 8);
+    tmpccmr2 |= (uint16_t)(TIM_ICFilter << 12);
+
+    if((TIMx == TIM1) || (TIMx == TIM2) || (TIMx == TIM3) || (TIMx == TIM4) || (TIMx == TIM5))
+    {
+        tmpccer &= (uint16_t) ~((uint16_t)(TIM_CC4P));
+        tmpccer |= (uint16_t)(tmp | (uint16_t)TIM_CC4E);
+    }
+    else
+    {
+        tmpccer &= (uint16_t) ~((uint16_t)(TIM_CC3P | TIM_CC4NP));
+        tmpccer |= (uint16_t)(TIM_ICPolarity | (uint16_t)TIM_CC4E);
+    }
+
+    TIMx->CHCTLR2 = tmpccmr2;
+    TIMx->CCER = tmpccer;
+}

--- a/Sources/source/Peripheral/src/ch32v20x_usart.c
+++ b/Sources/source/Peripheral/src/ch32v20x_usart.c
@@ -1,0 +1,812 @@
+/********************************** (C) COPYRIGHT *******************************
+ * File Name          : ch32v20x_usart.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2021/06/06
+ * Description        : This file provides all the USART firmware functions.
+*********************************************************************************
+* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+* Attention: This software (modified or not) and binary are used for 
+* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+#include "ch32v20x_usart.h"
+#include "ch32v20x_rcc.h"
+
+/* USART_Private_Defines */
+#define CTLR1_UE_Set              ((uint16_t)0x2000) /* USART Enable Mask */
+#define CTLR1_UE_Reset            ((uint16_t)0xDFFF) /* USART Disable Mask */
+
+#define CTLR1_WAKE_Mask           ((uint16_t)0xF7FF) /* USART WakeUp Method Mask */
+
+#define CTLR1_RWU_Set             ((uint16_t)0x0002) /* USART mute mode Enable Mask */
+#define CTLR1_RWU_Reset           ((uint16_t)0xFFFD) /* USART mute mode Enable Mask */
+#define CTLR1_SBK_Set             ((uint16_t)0x0001) /* USART Break Character send Mask */
+#define CTLR1_CLEAR_Mask          ((uint16_t)0xE9F3) /* USART CR1 Mask */
+#define CTLR2_Address_Mask        ((uint16_t)0xFFF0) /* USART address Mask */
+
+#define CTLR2_LINEN_Set           ((uint16_t)0x4000) /* USART LIN Enable Mask */
+#define CTLR2_LINEN_Reset         ((uint16_t)0xBFFF) /* USART LIN Disable Mask */
+
+#define CTLR2_LBDL_Mask           ((uint16_t)0xFFDF) /* USART LIN Break detection Mask */
+#define CTLR2_STOP_CLEAR_Mask     ((uint16_t)0xCFFF) /* USART CR2 STOP Bits Mask */
+#define CTLR2_CLOCK_CLEAR_Mask    ((uint16_t)0xF0FF) /* USART CR2 Clock Mask */
+
+#define CTLR3_SCEN_Set            ((uint16_t)0x0020) /* USART SC Enable Mask */
+#define CTLR3_SCEN_Reset          ((uint16_t)0xFFDF) /* USART SC Disable Mask */
+
+#define CTLR3_NACK_Set            ((uint16_t)0x0010) /* USART SC NACK Enable Mask */
+#define CTLR3_NACK_Reset          ((uint16_t)0xFFEF) /* USART SC NACK Disable Mask */
+
+#define CTLR3_HDSEL_Set           ((uint16_t)0x0008) /* USART Half-Duplex Enable Mask */
+#define CTLR3_HDSEL_Reset         ((uint16_t)0xFFF7) /* USART Half-Duplex Disable Mask */
+
+#define CTLR3_IRLP_Mask           ((uint16_t)0xFFFB) /* USART IrDA LowPower mode Mask */
+#define CTLR3_CLEAR_Mask          ((uint16_t)0xFCFF) /* USART CR3 Mask */
+
+#define CTLR3_IREN_Set            ((uint16_t)0x0002) /* USART IrDA Enable Mask */
+#define CTLR3_IREN_Reset          ((uint16_t)0xFFFD) /* USART IrDA Disable Mask */
+#define GPR_LSB_Mask              ((uint16_t)0x00FF) /* Guard Time Register LSB Mask */
+#define GPR_MSB_Mask              ((uint16_t)0xFF00) /* Guard Time Register MSB Mask */
+#define IT_Mask                   ((uint16_t)0x001F) /* USART Interrupt Mask */
+
+/* USART OverSampling-8 Mask */
+#define CTLR1_OVER8_Set           ((uint16_t)0x8000) /* USART OVER8 mode Enable Mask */
+#define CTLR1_OVER8_Reset         ((uint16_t)0x7FFF) /* USART OVER8 mode Disable Mask */
+
+/* USART One Bit Sampling Mask */
+#define CTLR3_ONEBITE_Set         ((uint16_t)0x0800) /* USART ONEBITE mode Enable Mask */
+#define CTLR3_ONEBITE_Reset       ((uint16_t)0xF7FF) /* USART ONEBITE mode Disable Mask */
+
+/*********************************************************************
+ * @fn      USART_DeInit
+ *
+ * @brief   Deinitializes the USARTx peripheral registers to their default
+ *        reset values.
+ *
+ * @param   USARTx - where x can be 1, 2 or 3 to select the UART peripheral.
+ *
+ * @return  none
+ */
+void USART_DeInit(USART_TypeDef *USARTx)
+{
+    if(USARTx == USART1)
+    {
+        RCC_APB2PeriphResetCmd(RCC_APB2Periph_USART1, ENABLE);
+        RCC_APB2PeriphResetCmd(RCC_APB2Periph_USART1, DISABLE);
+    }
+    else if(USARTx == USART2)
+    {
+        RCC_APB1PeriphResetCmd(RCC_APB1Periph_USART2, ENABLE);
+        RCC_APB1PeriphResetCmd(RCC_APB1Periph_USART2, DISABLE);
+    }
+    else if(USARTx == USART3)
+    {
+        RCC_APB1PeriphResetCmd(RCC_APB1Periph_USART3, ENABLE);
+        RCC_APB1PeriphResetCmd(RCC_APB1Periph_USART3, DISABLE);
+    }
+    else if(USARTx == UART4)
+    {
+        RCC_APB1PeriphResetCmd(RCC_APB1Periph_UART4, ENABLE);
+        RCC_APB1PeriphResetCmd(RCC_APB1Periph_UART4, DISABLE);
+    }
+}
+
+/*********************************************************************
+ * @fn      USART_Init
+ *
+ * @brief   Initializes the USARTx peripheral according to the specified
+ *        parameters in the USART_InitStruct.
+ *
+ * @param   USARTx - where x can be 1, 2 or 3 to select the UART peripheral.
+ *          USART_InitStruct - pointer to a USART_InitTypeDef structure
+ *        that contains the configuration information for the specified
+ *        USART peripheral.
+ *
+ * @return  none
+ */
+void USART_Init(USART_TypeDef *USARTx, USART_InitTypeDef *USART_InitStruct)
+{
+    uint32_t          tmpreg = 0x00, apbclock = 0x00;
+    uint32_t          integerdivider = 0x00;
+    uint32_t          fractionaldivider = 0x00;
+    uint32_t          usartxbase = 0;
+    RCC_ClocksTypeDef RCC_ClocksStatus;
+
+    if(USART_InitStruct->USART_HardwareFlowControl != USART_HardwareFlowControl_None)
+    {
+    }
+
+    usartxbase = (uint32_t)USARTx;
+    tmpreg = USARTx->CTLR2;
+    tmpreg &= CTLR2_STOP_CLEAR_Mask;
+    tmpreg |= (uint32_t)USART_InitStruct->USART_StopBits;
+
+    USARTx->CTLR2 = (uint16_t)tmpreg;
+    tmpreg = USARTx->CTLR1;
+    tmpreg &= CTLR1_CLEAR_Mask;
+    tmpreg |= (uint32_t)USART_InitStruct->USART_WordLength | USART_InitStruct->USART_Parity |
+              USART_InitStruct->USART_Mode;
+    USARTx->CTLR1 = (uint16_t)tmpreg;
+
+    tmpreg = USARTx->CTLR3;
+    tmpreg &= CTLR3_CLEAR_Mask;
+    tmpreg |= USART_InitStruct->USART_HardwareFlowControl;
+    USARTx->CTLR3 = (uint16_t)tmpreg;
+
+    RCC_GetClocksFreq(&RCC_ClocksStatus);
+
+    if(usartxbase == USART1_BASE)
+    {
+        apbclock = RCC_ClocksStatus.PCLK2_Frequency;
+    }
+    else
+    {
+        apbclock = RCC_ClocksStatus.PCLK1_Frequency;
+    }
+
+    if((USARTx->CTLR1 & CTLR1_OVER8_Set) != 0)
+    {
+        integerdivider = ((25 * apbclock) / (2 * (USART_InitStruct->USART_BaudRate)));
+    }
+    else
+    {
+        integerdivider = ((25 * apbclock) / (4 * (USART_InitStruct->USART_BaudRate)));
+    }
+    tmpreg = (integerdivider / 100) << 4;
+
+    fractionaldivider = integerdivider - (100 * (tmpreg >> 4));
+
+    if((USARTx->CTLR1 & CTLR1_OVER8_Set) != 0)
+    {
+        tmpreg |= ((((fractionaldivider * 8) + 50) / 100)) & ((uint8_t)0x07);
+    }
+    else
+    {
+        tmpreg |= ((((fractionaldivider * 16) + 50) / 100)) & ((uint8_t)0x0F);
+    }
+
+    USARTx->BRR = (uint16_t)tmpreg;
+}
+
+/*********************************************************************
+ * @fn      USART_StructInit
+ *
+ * @brief   Fills each USART_InitStruct member with its default value.
+ *
+ * @param   USART_InitStruct: pointer to a USART_InitTypeDef structure
+ *       which will be initialized.
+ *
+ * @return  none
+ */
+void USART_StructInit(USART_InitTypeDef *USART_InitStruct)
+{
+    USART_InitStruct->USART_BaudRate = 9600;
+    USART_InitStruct->USART_WordLength = USART_WordLength_8b;
+    USART_InitStruct->USART_StopBits = USART_StopBits_1;
+    USART_InitStruct->USART_Parity = USART_Parity_No;
+    USART_InitStruct->USART_Mode = USART_Mode_Rx | USART_Mode_Tx;
+    USART_InitStruct->USART_HardwareFlowControl = USART_HardwareFlowControl_None;
+}
+
+/*********************************************************************
+ * @fn      USART_ClockInit
+ *
+ * @brief   Initializes the USARTx peripheral Clock according to the
+ *        specified parameters in the USART_ClockInitStruct .
+ *
+ * @param   USARTx - where x can be 1, 2, 3 to select the USART peripheral.
+ *          USART_ClockInitStruct - pointer to a USART_ClockInitTypeDef
+ *        structure that contains the configuration information for the specified
+ *        USART peripheral.
+ *
+ * @return  none
+ */
+void USART_ClockInit(USART_TypeDef *USARTx, USART_ClockInitTypeDef *USART_ClockInitStruct)
+{
+    uint32_t tmpreg = 0x00;
+
+    tmpreg = USARTx->CTLR2;
+    tmpreg &= CTLR2_CLOCK_CLEAR_Mask;
+    tmpreg |= (uint32_t)USART_ClockInitStruct->USART_Clock | USART_ClockInitStruct->USART_CPOL |
+              USART_ClockInitStruct->USART_CPHA | USART_ClockInitStruct->USART_LastBit;
+    USARTx->CTLR2 = (uint16_t)tmpreg;
+}
+
+/*********************************************************************
+ * @fn      USART_ClockStructInit
+ *
+ * @brief   Fills each USART_ClockStructInit member with its default value.
+ *
+ * @param   USART_ClockInitStruct - pointer to a USART_ClockInitTypeDef
+ *        structure which will be initialized.
+ *
+ * @return  none
+ */
+void USART_ClockStructInit(USART_ClockInitTypeDef *USART_ClockInitStruct)
+{
+    USART_ClockInitStruct->USART_Clock = USART_Clock_Disable;
+    USART_ClockInitStruct->USART_CPOL = USART_CPOL_Low;
+    USART_ClockInitStruct->USART_CPHA = USART_CPHA_1Edge;
+    USART_ClockInitStruct->USART_LastBit = USART_LastBit_Disable;
+}
+
+/*********************************************************************
+ * @fn      USART_Cmd
+ *
+ * @brief   Enables or disables the specified USART peripheral.
+ *        reset values (Affects also the I2Ss).
+ *
+ * @param   USARTx - where x can be 1, 2, 3 to select the USART peripheral.
+ *          NewState: ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void USART_Cmd(USART_TypeDef *USARTx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        USARTx->CTLR1 |= CTLR1_UE_Set;
+    }
+    else
+    {
+        USARTx->CTLR1 &= CTLR1_UE_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      USART_ITConfig
+ *
+ * @brief   Enables or disables the specified USART interrupts.
+ *        reset values (Affects also the I2Ss).
+ *
+ * @param   USARTx - where x can be 1, 2, 3 to select the USART peripheral.
+ *          USART_IT - specifies the USART interrupt sources to be enabled or disabled.
+ *            USART_IT_LBD - LIN Break detection interrupt.
+ *            USART_IT_TXE - Transmit Data Register empty interrupt.
+ *            USART_IT_TC - Transmission complete interrupt.
+ *            USART_IT_RXNE - Receive Data register not empty interrupt.
+ *            USART_IT_IDLE - Idle line detection interrupt.
+ *            USART_IT_PE - Parity Error interrupt.
+ *            USART_IT_ERR - Error interrupt.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void USART_ITConfig(USART_TypeDef *USARTx, uint16_t USART_IT, FunctionalState NewState)
+{
+    uint32_t usartreg = 0x00, itpos = 0x00, itmask = 0x00;
+    uint32_t usartxbase = 0x00;
+
+
+    usartxbase = (uint32_t)USARTx;
+    usartreg = (((uint8_t)USART_IT) >> 0x05);
+    itpos = USART_IT & IT_Mask;
+    itmask = (((uint32_t)0x01) << itpos);
+
+    if(usartreg == 0x01)
+    {
+        usartxbase += 0x0C;
+    }
+    else if(usartreg == 0x02)
+    {
+        usartxbase += 0x10;
+    }
+    else
+    {
+        usartxbase += 0x14;
+    }
+
+    if(NewState != DISABLE)
+    {
+        *(__IO uint32_t *)usartxbase |= itmask;
+    }
+    else
+    {
+        *(__IO uint32_t *)usartxbase &= ~itmask;
+    }
+}
+
+/*********************************************************************
+ * @fn      USART_DMACmd
+ *
+ * @brief   Enables or disables the USART DMA interface.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 to select the USART peripheral.
+ *          USART_DMAReq - specifies the DMA request.
+ *            USART_DMAReq_Tx - USART DMA transmit request.
+ *            USART_DMAReq_Rx - USART DMA receive request.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void USART_DMACmd(USART_TypeDef *USARTx, uint16_t USART_DMAReq, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        USARTx->CTLR3 |= USART_DMAReq;
+    }
+    else
+    {
+        USARTx->CTLR3 &= (uint16_t)~USART_DMAReq;
+    }
+}
+
+/*********************************************************************
+ * @fn      USART_SetAddress
+ *
+ * @brief   Sets the address of the USART node.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 to select the USART peripheral.
+ *          USART_Address - Indicates the address of the USART node.
+ *
+ * @return  none
+ */
+void USART_SetAddress(USART_TypeDef *USARTx, uint8_t USART_Address)
+{
+    USARTx->CTLR2 &= CTLR2_Address_Mask;
+    USARTx->CTLR2 |= USART_Address;
+}
+
+/*********************************************************************
+ * @fn      USART_WakeUpConfig
+ *
+ * @brief   Selects the USART WakeUp method.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 to select the USART peripheral.
+ *          USART_WakeUp - specifies the USART wakeup method.
+ *            USART_WakeUp_IdleLine - WakeUp by an idle line detection.
+ *            USART_WakeUp_AddressMark - WakeUp by an address mark.
+ *
+ * @return  none
+ */
+void USART_WakeUpConfig(USART_TypeDef *USARTx, uint16_t USART_WakeUp)
+{
+    USARTx->CTLR1 &= CTLR1_WAKE_Mask;
+    USARTx->CTLR1 |= USART_WakeUp;
+}
+
+/*********************************************************************
+ * @fn      USART_ReceiverWakeUpCmd
+ *
+ * @brief   Determines if the USART is in mute mode or not.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 to select the USART peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void USART_ReceiverWakeUpCmd(USART_TypeDef *USARTx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        USARTx->CTLR1 |= CTLR1_RWU_Set;
+    }
+    else
+    {
+        USARTx->CTLR1 &= CTLR1_RWU_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      USART_LINBreakDetectLengthConfig
+ *
+ * @brief   Sets the USART LIN Break detection length.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 to select the USART peripheral.
+ *          USART_LINBreakDetectLength - specifies the LIN break detection length.
+ *            USART_LINBreakDetectLength_10b - 10-bit break detection.
+ *            USART_LINBreakDetectLength_11b - 11-bit break detection.
+ *
+ * @return  none
+ */
+void USART_LINBreakDetectLengthConfig(USART_TypeDef *USARTx, uint16_t USART_LINBreakDetectLength)
+{
+    USARTx->CTLR2 &= CTLR2_LBDL_Mask;
+    USARTx->CTLR2 |= USART_LINBreakDetectLength;
+}
+
+/*********************************************************************
+ * @fn      USART_LINCmd
+ *
+ * @brief   Enables or disables the USART LIN mode.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 to select the USART peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void USART_LINCmd(USART_TypeDef *USARTx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        USARTx->CTLR2 |= CTLR2_LINEN_Set;
+    }
+    else
+    {
+        USARTx->CTLR2 &= CTLR2_LINEN_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      USART_SendData
+ *
+ * @brief   Transmits single data through the USARTx peripheral.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 to select the USART peripheral.
+ *          Data - the data to transmit.
+ *
+ * @return  none
+ */
+void USART_SendData(USART_TypeDef *USARTx, uint16_t Data)
+{
+    USARTx->DATAR = (Data & (uint16_t)0x01FF);
+}
+
+/*********************************************************************
+ * @fn      USART_ReceiveData
+ *
+ * @brief   Returns the most recent received data by the USARTx peripheral.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 to select the USART peripheral.
+ *
+ * @return  The received data.
+ */
+uint16_t USART_ReceiveData(USART_TypeDef *USARTx)
+{
+    return (uint16_t)(USARTx->DATAR & (uint16_t)0x01FF);
+}
+
+/*********************************************************************
+ * @fn      USART_SendBreak
+ *
+ * @brief   Transmits break characters.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 to select the USART peripheral.
+ *
+ * @return  none
+ */
+void USART_SendBreak(USART_TypeDef *USARTx)
+{
+    USARTx->CTLR1 |= CTLR1_SBK_Set;
+}
+
+/*********************************************************************
+ * @fn      USART_SetGuardTime
+ *
+ * @brief   Sets the specified USART guard time.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 to select the USART peripheral.
+ *          USART_GuardTime - specifies the guard time.
+ *
+ * @return  none
+ */
+void USART_SetGuardTime(USART_TypeDef *USARTx, uint8_t USART_GuardTime)
+{
+    USARTx->GPR &= GPR_LSB_Mask;
+    USARTx->GPR |= (uint16_t)((uint16_t)USART_GuardTime << 0x08);
+}
+
+/*********************************************************************
+ * @fn      USART_SetPrescaler
+ *
+ * @brief   Sets the system clock prescaler.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 to select the USART peripheral.
+ *          USART_Prescaler - specifies the prescaler clock.
+ *
+ * @return  none
+ */
+void USART_SetPrescaler(USART_TypeDef *USARTx, uint8_t USART_Prescaler)
+{
+    USARTx->GPR &= GPR_MSB_Mask;
+    USARTx->GPR |= USART_Prescaler;
+}
+
+/*********************************************************************
+ * @fn      USART_SmartCardCmd
+ *
+ * @brief   Enables or disables the USART Smart Card mode.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 to select the USART peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void USART_SmartCardCmd(USART_TypeDef *USARTx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        USARTx->CTLR3 |= CTLR3_SCEN_Set;
+    }
+    else
+    {
+        USARTx->CTLR3 &= CTLR3_SCEN_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      USART_SmartCardNACKCmd
+ *
+ * @brief   Enables or disables NACK transmission.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 to select the USART peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void USART_SmartCardNACKCmd(USART_TypeDef *USARTx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        USARTx->CTLR3 |= CTLR3_NACK_Set;
+    }
+    else
+    {
+        USARTx->CTLR3 &= CTLR3_NACK_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      USART_HalfDuplexCmd
+ *
+ * @brief   Enables or disables the USART Half Duplex communication.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 to select the USART peripheral.
+ *                  NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void USART_HalfDuplexCmd(USART_TypeDef *USARTx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        USARTx->CTLR3 |= CTLR3_HDSEL_Set;
+    }
+    else
+    {
+        USARTx->CTLR3 &= CTLR3_HDSEL_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      USART_OverSampling8Cmd
+ *
+ * @brief   Enables or disables the USART's 8x oversampling mode.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 to select the USART peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *          Note-
+ *          This function has to be called before calling USART_Init()
+ *          function in order to have correct baudrate Divider value. 
+ * @return  none
+ */
+void USART_OverSampling8Cmd(USART_TypeDef *USARTx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        USARTx->CTLR1 |= CTLR1_OVER8_Set;
+    }
+    else
+    {
+        USARTx->CTLR1 &= CTLR1_OVER8_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      USART_OneBitMethodCmd
+ *
+ * @brief   Enables or disables the USART's one bit sampling method.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 to select the USART peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void USART_OneBitMethodCmd(USART_TypeDef *USARTx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        USARTx->CTLR3 |= CTLR3_ONEBITE_Set;
+    }
+    else
+    {
+        USARTx->CTLR3 &= CTLR3_ONEBITE_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      USART_IrDAConfig
+ *
+ * @brief   Configures the USART's IrDA interface.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 to select the USART peripheral.
+ *          USART_IrDAMode - specifies the IrDA mode.
+ *            USART_IrDAMode_LowPower.
+ *            USART_IrDAMode_Normal.
+ *
+ * @return  none
+ */
+void USART_IrDAConfig(USART_TypeDef *USARTx, uint16_t USART_IrDAMode)
+{
+    USARTx->CTLR3 &= CTLR3_IRLP_Mask;
+    USARTx->CTLR3 |= USART_IrDAMode;
+}
+
+/*********************************************************************
+ * @fn      USART_IrDACmd
+ *
+ * @brief   Enables or disables the USART's IrDA interface.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 to select the USART peripheral.
+ *          NewState - ENABLE or DISABLE.
+ *
+ * @return  none
+ */
+void USART_IrDACmd(USART_TypeDef *USARTx, FunctionalState NewState)
+{
+    if(NewState != DISABLE)
+    {
+        USARTx->CTLR3 |= CTLR3_IREN_Set;
+    }
+    else
+    {
+        USARTx->CTLR3 &= CTLR3_IREN_Reset;
+    }
+}
+
+/*********************************************************************
+ * @fn      USART_GetFlagStatus
+ *
+ * @brief   Checks whether the specified USART flag is set or not.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 to select the USART peripheral.
+ *          USART_FLAG - specifies the flag to check.
+ *            USART_FLAG_LBD - LIN Break detection flag.
+ *            USART_FLAG_TXE - Transmit data register empty flag.
+ *            USART_FLAG_TC - Transmission Complete flag.
+ *            USART_FLAG_RXNE - Receive data register not empty flag.
+ *            USART_FLAG_IDLE - Idle Line detection flag.
+ *            USART_FLAG_ORE - OverRun Error flag.
+ *            USART_FLAG_NE - Noise Error flag.
+ *            USART_FLAG_FE - Framing Error flag.
+ *            USART_FLAG_PE - Parity Error flag.
+ *
+ * @return  bitstatus: SET or RESET
+ */
+FlagStatus USART_GetFlagStatus(USART_TypeDef *USARTx, uint16_t USART_FLAG)
+{
+    FlagStatus bitstatus = RESET;
+
+
+    if((USARTx->STATR & USART_FLAG) != (uint16_t)RESET)
+    {
+        bitstatus = SET;
+    }
+    else
+    {
+        bitstatus = RESET;
+    }
+    return bitstatus;
+}
+
+/*********************************************************************
+ * @fn      USART_ClearFlag
+ *
+ * @brief   Clears the USARTx's pending flags.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 to select the USART peripheral.
+ *          USART_FLAG - specifies the flag to clear.
+ *            USART_FLAG_LBD - LIN Break detection flag.
+ *            USART_FLAG_TC - Transmission Complete flag.
+ *            USART_FLAG_RXNE - Receive data register not empty flag.
+ *          Note-
+ *            - PE (Parity error), FE (Framing error), NE (Noise error), ORE (OverRun 
+ *            error) and IDLE (Idle line detected) flags are cleared by software 
+ *            sequence: a read operation to USART_STATR register (USART_GetFlagStatus()) 
+ *            followed by a read operation to USART_DATAR register (USART_ReceiveData()).
+ *            - RXNE flag can be also cleared by a read to the USART_DATAR register 
+ *            (USART_ReceiveData()).
+ *            - TC flag can be also cleared by software sequence: a read operation to 
+ *            USART_STATR register (USART_GetFlagStatus()) followed by a write operation
+ *            to USART_DATAR register (USART_SendData()).
+ *            - TXE flag is cleared only by a write to the USART_DATAR register 
+ *            (USART_SendData()).
+ * @return  none
+ */
+void USART_ClearFlag(USART_TypeDef *USARTx, uint16_t USART_FLAG)
+{
+
+    USARTx->STATR = (uint16_t)~USART_FLAG;
+}
+
+/*********************************************************************
+ * @fn      USART_GetITStatus
+ *
+ * @brief   Checks whether the specified USART interrupt has occurred or not.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 to select the USART peripheral.
+ *          USART_IT - specifies the USART interrupt source to check.
+ *            USART_IT_LBD - LIN Break detection interrupt.
+ *            USART_IT_TXE - Tansmit Data Register empty interrupt.
+ *            USART_IT_TC - Transmission complete interrupt.
+ *            USART_IT_RXNE - Receive Data register not empty interrupt.
+ *            USART_IT_IDLE - Idle line detection interrupt.
+ *            USART_IT_ORE_RX - OverRun Error interrupt if the RXNEIE bit is set.
+ *            USART_IT_ORE_ER - OverRun Error interrupt if the EIE bit is set.
+ *            USART_IT_NE - Noise Error interrupt.
+ *            USART_IT_FE - Framing Error interrupt.
+ *            USART_IT_PE - Parity Error interrupt.
+ *
+ * @return  bitstatus: SET or RESET.
+ */
+ITStatus USART_GetITStatus(USART_TypeDef *USARTx, uint16_t USART_IT)
+{
+    uint32_t bitpos = 0x00, itmask = 0x00, usartreg = 0x00;
+    ITStatus bitstatus = RESET;
+
+    usartreg = (((uint8_t)USART_IT) >> 0x05);
+    itmask = USART_IT & IT_Mask;
+    itmask = (uint32_t)0x01 << itmask;
+
+    if(usartreg == 0x01)
+    {
+        itmask &= USARTx->CTLR1;
+    }
+    else if(usartreg == 0x02)
+    {
+        itmask &= USARTx->CTLR2;
+    }
+    else
+    {
+        itmask &= USARTx->CTLR3;
+    }
+
+    bitpos = USART_IT >> 0x08;
+    bitpos = (uint32_t)0x01 << bitpos;
+    bitpos &= USARTx->STATR;
+
+    if((itmask != (uint16_t)RESET) && (bitpos != (uint16_t)RESET))
+    {
+        bitstatus = SET;
+    }
+    else
+    {
+        bitstatus = RESET;
+    }
+
+    return bitstatus;
+}
+
+/*********************************************************************
+ * @fn      USART_ClearITPendingBit
+ *
+ * @brief   Clears the USARTx's interrupt pending bits.
+ *
+ * @param   USARTx - where x can be 1, 2, 3 to select the USART peripheral.
+ *          USART_IT - specifies the interrupt pending bit to clear.
+ *            USART_IT_LBD - LIN Break detection interrupt.
+ *            USART_IT_TC - Transmission complete interrupt.
+ *            USART_IT_RXNE - Receive Data register not empty interrupt.
+ *         Note-
+ *            - PE (Parity error), FE (Framing error), NE (Noise error), ORE (OverRun 
+ *            error) and IDLE (Idle line detected) pending bits are cleared by 
+ *            software sequence: a read operation to USART_STATR register 
+ *            (USART_GetITStatus()) followed by a read operation to USART_DATAR register 
+ *            (USART_ReceiveData()).
+ *            - RXNE pending bit can be also cleared by a read to the USART_DATAR register 
+ *            (USART_ReceiveData()).
+ *            - TC pending bit can be also cleared by software sequence: a read 
+ *            operation to USART_STATR register (USART_GetITStatus()) followed by a write 
+ *            operation to USART_DATAR register (USART_SendData()).
+ *            - TXE pending bit is cleared only by a write to the USART_DATAR register 
+ *            (USART_SendData()).
+ * @return  none
+ */
+void USART_ClearITPendingBit(USART_TypeDef *USARTx, uint16_t USART_IT)
+{
+    uint16_t bitpos = 0x00, itmask = 0x00;
+
+    bitpos = USART_IT >> 0x08;
+    itmask = ((uint16_t)0x01 << (uint16_t)bitpos);
+    USARTx->STATR = (uint16_t)~itmask;
+}

--- a/Sources/source/Startup/startup_ch32v20x_D6.S
+++ b/Sources/source/Startup/startup_ch32v20x_D6.S
@@ -1,0 +1,246 @@
+;/********************************** (C) COPYRIGHT *******************************
+;* File Name          : startup_ch32v20x_D6.s
+;* Author             : WCH
+;* Version            : V1.0.1
+;* Date               : 2024/01/31
+;* Description        :  CH32V203F6-CH32V203F8-CH32V203G6-CH32V203G8-CH32V203K6-CH32V203K8-CH32V203C6-CH32V203C8-CH32V203G8
+;*                    vector table for eclipse toolchain.
+;*********************************************************************************
+;* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+;* Attention: This software (modified or not) and binary are used for
+;* microcontroller manufactured by Nanjing Qinheng Microelectronics.
+*******************************************************************************/
+	.section	.init,"ax",@progbits
+	.global	_start
+	.align	1
+_start:
+	j	handle_reset
+    .section    .vector,"ax",@progbits
+    .align  1
+_vector_base:
+    .option norvc;
+    .word   _start
+    .word   0
+    .word   NMI_Handler                /* NMI */
+    .word   HardFault_Handler          /* Hard Fault */
+    .word   0
+    .word   Ecall_M_Mode_Handler       /* Ecall M Mode */
+    .word   0
+    .word   0
+    .word   Ecall_U_Mode_Handler       /* Ecall U Mode */
+    .word   Break_Point_Handler        /* Break Point */
+    .word   0
+    .word   0
+    .word   SysTick_Handler            /* SysTick */
+    .word   0
+    .word   SW_Handler                 /* SW */
+    .word   0
+    /* External Interrupts */
+    .word   WWDG_IRQHandler            /* Window Watchdog */
+    .word   PVD_IRQHandler             /* PVD through EXTI Line detect */
+    .word   TAMPER_IRQHandler          /* TAMPER */
+    .word   RTC_IRQHandler             /* RTC */
+    .word   FLASH_IRQHandler           /* Flash */
+    .word   RCC_IRQHandler             /* RCC */
+    .word   EXTI0_IRQHandler           /* EXTI Line 0 */
+    .word   EXTI1_IRQHandler           /* EXTI Line 1 */
+    .word   EXTI2_IRQHandler           /* EXTI Line 2 */
+    .word   EXTI3_IRQHandler           /* EXTI Line 3 */
+    .word   EXTI4_IRQHandler           /* EXTI Line 4 */
+    .word   DMA1_Channel1_IRQHandler   /* DMA1 Channel 1 */
+    .word   DMA1_Channel2_IRQHandler   /* DMA1 Channel 2 */
+    .word   DMA1_Channel3_IRQHandler   /* DMA1 Channel 3 */
+    .word   DMA1_Channel4_IRQHandler   /* DMA1 Channel 4 */
+    .word   DMA1_Channel5_IRQHandler   /* DMA1 Channel 5 */
+    .word   DMA1_Channel6_IRQHandler   /* DMA1 Channel 6 */
+    .word   DMA1_Channel7_IRQHandler   /* DMA1 Channel 7 */
+    .word   ADC1_2_IRQHandler          /* ADC1_2 */
+    .word   USB_HP_CAN1_TX_IRQHandler  /* USB HP and CAN1 TX */
+    .word   USB_LP_CAN1_RX0_IRQHandler /* USB LP and CAN1RX0 */
+    .word   CAN1_RX1_IRQHandler        /* CAN1 RX1 */
+    .word   CAN1_SCE_IRQHandler        /* CAN1 SCE */
+    .word   EXTI9_5_IRQHandler         /* EXTI Line 9..5 */
+    .word   TIM1_BRK_IRQHandler        /* TIM1 Break */
+    .word   TIM1_UP_IRQHandler         /* TIM1 Update */
+    .word   TIM1_TRG_COM_IRQHandler    /* TIM1 Trigger and Commutation */
+    .word   TIM1_CC_IRQHandler         /* TIM1 Capture Compare */
+    .word   TIM2_IRQHandler            /* TIM2 */
+    .word   TIM3_IRQHandler            /* TIM3 */
+    .word   TIM4_IRQHandler            /* TIM4 */
+    .word   I2C1_EV_IRQHandler         /* I2C1 Event */
+    .word   I2C1_ER_IRQHandler         /* I2C1 Error */
+    .word   I2C2_EV_IRQHandler         /* I2C2 Event */
+    .word   I2C2_ER_IRQHandler         /* I2C2 Error */
+    .word   SPI1_IRQHandler            /* SPI1 */
+    .word   SPI2_IRQHandler            /* SPI2 */
+    .word   USART1_IRQHandler          /* USART1 */
+    .word   USART2_IRQHandler          /* USART2 */
+    .word   USART3_IRQHandler          /* USART3 */
+    .word   EXTI15_10_IRQHandler       /* EXTI Line 15..10 */
+    .word   RTCAlarm_IRQHandler        /* RTC Alarm through EXTI Line */
+    .word   USBWakeUp_IRQHandler       /* USB Wake up from suspend */
+    .word   USBFS_IRQHandler           /* USBFS Break */
+    .word   USBFSWakeUp_IRQHandler     /* USBFS Wake up from suspend */
+    .word   UART4_IRQHandler           /* UART4 */
+    .word   DMA1_Channel8_IRQHandler   /* DMA1 Channel8 */
+    .option rvc;
+    .section    .text.vector_handler, "ax", @progbits
+    .weak   NMI_Handler                /* NMI */
+    .weak   HardFault_Handler          /* Hard Fault */
+    .weak   Ecall_M_Mode_Handler       /* Ecall M Mode */
+    .weak   Ecall_U_Mode_Handler       /* Ecall U Mode */
+    .weak   Break_Point_Handler        /* Break Point */
+    .weak   SysTick_Handler            /* SysTick */
+    .weak   SW_Handler                 /* SW */
+    .weak   WWDG_IRQHandler            /* Window Watchdog */
+    .weak   PVD_IRQHandler             /* PVD through EXTI Line detect */
+    .weak   TAMPER_IRQHandler          /* TAMPER */
+    .weak   RTC_IRQHandler             /* RTC */
+    .weak   FLASH_IRQHandler           /* Flash */
+    .weak   RCC_IRQHandler             /* RCC */
+    .weak   EXTI0_IRQHandler           /* EXTI Line 0 */
+    .weak   EXTI1_IRQHandler           /* EXTI Line 1 */
+    .weak   EXTI2_IRQHandler           /* EXTI Line 2 */
+    .weak   EXTI3_IRQHandler           /* EXTI Line 3 */
+    .weak   EXTI4_IRQHandler           /* EXTI Line 4 */
+    .weak   DMA1_Channel1_IRQHandler   /* DMA1 Channel 1 */
+    .weak   DMA1_Channel2_IRQHandler   /* DMA1 Channel 2 */
+    .weak   DMA1_Channel3_IRQHandler   /* DMA1 Channel 3 */
+    .weak   DMA1_Channel4_IRQHandler   /* DMA1 Channel 4 */
+    .weak   DMA1_Channel5_IRQHandler   /* DMA1 Channel 5 */
+    .weak   DMA1_Channel6_IRQHandler   /* DMA1 Channel 6 */
+    .weak   DMA1_Channel7_IRQHandler   /* DMA1 Channel 7 */
+    .weak   ADC1_2_IRQHandler          /* ADC1_2 */
+    .weak   USB_HP_CAN1_TX_IRQHandler  /* USB HP and CAN1 TX */
+    .weak   USB_LP_CAN1_RX0_IRQHandler /* USB LP and CAN1RX0 */
+    .weak   CAN1_RX1_IRQHandler        /* CAN1 RX1 */
+    .weak   CAN1_SCE_IRQHandler        /* CAN1 SCE */
+    .weak   EXTI9_5_IRQHandler         /* EXTI Line 9..5 */
+    .weak   TIM1_BRK_IRQHandler        /* TIM1 Break */
+    .weak   TIM1_UP_IRQHandler         /* TIM1 Update */
+    .weak   TIM1_TRG_COM_IRQHandler    /* TIM1 Trigger and Commutation */
+    .weak   TIM1_CC_IRQHandler         /* TIM1 Capture Compare */
+    .weak   TIM2_IRQHandler            /* TIM2 */
+    .weak   TIM3_IRQHandler            /* TIM3 */
+    .weak   TIM4_IRQHandler            /* TIM4 */
+    .weak   I2C1_EV_IRQHandler         /* I2C1 Event */
+    .weak   I2C1_ER_IRQHandler         /* I2C1 Error */
+    .weak   I2C2_EV_IRQHandler         /* I2C2 Event */
+    .weak   I2C2_ER_IRQHandler         /* I2C2 Error */
+    .weak   SPI1_IRQHandler            /* SPI1 */
+    .weak   SPI2_IRQHandler            /* SPI2 */
+    .weak   USART1_IRQHandler          /* USART1 */
+    .weak   USART2_IRQHandler          /* USART2 */
+    .weak   USART3_IRQHandler          /* USART3 */
+    .weak   EXTI15_10_IRQHandler       /* EXTI Line 15..10 */
+    .weak   RTCAlarm_IRQHandler        /* RTC Alarm through EXTI Line */
+    .weak   USBWakeUp_IRQHandler       /* USB Wakeup from suspend */
+    .weak   USBFS_IRQHandler           /* USBFS */
+    .weak   USBFSWakeUp_IRQHandler     /* USBFS Wake Up */
+    .weak   UART4_IRQHandler           /* UART4 */
+    .weak   DMA1_Channel8_IRQHandler   /* DMA1 Channel8 */
+NMI_Handler:
+HardFault_Handler:
+Ecall_M_Mode_Handler:
+Ecall_U_Mode_Handler:
+Break_Point_Handler:
+SysTick_Handler:
+SW_Handler:
+WWDG_IRQHandler:
+PVD_IRQHandler:
+TAMPER_IRQHandler:
+RTC_IRQHandler:
+FLASH_IRQHandler:
+RCC_IRQHandler:
+EXTI0_IRQHandler:
+EXTI1_IRQHandler:
+EXTI2_IRQHandler:
+EXTI3_IRQHandler:
+EXTI4_IRQHandler:
+DMA1_Channel1_IRQHandler:
+DMA1_Channel2_IRQHandler:
+DMA1_Channel3_IRQHandler:
+DMA1_Channel4_IRQHandler:
+DMA1_Channel5_IRQHandler:
+DMA1_Channel6_IRQHandler:
+DMA1_Channel7_IRQHandler:
+ADC1_2_IRQHandler:
+USB_HP_CAN1_TX_IRQHandler:
+USB_LP_CAN1_RX0_IRQHandler:
+CAN1_RX1_IRQHandler:
+CAN1_SCE_IRQHandler:
+EXTI9_5_IRQHandler:
+TIM1_BRK_IRQHandler:
+TIM1_UP_IRQHandler:
+TIM1_TRG_COM_IRQHandler:
+TIM1_CC_IRQHandler:
+TIM2_IRQHandler:
+TIM3_IRQHandler:
+TIM4_IRQHandler:
+I2C1_EV_IRQHandler:
+I2C1_ER_IRQHandler:
+I2C2_EV_IRQHandler:
+I2C2_ER_IRQHandler:
+SPI1_IRQHandler:
+SPI2_IRQHandler:
+USART1_IRQHandler:
+USART2_IRQHandler:
+USART3_IRQHandler:
+EXTI15_10_IRQHandler:
+RTCAlarm_IRQHandler:
+USBWakeUp_IRQHandler:
+USBFS_IRQHandler:
+USBFSWakeUp_IRQHandler:
+UART4_IRQHandler:
+DMA1_Channel8_IRQHandler:
+1:
+	j 1b
+	.section	.text.handle_reset,"ax",@progbits
+	.weak	handle_reset
+	.align	1
+handle_reset:
+.option push
+.option	norelax
+	la gp, __global_pointer$
+.option	pop
+1:
+	la sp, _eusrstack
+2:
+/* Load data section from flash to RAM */
+	la a0, _data_lma
+	la a1, _data_vma
+	la a2, _edata
+	bgeu a1, a2, 2f
+1:
+	lw t0, (a0)
+	sw t0, (a1)
+	addi a0, a0, 4
+	addi a1, a1, 4
+	bltu a1, a2, 1b
+2:
+/* Clear bss section */
+	la a0, _sbss
+	la a1, _ebss
+	bgeu a0, a1, 2f
+1:
+	sw zero, (a0)
+	addi a0, a0, 4
+	bltu a0, a1, 1b
+2:
+/* Configure pipelining and instruction prediction */
+    li t0, 0x1f
+    csrw 0xbc0, t0
+/* Enable interrupt nesting and hardware stack */
+	li t0, 0x3
+	csrw 0x804, t0
+/* Enable global interrupt and configure privileged mode */
+   	li t0, 0x88
+   	csrw mstatus, t0
+/* Configure the interrupt vector table recognition mode and entry address mode */
+ 	la t0, _vector_base
+    ori t0, t0, 3
+	csrw mtvec, t0
+    jal  SystemInit
+	la t0, main
+	csrw mepc, t0
+	mret


### PR DESCRIPTION
This PR adds a first version on the LANA_TNY firmware that is mounted on the communicator. It supports:

- USB HID reporting
- I2C slave function (address 0x38) to read the current HID report
- UART TX send the HID report when changed
- Function key to toggle special functions and the LANA_TNY LEDs and backlight (see README.md)